### PR TITLE
fix: handle programs that only contain comments

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -25,7 +25,8 @@ export function parse(source, options={}) {
 
   let context = ParseContext.fromSource(source, lex, CS.nodes);
 
-  if (source.length === 0) {
+  let ast = context.ast;
+  if (type(ast) === 'Block' && ast.expressions.length === 0) {
     let program = {
       type: 'Program',
       line: 1,

--- a/test/examples/comment-only-file/input.coffee
+++ b/test/examples/comment-only-file/input.coffee
@@ -1,0 +1,1 @@
+# Testing

--- a/test/examples/comment-only-file/output.json
+++ b/test/examples/comment-only-file/output.json
@@ -1,0 +1,11 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "raw": "# Testing\n",
+  "range": [
+    0,
+    0
+  ],
+  "body": null
+}


### PR DESCRIPTION
Closes https://github.com/decaffeinate/decaffeinate/issues/352

There was already a check for empty programs that just checked if the source
code had length zero, but that didn't handle cases where there was a comment.
Now, we check if the CoffeeScript AST is a block with zero statements.