### PR TITLE
fix: ignore whitespace-only lines when calculating herestring indent level

### DIFF
--- a/test/util/parseLiteral_test.js
+++ b/test/util/parseLiteral_test.js
@@ -166,6 +166,22 @@ a
       'a');
   });
 
+  it('handles a string with a blank line with spaces in it', () => {
+    verifyHerestringMatchesCoffeeScript(`
+  a
+ 
+  b`,
+      'a\n \nb');
+  });
+
+  it('handles a string where the last line is a blank line with spaces', () => {
+    verifyHerestringMatchesCoffeeScript(`
+  a
+  b
+ `,
+      'a\nb');
+  });
+
   function verifyHerestringMatchesCoffeeScript(stringContents, expectedResultString) {
     let code = `"""${stringContents}"""`;
     let decaffeinateParserResult = parseLiteral(code).data;


### PR DESCRIPTION
This is an edge case that wasn't handled that ended up causing a build break in
a decaffeinate test:
https://github.com/decaffeinate/decaffeinate/pull/422