### PR TITLE
Fix lineColumnMapper for sources beginning with newlines

### DIFF
--- a/src/util/lineColumnMapper.js
+++ b/src/util/lineColumnMapper.js
@@ -6,7 +6,7 @@ export default function lineColumnMapper(source) {
   const offsets = [0];
   let offset = 0;
 
-  while ((offset = source.indexOf('\n', offset)) > 0) {
+  while ((offset = source.indexOf('\n', offset)) >= 0) {
     offset += '\n'.length;
     offsets.push(offset);
   }


### PR DESCRIPTION
This error occurs when parsing sources that begin with newlines:

```
Error: unexpected 'null' index, perhaps you forgot to check the result of 'indexOfTokenContainingSourceIndex'?
```

This fix simply corrects the `indexOf` usage in this loop, which didn't previously support empty lines.

Same as https://github.com/decaffeinate/decaffeinate-parser/pull/5, but simpler fix.