### PR TITLE
fix: don't shrink loop bounds by assuming the body is at the end

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -260,7 +260,7 @@ function convert(context) {
       case 'While':
       {
         let lastChild = node.body;
-        node.locationData = locationWithLastPosition(
+        node.locationData = mergeLocations(
           node.locationData,
           lastChild.locationData
         );

--- a/test/examples/post-for/input.coffee
+++ b/test/examples/post-for/input.coffee
@@ -1,0 +1,1 @@
+a for a in b

--- a/test/examples/post-for/output.json
+++ b/test/examples/post-for/output.json
@@ -1,0 +1,81 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    13
+  ],
+  "raw": "a for a in b\n",
+  "body": {
+    "type": "Block",
+    "line": 1,
+    "column": 1,
+    "range": [
+      0,
+      12
+    ],
+    "statements": [
+      {
+        "type": "ForIn",
+        "line": 1,
+        "column": 1,
+        "range": [
+          0,
+          12
+        ],
+        "keyAssignee": null,
+        "valAssignee": {
+          "type": "Identifier",
+          "line": 1,
+          "column": 7,
+          "range": [
+            6,
+            7
+          ],
+          "data": "a",
+          "raw": "a"
+        },
+        "body": {
+          "type": "Block",
+          "line": 1,
+          "column": 1,
+          "range": [
+            0,
+            1
+          ],
+          "statements": [
+            {
+              "type": "Identifier",
+              "line": 1,
+              "column": 1,
+              "range": [
+                0,
+                1
+              ],
+              "data": "a",
+              "raw": "a"
+            }
+          ],
+          "raw": "a",
+          "inline": false
+        },
+        "target": {
+          "type": "Identifier",
+          "line": 1,
+          "column": 12,
+          "range": [
+            11,
+            12
+          ],
+          "data": "b",
+          "raw": "b"
+        },
+        "filter": null,
+        "step": null,
+        "raw": "a for a in b"
+      }
+    ],
+    "raw": "a for a in b"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/333
Fixes https://github.com/decaffeinate/decaffeinate/issues/502

The code to fix CoffeeScript location data was incorrectly assuming that the
last node of a loop is the loop body, but that isn't true in postfix loops, so
it was causing the end location to be artificially early. Probably, the ideal
behavior (assuming location data actually needs to be fixed here) is to take the
max of all nodes, but that didn't seem trivial. Instead, an easy fix is to just
do the same thing we do for the `if` case: just use the body to extend the
bounds if necessary, but never shrink it. This also seems more robust in
general, probably. At the very least, it's really simple and doesn't break any
decaffeinate tests.