### PR TITLE
refactor: always use the String node type for strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "coffee-lex": "^4.2.0",
-    "decaffeinate-coffeescript": "^1.10.0-patch3",
+    "decaffeinate-coffeescript": "^1.10.0-patch5",
     "lines-and-columns": "^1.1.5"
   },
   "devDependencies": {

--- a/src/parser.js
+++ b/src/parser.js
@@ -427,7 +427,7 @@ function convert(context) {
             throw new Error(literal.error.message);
           } else if (literal.type === 'string') {
             // Top-level strings should all be in the same format: an array of
-            // quasis an expressions. For a normal string literal, this is the
+            // quasis and expressions. For a normal string literal, this is the
             // simple case of one quasi and no expressions. But if this string
             // is actually a quasi that CoffeeScript is calling a string, then
             // just return a Quasi node, and higher-up code should insert it

--- a/src/parser.js
+++ b/src/parser.js
@@ -3,6 +3,7 @@ import ParseContext from './util/ParseContext';
 import isChainedComparison from './util/isChainedComparison';
 import isImplicitPlusOp from './util/isImplicitPlusOp';
 import isInterpolatedString from './util/isInterpolatedString';
+import isStringAtPosition from './util/isStringAtPosition';
 import fixInvalidLocationData from './util/fixInvalidLocationData';
 import lex, { NEWLINE, COMMENT, HERECOMMENT, IF, RELATION, OPERATOR, LBRACKET, RBRACKET, STRING_CONTENT } from 'coffee-lex';
 import locationsEqual from './util/locationsEqual';
@@ -406,7 +407,8 @@ function convert(context) {
           let start = linesAndColumns.indexForLocation({ line: node.locationData.first_line, column: node.locationData.first_column });
           let end = linesAndColumns.indexForLocation({ line: node.locationData.last_line, column: node.locationData.last_column }) + 1;
           let raw = source.slice(start, end);
-          let literal = parseLiteral(raw, start);
+          let literal = parseLiteral(node.value);
+
           if (!literal) {
             if (raw[0] === '`' && raw[raw.length - 1] === '`') {
               return makeNode('JavaScript', node.locationData, { data: node.value });
@@ -422,22 +424,28 @@ function convert(context) {
             }
             return makeNode('Identifier', node.locationData, { data: node.value });
           } else if (literal.type === 'error') {
-            if (literal.error.type === 'unbalanced-quotes' || literal.error.type === 'unexpected-closing-quote') {
-              // This is probably part of an interpolated string.
-              literal = parseLiteral(node.value);
-              return makeNode('String', node.locationData, { data: parseLiteral(node.value).data });
-            }
             throw new Error(literal.error.message);
           } else if (literal.type === 'string') {
-            return makeNode('String', node.locationData, { data: literal.data });
+            // Top-level strings should all be in the same format: an array of
+            // quasis an expressions. For a normal string literal, this is the
+            // simple case of one quasi and no expressions. But if this string
+            // is actually a quasi that CoffeeScript is calling a string, then
+            // just return a Quasi node, and higher-up code should insert it
+            // into a string interpolation.
+            if (isStringAtPosition(start, end, context)) {
+              return makeNode('String', node.locationData, {
+                quasis: [
+                  makeNode('Quasi', node.locationData, {data: literal.data})
+                ],
+                expressions: [],
+              });
+            } else {
+              return makeNode('Quasi', node.locationData, {data: literal.data});
+            }
           } else if (literal.type === 'int') {
             return makeNode('Int', node.locationData, { data: literal.data });
           } else if (literal.type === 'float') {
             return makeNode('Float', node.locationData, { data: literal.data });
-          } else if (literal.type === 'Herestring') {
-            return makeNode('Herestring', node.locationData, { data: literal.data, padding: literal.padding });
-          } else if (literal.type === 'RegExp') {
-            return makeNode('RegExp', node.locationData, { data: literal.data, flags: literal.flags });
           } else {
             throw new Error(`unknown literal type for value: ${JSON.stringify(literal)}`);
           }
@@ -958,7 +966,7 @@ function convert(context) {
       }
       let firstToken = tokens.tokenAtIndex(interpolatedStringTokenRange[0]);
       let lastToken = tokens.tokenAtIndex(interpolatedStringTokenRange[1].previous());
-      op.type = 'TemplateLiteral';
+      op.type = 'String';
       op.range = [firstToken.start, lastToken.end];
       op.raw = source.slice(...op.range);
 
@@ -1010,7 +1018,7 @@ function convert(context) {
       function buildQuasi(range) {
         let loc = linesAndColumns.locationForIndex(range[0]);
         return {
-          type: 'String',
+          type: 'Quasi',
           data: '',
           raw: source.slice(...range),
           line: loc.line + 1,
@@ -1022,22 +1030,13 @@ function convert(context) {
       function buildQuasiWithString(range, raw){
         let loc = linesAndColumns.locationForIndex(range[0]);
         return {
-          type: 'String',
+          type: 'Quasi',
           data: raw,
           raw: source.slice(...range),
           line: loc.line + 1,
           column: loc.column ,
           range
         };
-      }
-
-      function isQuasi(element) {
-        if (element.type !== 'String') {
-          return false;
-        }
-        let tokens = context.sourceTokens;
-        let tokenIndex = tokens.indexOfTokenContainingSourceIndex(element.range[0]);
-        return tokenIndex !== null && tokens.tokenAtIndex(tokenIndex).type === STRING_CONTENT;
       }
 
       elements.forEach((element, i) => {
@@ -1056,7 +1055,7 @@ function convert(context) {
           }
         }
 
-        if (isQuasi(element)) {
+        if (element.type === 'Quasi') {
           quasis.push(element);
         } else {
           if (quasis.length === 0) {

--- a/src/util/isStringAtPosition.js
+++ b/src/util/isStringAtPosition.js
@@ -1,0 +1,29 @@
+import {
+  SSTRING_START,
+  SSTRING_END,
+  DSTRING_START,
+  DSTRING_END,
+  TSSTRING_START,
+  TSSTRING_END,
+  TDSTRING_START,
+  TDSTRING_END
+} from 'coffee-lex';
+
+/**
+ * Determine if the given code position contains a real string. If not, then it
+ * is an interpolated string quasi.
+ */
+export default function isStringAtPosition(start, end, context) {
+  let tokens = context.sourceTokens;
+  let startTokenIndex = tokens.indexOfTokenContainingSourceIndex(start);
+  let endTokenIndex = tokens.indexOfTokenContainingSourceIndex(end - 1);
+  if (startTokenIndex === null || endTokenIndex === null) {
+    return false;
+  }
+  let startType = tokens.tokenAtIndex(startTokenIndex).type;
+  let endType = tokens.tokenAtIndex(endTokenIndex).type;
+  return (startType === SSTRING_START && endType === SSTRING_END) ||
+    (startType === DSTRING_START && endType === DSTRING_END) ||
+    (startType === TSSTRING_START && endType === TSSTRING_END) ||
+    (startType === TDSTRING_START && endType === TDSTRING_END);
+}

--- a/test/examples/chain-calls-with-parens/output.json
+++ b/test/examples/chain-calls-with-parens/output.json
@@ -2,81 +2,137 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 56 ],
+  "range": [
+    0,
+    56
+  ],
   "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 56 ],
-    "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
+    "range": [
+      0,
+      56
+    ],
     "statements": [
       {
         "type": "FunctionApplication",
         "line": 1,
         "column": 1,
-        "range": [ 0, 56 ],
-        "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
-        "arguments": [
-          {
-            "type": "String",
-            "line": 3,
-            "column": 15,
-            "range": [ 39, 47 ],
-            "raw": "'MyCtrl'",
-            "data": "MyCtrl"
-          },
-          {
-            "type": "Identifier",
-            "line": 3,
-            "column": 25,
-            "range": [ 49, 55 ],
-            "raw": "MyCtrl",
-            "data": "MyCtrl"
-          }
+        "range": [
+          0,
+          56
         ],
         "function": {
           "type": "MemberAccessOp",
           "line": 1,
           "column": 1,
-          "range": [ 0, 38 ],
-          "raw": "angular\n  .module('app')\n  .controller",
+          "range": [
+            0,
+            38
+          ],
           "expression": {
             "type": "FunctionApplication",
             "line": 1,
             "column": 1,
-            "range": [ 0, 24 ],
-            "raw": "angular\n  .module('app')",
-            "arguments": [
-              {
-                "type": "String",
-                "line": 2,
-                "column": 11,
-                "range": [ 18, 23 ],
-                "raw": "'app'",
-                "data": "app"
-              }
+            "range": [
+              0,
+              24
             ],
             "function": {
               "type": "MemberAccessOp",
               "line": 1,
               "column": 1,
-              "range": [ 0, 17 ],
-              "raw": "angular\n  .module",
+              "range": [
+                0,
+                17
+              ],
               "expression": {
                 "type": "Identifier",
                 "line": 1,
                 "column": 1,
-                "range": [ 0, 7 ],
-                "raw": "angular",
-                "data": "angular"
+                "range": [
+                  0,
+                  7
+                ],
+                "data": "angular",
+                "raw": "angular"
               },
-              "memberName": "module"
-            }
+              "memberName": "module",
+              "raw": "angular\n  .module"
+            },
+            "arguments": [
+              {
+                "type": "String",
+                "line": 2,
+                "column": 11,
+                "range": [
+                  18,
+                  23
+                ],
+                "quasis": [
+                  {
+                    "type": "Quasi",
+                    "line": 2,
+                    "column": 11,
+                    "range": [
+                      18,
+                      23
+                    ],
+                    "data": "app",
+                    "raw": "'app'"
+                  }
+                ],
+                "expressions": [],
+                "raw": "'app'"
+              }
+            ],
+            "raw": "angular\n  .module('app')"
           },
-          "memberName": "controller"
-        }
+          "memberName": "controller",
+          "raw": "angular\n  .module('app')\n  .controller"
+        },
+        "arguments": [
+          {
+            "type": "String",
+            "line": 3,
+            "column": 15,
+            "range": [
+              39,
+              47
+            ],
+            "quasis": [
+              {
+                "type": "Quasi",
+                "line": 3,
+                "column": 15,
+                "range": [
+                  39,
+                  47
+                ],
+                "data": "MyCtrl",
+                "raw": "'MyCtrl'"
+              }
+            ],
+            "expressions": [],
+            "raw": "'MyCtrl'"
+          },
+          {
+            "type": "Identifier",
+            "line": 3,
+            "column": 25,
+            "range": [
+              49,
+              55
+            ],
+            "data": "MyCtrl",
+            "raw": "MyCtrl"
+          }
+        ],
+        "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)"
       }
-    ]
+    ],
+    "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)"
   }
 }

--- a/test/examples/chain-calls-without-indent/output.json
+++ b/test/examples/chain-calls-without-indent/output.json
@@ -2,73 +2,126 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 40 ],
+  "range": [
+    0,
+    40
+  ],
   "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 40 ],
-    "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+    "range": [
+      0,
+      40
+    ],
     "statements": [
       {
         "type": "FunctionApplication",
         "line": 1,
         "column": 1,
-        "range": [ 0, 40 ],
-        "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
-        "arguments": [
-          {
-            "type": "String",
-            "line": 3,
-            "column": 8,
-            "range": [ 35, 40 ],
-            "raw": "'bar'",
-            "data": "bar"
-          }
+        "range": [
+          0,
+          40
         ],
         "function": {
           "type": "MemberAccessOp",
           "line": 1,
           "column": 1,
-          "range": [ 0, 34 ],
-          "raw": "$stateProvider\n.state 'foo'\n.state",
+          "range": [
+            0,
+            34
+          ],
           "expression": {
             "type": "FunctionApplication",
             "line": 1,
             "column": 1,
-            "range": [ 0, 27 ],
-            "raw": "$stateProvider\n.state 'foo'",
-            "arguments": [
-              {
-                "type": "String",
-                "line": 2,
-                "column": 8,
-                "range": [ 22, 27 ],
-                "raw": "'foo'",
-                "data": "foo"
-              }
+            "range": [
+              0,
+              27
             ],
             "function": {
               "type": "MemberAccessOp",
               "line": 1,
               "column": 1,
-              "range": [ 0, 21 ],
-              "raw": "$stateProvider\n.state",
+              "range": [
+                0,
+                21
+              ],
               "expression": {
                 "type": "Identifier",
                 "line": 1,
                 "column": 1,
-                "range": [ 0, 14 ],
-                "raw": "$stateProvider",
-                "data": "$stateProvider"
+                "range": [
+                  0,
+                  14
+                ],
+                "data": "$stateProvider",
+                "raw": "$stateProvider"
               },
-              "memberName": "state"
-            }
+              "memberName": "state",
+              "raw": "$stateProvider\n.state"
+            },
+            "arguments": [
+              {
+                "type": "String",
+                "line": 2,
+                "column": 8,
+                "range": [
+                  22,
+                  27
+                ],
+                "quasis": [
+                  {
+                    "type": "Quasi",
+                    "line": 2,
+                    "column": 8,
+                    "range": [
+                      22,
+                      27
+                    ],
+                    "data": "foo",
+                    "raw": "'foo'"
+                  }
+                ],
+                "expressions": [],
+                "raw": "'foo'"
+              }
+            ],
+            "raw": "$stateProvider\n.state 'foo'"
           },
-          "memberName": "state"
-        }
+          "memberName": "state",
+          "raw": "$stateProvider\n.state 'foo'\n.state"
+        },
+        "arguments": [
+          {
+            "type": "String",
+            "line": 3,
+            "column": 8,
+            "range": [
+              35,
+              40
+            ],
+            "quasis": [
+              {
+                "type": "Quasi",
+                "line": 3,
+                "column": 8,
+                "range": [
+                  35,
+                  40
+                ],
+                "data": "bar",
+                "raw": "'bar'"
+              }
+            ],
+            "expressions": [],
+            "raw": "'bar'"
+          }
+        ],
+        "raw": "$stateProvider\n.state 'foo'\n.state 'bar'"
       }
-    ]
+    ],
+    "raw": "$stateProvider\n.state 'foo'\n.state 'bar'"
   }
 }

--- a/test/examples/chain-calls-without-parens/output.json
+++ b/test/examples/chain-calls-without-parens/output.json
@@ -2,73 +2,126 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 40 ],
+  "range": [
+    0,
+    40
+  ],
   "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 40 ],
-    "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+    "range": [
+      0,
+      40
+    ],
     "statements": [
       {
         "type": "FunctionApplication",
         "line": 1,
         "column": 1,
-        "range": [ 0, 40 ],
-        "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
-        "arguments": [
-          {
-            "type": "String",
-            "line": 3,
-            "column": 8,
-            "range": [ 35, 40 ],
-            "raw": "'bar'",
-            "data": "bar"
-          }
+        "range": [
+          0,
+          40
         ],
         "function": {
           "type": "MemberAccessOp",
           "line": 1,
           "column": 1,
-          "range": [ 0, 34 ],
-          "raw": "$stateProvider\n.state 'foo'\n.state",
+          "range": [
+            0,
+            34
+          ],
           "expression": {
             "type": "FunctionApplication",
             "line": 1,
             "column": 1,
-            "range": [ 0, 27 ],
-            "raw": "$stateProvider\n.state 'foo'",
-            "arguments": [
-              {
-                "type": "String",
-                "line": 2,
-                "column": 8,
-                "range": [ 22, 27 ],
-                "raw": "'foo'",
-                "data": "foo"
-              }
+            "range": [
+              0,
+              27
             ],
             "function": {
               "type": "MemberAccessOp",
               "line": 1,
               "column": 1,
-              "range": [ 0, 21 ],
-              "raw": "$stateProvider\n.state",
+              "range": [
+                0,
+                21
+              ],
               "expression": {
                 "type": "Identifier",
                 "line": 1,
                 "column": 1,
-                "range": [ 0, 14 ],
-                "raw": "$stateProvider",
-                "data": "$stateProvider"
+                "range": [
+                  0,
+                  14
+                ],
+                "data": "$stateProvider",
+                "raw": "$stateProvider"
               },
-              "memberName": "state"
-            }
+              "memberName": "state",
+              "raw": "$stateProvider\n.state"
+            },
+            "arguments": [
+              {
+                "type": "String",
+                "line": 2,
+                "column": 8,
+                "range": [
+                  22,
+                  27
+                ],
+                "quasis": [
+                  {
+                    "type": "Quasi",
+                    "line": 2,
+                    "column": 8,
+                    "range": [
+                      22,
+                      27
+                    ],
+                    "data": "foo",
+                    "raw": "'foo'"
+                  }
+                ],
+                "expressions": [],
+                "raw": "'foo'"
+              }
+            ],
+            "raw": "$stateProvider\n.state 'foo'"
           },
-          "memberName": "state"
-        }
+          "memberName": "state",
+          "raw": "$stateProvider\n.state 'foo'\n.state"
+        },
+        "arguments": [
+          {
+            "type": "String",
+            "line": 3,
+            "column": 8,
+            "range": [
+              35,
+              40
+            ],
+            "quasis": [
+              {
+                "type": "Quasi",
+                "line": 3,
+                "column": 8,
+                "range": [
+                  35,
+                  40
+                ],
+                "data": "bar",
+                "raw": "'bar'"
+              }
+            ],
+            "expressions": [],
+            "raw": "'bar'"
+          }
+        ],
+        "raw": "$stateProvider\n.state 'foo'\n.state 'bar'"
       }
-    ]
+    ],
+    "raw": "$stateProvider\n.state 'foo'\n.state 'bar'"
   }
 }

--- a/test/examples/multiline-string-with-interpolations-and-quotes/output.json
+++ b/test/examples/multiline-string-with-interpolations-and-quotes/output.json
@@ -17,7 +17,7 @@
     ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
         "range": [
@@ -27,7 +27,7 @@
         "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
             "range": [
@@ -38,18 +38,18 @@
             "raw": "\"\"\"\n  a\n    b\""
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 3,
             "column": 11,
             "range": [
               18,
               26
             ],
-            "data": "\n    d",
+            "data": "\"\n  d\"",
             "raw": "\"\n    d\""
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 4,
             "column": 11,
             "range": [

--- a/test/examples/multiline-string-with-quoted-interpolations-and-non-interpolations/output.json
+++ b/test/examples/multiline-string-with-quoted-interpolations-and-non-interpolations/output.json
@@ -17,7 +17,7 @@
     ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
         "range": [
@@ -27,7 +27,7 @@
         "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
             "range": [
@@ -38,7 +38,7 @@
             "raw": "\"\"\"\n  a\n    b\""
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 3,
             "column": 11,
             "range": [
@@ -49,7 +49,7 @@
             "raw": "\"\n    d\"e\"\n    f\""
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 5,
             "column": 11,
             "range": [

--- a/test/examples/nested-string-interpolation/output.json
+++ b/test/examples/nested-string-interpolation/output.json
@@ -2,61 +2,85 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 13 ],
+  "range": [
+    0,
+    13
+  ],
   "raw": "\"a#{\"b#{c}\"}\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 13 ],
+    "range": [
+      0,
+      13
+    ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 13 ],
+        "range": [
+          0,
+          13
+        ],
         "raw": "\"a#{\"b#{c}\"}\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
-            "range": [ 0, 2 ],
+            "range": [
+              0,
+              2
+            ],
             "data": "a",
             "raw": "\"a"
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 1,
             "column": 13,
-            "range": [ 12, 13 ]
+            "range": [
+              12,
+              13
+            ]
           }
         ],
         "expressions": [
           {
-            "type": "TemplateLiteral",
+            "type": "String",
             "line": 1,
             "column": 5,
-            "range": [ 4, 11 ],
+            "range": [
+              4,
+              11
+            ],
             "raw": "\"b#{c}\"",
             "quasis": [
               {
-                "type": "String",
+                "type": "Quasi",
                 "line": 1,
                 "column": 5,
-                "range": [ 4, 6 ],
+                "range": [
+                  4,
+                  6
+                ],
                 "data": "b",
                 "raw": "\"b"
               },
               {
-                "type": "String",
+                "type": "Quasi",
                 "data": "",
                 "raw": "\"",
                 "line": 1,
                 "column": 11,
-                "range": [ 10, 11 ]
+                "range": [
+                  10,
+                  11
+                ]
               }
             ],
             "expressions": [
@@ -64,7 +88,10 @@
                 "type": "Identifier",
                 "line": 1,
                 "column": 9,
-                "range": [ 8, 9 ],
+                "range": [
+                  8,
+                  9
+                ],
                 "data": "c",
                 "raw": "c"
               }

--- a/test/examples/string-ending-with-interpolation/output.json
+++ b/test/examples/string-ending-with-interpolation/output.json
@@ -6,6 +6,7 @@
     0,
     7
   ],
+  "raw": "\"a#{b}\"",
   "body": {
     "type": "Block",
     "line": 1,
@@ -16,7 +17,7 @@
     ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
         "range": [
@@ -26,7 +27,7 @@
         "raw": "\"a#{b}\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
             "range": [
@@ -37,7 +38,7 @@
             "raw": "\"a"
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 1,
@@ -64,6 +65,5 @@
       }
     ],
     "raw": "\"a#{b}\""
-  },
-  "raw": "\"a#{b}\""
+  }
 }

--- a/test/examples/string-interpolation-in-object-literal/output.json
+++ b/test/examples/string-interpolation-in-object-literal/output.json
@@ -45,7 +45,7 @@
               "raw": "a"
             },
             "expression": {
-              "type": "TemplateLiteral",
+              "type": "String",
               "line": 1,
               "column": 5,
               "range": [
@@ -55,7 +55,7 @@
               "raw": "\"#{b}\"",
               "quasis": [
                 {
-                  "type": "String",
+                  "type": "Quasi",
                   "line": 1,
                   "column": 5,
                   "range": [
@@ -66,7 +66,7 @@
                   "raw": "\""
                 },
                 {
-                  "type": "String",
+                  "type": "Quasi",
                   "data": "",
                   "raw": "\"",
                   "line": 1,

--- a/test/examples/string-interpolation-plus-normal-string/output.json
+++ b/test/examples/string-interpolation-plus-normal-string/output.json
@@ -25,7 +25,7 @@
           12
         ],
         "left": {
-          "type": "TemplateLiteral",
+          "type": "String",
           "line": 1,
           "column": 1,
           "range": [
@@ -35,7 +35,7 @@
           "raw": "\"#{a}\"",
           "quasis": [
             {
-              "type": "String",
+              "type": "Quasi",
               "line": 1,
               "column": 1,
               "range": [
@@ -46,7 +46,7 @@
               "raw": "\""
             },
             {
-              "type": "String",
+              "type": "Quasi",
               "data": "",
               "raw": "\"",
               "line": 1,
@@ -79,7 +79,20 @@
             9,
             12
           ],
-          "data": "b",
+          "quasis": [
+            {
+              "type": "Quasi",
+              "line": 1,
+              "column": 10,
+              "range": [
+                9,
+                12
+              ],
+              "data": "b",
+              "raw": "\"b\""
+            }
+          ],
+          "expressions": [],
           "raw": "\"b\""
         },
         "raw": "\"#{a}\" + \"b\""

--- a/test/examples/string-interpolation-preceded-by-parenthesis/output.json
+++ b/test/examples/string-interpolation-preceded-by-parenthesis/output.json
@@ -2,36 +2,51 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 66 ],
+  "range": [
+    0,
+    66
+  ],
   "raw": "# https://github.com/decaffeinate/decaffeinate/issues/212\n\"(#{a}\"\n",
   "body": {
     "type": "Block",
     "line": 2,
     "column": 1,
-    "range": [ 58, 65 ],
+    "range": [
+      58,
+      65
+    ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 2,
         "column": 1,
-        "range": [ 58, 65 ],
+        "range": [
+          58,
+          65
+        ],
         "raw": "\"(#{a}\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 2,
             "column": 1,
-            "range": [ 58, 60 ],
+            "range": [
+              58,
+              60
+            ],
             "data": "(",
             "raw": "\"("
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 2,
             "column": 7,
-            "range": [ 64, 65 ]
+            "range": [
+              64,
+              65
+            ]
           }
         ],
         "expressions": [
@@ -39,7 +54,10 @@
             "type": "Identifier",
             "line": 2,
             "column": 5,
-            "range": [ 62, 63 ],
+            "range": [
+              62,
+              63
+            ],
             "data": "a",
             "raw": "a"
           }

--- a/test/examples/string-interpolation-with-escaped-newline/output.json
+++ b/test/examples/string-interpolation-with-escaped-newline/output.json
@@ -17,7 +17,7 @@
     ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
         "range": [
@@ -27,7 +27,7 @@
         "raw": "\"#{a}\\\n#{b}\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
             "range": [
@@ -38,7 +38,7 @@
             "raw": "\""
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "",
             "line": 2,
@@ -49,7 +49,7 @@
             ]
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 2,

--- a/test/examples/string-interpolation-with-plus/output.json
+++ b/test/examples/string-interpolation-with-plus/output.json
@@ -17,7 +17,7 @@
     ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 3,
         "range": [
@@ -27,7 +27,7 @@
         "raw": "\"#{a + b}c\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 1,
@@ -38,7 +38,7 @@
             ]
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 10,
             "range": [

--- a/test/examples/string-starting-with-interpolation/output.json
+++ b/test/examples/string-starting-with-interpolation/output.json
@@ -6,6 +6,7 @@
     0,
     7
   ],
+  "raw": "\"#{a}b\"",
   "body": {
     "type": "Block",
     "line": 1,
@@ -16,7 +17,7 @@
     ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 3,
         "range": [
@@ -26,7 +27,7 @@
         "raw": "\"#{a}b\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 1,
@@ -37,7 +38,7 @@
             ]
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 6,
             "range": [
@@ -64,6 +65,5 @@
       }
     ],
     "raw": "\"#{a}b\""
-  },
-  "raw": "\"#{a}b\""
+  }
 }

--- a/test/examples/string-with-double-quotes/output.json
+++ b/test/examples/string-with-double-quotes/output.json
@@ -2,23 +2,45 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 11 ],
+  "range": [
+    0,
+    11
+  ],
   "raw": "\"coffee me\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 11 ],
-    "raw": "\"coffee me\"",
+    "range": [
+      0,
+      11
+    ],
     "statements": [
       {
         "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 11 ],
-        "raw": "\"coffee me\"",
-        "data": "coffee me"
+        "range": [
+          0,
+          11
+        ],
+        "quasis": [
+          {
+            "type": "Quasi",
+            "line": 1,
+            "column": 1,
+            "range": [
+              0,
+              11
+            ],
+            "data": "coffee me",
+            "raw": "\"coffee me\""
+          }
+        ],
+        "expressions": [],
+        "raw": "\"coffee me\""
       }
-    ]
+    ],
+    "raw": "\"coffee me\""
   }
 }

--- a/test/examples/string-with-interpolation/output.json
+++ b/test/examples/string-with-interpolation/output.json
@@ -6,6 +6,7 @@
     0,
     8
   ],
+  "raw": "\"a#{b}c\"",
   "body": {
     "type": "Block",
     "line": 1,
@@ -16,7 +17,7 @@
     ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
         "range": [
@@ -26,7 +27,7 @@
         "raw": "\"a#{b}c\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
             "range": [
@@ -37,7 +38,7 @@
             "raw": "\"a"
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 7,
             "range": [
@@ -64,6 +65,5 @@
       }
     ],
     "raw": "\"a#{b}c\""
-  },
-  "raw": "\"a#{b}c\""
+  }
 }

--- a/test/examples/string-with-interpolations-at-start-and-end/output.json
+++ b/test/examples/string-with-interpolations-at-start-and-end/output.json
@@ -2,44 +2,62 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 11 ],
+  "range": [
+    0,
+    11
+  ],
   "raw": "\"#{a} #{b}\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 11 ],
+    "range": [
+      0,
+      11
+    ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 3,
-        "range": [ 0, 11 ],
+        "range": [
+          0,
+          11
+        ],
         "raw": "\"#{a} #{b}\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 1,
             "column": 1,
-            "range": [ 0, 1 ]
+            "range": [
+              0,
+              1
+            ]
           },
           {
-            "type": "String",
-            "data": " ",
-            "raw": " ",
+            "type": "Quasi",
             "line": 1,
-            "column": 5,
-            "range": [ 5, 6 ]
+            "column": 6,
+            "range": [
+              5,
+              6
+            ],
+            "data": " ",
+            "raw": " "
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 1,
             "column": 11,
-            "range": [ 10, 11 ]
+            "range": [
+              10,
+              11
+            ]
           }
         ],
         "expressions": [
@@ -47,7 +65,10 @@
             "type": "Identifier",
             "line": 1,
             "column": 4,
-            "range": [ 3, 4 ],
+            "range": [
+              3,
+              4
+            ],
             "data": "a",
             "raw": "a"
           },
@@ -55,7 +76,10 @@
             "type": "Identifier",
             "line": 1,
             "column": 9,
-            "range": [ 8, 9 ],
+            "range": [
+              8,
+              9
+            ],
             "data": "b",
             "raw": "b"
           }

--- a/test/examples/string-with-noop-escape/output.json
+++ b/test/examples/string-with-noop-escape/output.json
@@ -2,23 +2,45 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 4 ],
+  "range": [
+    0,
+    4
+  ],
   "raw": "'\\.'",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 4 ],
-    "raw": "'\\.'",
+    "range": [
+      0,
+      4
+    ],
     "statements": [
       {
         "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 4 ],
-        "raw": "'\\.'",
-        "data": "."
+        "range": [
+          0,
+          4
+        ],
+        "quasis": [
+          {
+            "type": "Quasi",
+            "line": 1,
+            "column": 1,
+            "range": [
+              0,
+              4
+            ],
+            "data": ".",
+            "raw": "'\\.'"
+          }
+        ],
+        "expressions": [],
+        "raw": "'\\.'"
       }
-    ]
+    ],
+    "raw": "'\\.'"
   }
 }

--- a/test/examples/string-with-only-multiple-interpolations/output.json
+++ b/test/examples/string-with-only-multiple-interpolations/output.json
@@ -2,51 +2,73 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 14 ],
+  "range": [
+    0,
+    14
+  ],
+  "raw": "\"#{a}#{b}#{c}\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 14 ],
+    "range": [
+      0,
+      14
+    ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 14 ],
+        "range": [
+          0,
+          14
+        ],
         "raw": "\"#{a}#{b}#{c}\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
-            "range": [ 0, 1 ],
+            "range": [
+              0,
+              1
+            ],
             "data": "",
             "raw": "\""
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "",
             "line": 1,
             "column": 6,
-            "range": [ 5, 5 ]
+            "range": [
+              5,
+              5
+            ]
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "",
             "line": 1,
             "column": 10,
-            "range": [ 9, 9 ]
+            "range": [
+              9,
+              9
+            ]
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 1,
             "column": 14,
-            "range": [ 13, 14 ]
+            "range": [
+              13,
+              14
+            ]
           }
         ],
         "expressions": [
@@ -54,7 +76,10 @@
             "type": "Identifier",
             "line": 1,
             "column": 4,
-            "range": [ 3, 4 ],
+            "range": [
+              3,
+              4
+            ],
             "data": "a",
             "raw": "a"
           },
@@ -62,7 +87,10 @@
             "type": "Identifier",
             "line": 1,
             "column": 8,
-            "range": [ 7, 8 ],
+            "range": [
+              7,
+              8
+            ],
             "data": "b",
             "raw": "b"
           },
@@ -70,7 +98,10 @@
             "type": "Identifier",
             "line": 1,
             "column": 12,
-            "range": [ 11, 12 ],
+            "range": [
+              11,
+              12
+            ],
             "data": "c",
             "raw": "c"
           }
@@ -78,6 +109,5 @@
       }
     ],
     "raw": "\"#{a}#{b}#{c}\""
-  },
-  "raw": "\"#{a}#{b}#{c}\""
+  }
 }

--- a/test/examples/string-with-only-single-interpolation/output.json
+++ b/test/examples/string-with-only-single-interpolation/output.json
@@ -2,35 +2,51 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 6 ],
+  "range": [
+    0,
+    6
+  ],
+  "raw": "\"#{a}\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "range": [
+      0,
+      6
+    ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
+        "range": [
+          0,
+          6
+        ],
         "raw": "\"#{a}\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
-            "range": [ 0, 1 ],
+            "range": [
+              0,
+              1
+            ],
             "data": "",
             "raw": "\""
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\"",
             "line": 1,
             "column": 6,
-            "range": [ 5, 6 ]
+            "range": [
+              5,
+              6
+            ]
           }
         ],
         "expressions": [
@@ -38,7 +54,10 @@
             "type": "Identifier",
             "line": 1,
             "column": 4,
-            "range": [ 3, 4 ],
+            "range": [
+              3,
+              4
+            ],
             "data": "a",
             "raw": "a"
           }
@@ -46,6 +65,5 @@
       }
     ],
     "raw": "\"#{a}\""
-  },
-  "raw": "\"#{a}\""
+  }
 }

--- a/test/examples/string-with-parentheses-inside/output.json
+++ b/test/examples/string-with-parentheses-inside/output.json
@@ -2,20 +2,42 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 5 ],
+  "range": [
+    0,
+    5
+  ],
   "raw": "\"( a\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "range": [
+      0,
+      5
+    ],
     "statements": [
       {
         "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "data": "( a",
+        "range": [
+          0,
+          5
+        ],
+        "quasis": [
+          {
+            "type": "Quasi",
+            "line": 1,
+            "column": 1,
+            "range": [
+              0,
+              5
+            ],
+            "data": "( a",
+            "raw": "\"( a\""
+          }
+        ],
+        "expressions": [],
         "raw": "\"( a\""
       }
     ],

--- a/test/examples/string-with-single-quotes/output.json
+++ b/test/examples/string-with-single-quotes/output.json
@@ -2,23 +2,45 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 15 ],
+  "range": [
+    0,
+    15
+  ],
   "raw": "'coffee script'",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 15 ],
-    "raw": "'coffee script'",
+    "range": [
+      0,
+      15
+    ],
     "statements": [
       {
         "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 15 ],
-        "raw": "'coffee script'",
-        "data": "coffee script"
+        "range": [
+          0,
+          15
+        ],
+        "quasis": [
+          {
+            "type": "Quasi",
+            "line": 1,
+            "column": 1,
+            "range": [
+              0,
+              15
+            ],
+            "data": "coffee script",
+            "raw": "'coffee script'"
+          }
+        ],
+        "expressions": [],
+        "raw": "'coffee script'"
       }
-    ]
+    ],
+    "raw": "'coffee script'"
   }
 }

--- a/test/examples/string-with-triple-double-quotes/output.json
+++ b/test/examples/string-with-triple-double-quotes/output.json
@@ -2,27 +2,45 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 26 ],
+  "range": [
+    0,
+    26
+  ],
   "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 26 ],
-    "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
+    "range": [
+      0,
+      26
+    ],
     "statements": [
       {
-        "type": "Herestring",
+        "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 26 ],
-        "padding": [
-          [ 3, 4 ],
-          [ 22, 23 ]
+        "range": [
+          0,
+          26
         ],
-        "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
-        "data": "multi-line strings"
+        "quasis": [
+          {
+            "type": "Quasi",
+            "line": 1,
+            "column": 1,
+            "range": [
+              0,
+              26
+            ],
+            "data": "multi-line strings",
+            "raw": "\"\"\"\nmulti-line strings\n\"\"\""
+          }
+        ],
+        "expressions": [],
+        "raw": "\"\"\"\nmulti-line strings\n\"\"\""
       }
-    ]
+    ],
+    "raw": "\"\"\"\nmulti-line strings\n\"\"\""
   }
 }

--- a/test/examples/string-with-triple-quote-interpolation-containing-quotes/output.json
+++ b/test/examples/string-with-triple-quote-interpolation-containing-quotes/output.json
@@ -2,35 +2,51 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 20 ],
+  "range": [
+    0,
+    20
+  ],
+  "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 20 ],
+    "range": [
+      0,
+      20
+    ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 20 ],
+        "range": [
+          0,
+          20
+        ],
         "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
-            "range": [ 0, 9 ],
+            "range": [
+              0,
+              9
+            ],
             "data": "bar=\"",
             "raw": "\"\"\"\nbar=\""
           },
           {
-            "type": "String",
-            "data": "\"",
-            "raw": "\"\n\"\"\"",
+            "type": "Quasi",
             "line": 2,
             "column": 12,
-            "range": [ 15, 20 ]
+            "range": [
+              15,
+              20
+            ],
+            "data": "\"",
+            "raw": "\"\n\"\"\""
           }
         ],
         "expressions": [
@@ -38,7 +54,10 @@
             "type": "Identifier",
             "line": 2,
             "column": 8,
-            "range": [ 11, 14 ],
+            "range": [
+              11,
+              14
+            ],
             "data": "bar",
             "raw": "bar"
           }
@@ -46,6 +65,5 @@
       }
     ],
     "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\""
-  },
-  "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\""
+  }
 }

--- a/test/examples/string-with-triple-quote-interpolation/output.json
+++ b/test/examples/string-with-triple-quote-interpolation/output.json
@@ -2,35 +2,51 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 12 ],
+  "range": [
+    0,
+    12
+  ],
+  "raw": "\"\"\"\n#{a}\n\"\"\"",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "range": [
+      0,
+      12
+    ],
     "statements": [
       {
-        "type": "TemplateLiteral",
+        "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 12 ],
+        "range": [
+          0,
+          12
+        ],
         "raw": "\"\"\"\n#{a}\n\"\"\"",
         "quasis": [
           {
-            "type": "String",
+            "type": "Quasi",
             "line": 1,
             "column": 1,
-            "range": [ 0, 4 ],
+            "range": [
+              0,
+              4
+            ],
             "data": "",
             "raw": "\"\"\"\n"
           },
           {
-            "type": "String",
+            "type": "Quasi",
             "data": "",
             "raw": "\n\"\"\"",
             "line": 2,
             "column": 5,
-            "range": [ 8, 12 ]
+            "range": [
+              8,
+              12
+            ]
           }
         ],
         "expressions": [
@@ -38,7 +54,10 @@
             "type": "Identifier",
             "line": 2,
             "column": 3,
-            "range": [ 6, 7 ],
+            "range": [
+              6,
+              7
+            ],
             "data": "a",
             "raw": "a"
           }
@@ -46,6 +65,5 @@
       }
     ],
     "raw": "\"\"\"\n#{a}\n\"\"\""
-  },
-  "raw": "\"\"\"\n#{a}\n\"\"\""
+  }
 }

--- a/test/examples/string-with-triple-single-quotes/output.json
+++ b/test/examples/string-with-triple-single-quotes/output.json
@@ -2,27 +2,45 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 26 ],
+  "range": [
+    0,
+    26
+  ],
   "raw": "'''\nmulti-line strings\n'''",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 26 ],
-    "raw": "'''\nmulti-line strings\n'''",
+    "range": [
+      0,
+      26
+    ],
     "statements": [
       {
-        "type": "Herestring",
+        "type": "String",
         "line": 1,
         "column": 1,
-        "range": [ 0, 26 ],
-        "padding": [
-          [ 3, 4 ],
-          [ 22, 23 ]
+        "range": [
+          0,
+          26
         ],
-        "raw": "'''\nmulti-line strings\n'''",
-        "data": "multi-line strings"
+        "quasis": [
+          {
+            "type": "Quasi",
+            "line": 1,
+            "column": 1,
+            "range": [
+              0,
+              26
+            ],
+            "data": "multi-line strings",
+            "raw": "'''\nmulti-line strings\n'''"
+          }
+        ],
+        "expressions": [],
+        "raw": "'''\nmulti-line strings\n'''"
       }
-    ]
+    ],
+    "raw": "'''\nmulti-line strings\n'''"
   }
 }

--- a/test/util/parseLiteral_test.js
+++ b/test/util/parseLiteral_test.js
@@ -1,5 +1,4 @@
 import { deepEqual } from 'assert';
-import * as CoffeeScript from 'decaffeinate-coffeescript';
 
 import parseLiteral from '../../src/util/parseLiteral';
 
@@ -28,58 +27,6 @@ describe('parseLiteral', () => {
     deepEqual(parseLiteral('"1\\n2"'), { type: 'string', data: '1\n2' });
   });
 
-  it('parses triple-single-quoted strings', () => {
-    deepEqual(parseLiteral('\'\'\'foo\'\'\''), { type: 'Herestring', data: 'foo', padding: [] });
-  });
-
-  it('parses triple-single-quoted strings with single-quotes escaped', () => {
-    deepEqual(parseLiteral('\'\'\'Brian\'s code\'\'\''), { type: 'Herestring', data: 'Brian\'s code', padding: [] });
-  });
-
-  it('parses triple-single-quoted strings with escaped newlines', () => {
-    deepEqual(parseLiteral('\'\'\'1\\n2\'\'\''), { type: 'Herestring', data: '1\n2', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings', () => {
-    deepEqual(parseLiteral('"""foo"""'), { type: 'Herestring', data: 'foo', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with double-quotes escaped', () => {
-    deepEqual(parseLiteral('"""Hello "Brian\\""""'), { type: 'Herestring', data: 'Hello "Brian"', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with escaped newlines', () => {
-    deepEqual(parseLiteral('"""1\\n2"""'), { type: 'Herestring', data: '1\n2', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with escaped carriage returns', () => {
-    deepEqual(parseLiteral('"""1\\r2"""'), { type: 'Herestring', data: '1\r2', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with escaped tabs', () => {
-    deepEqual(parseLiteral('"""1\\t2"""'), { type: 'Herestring', data: '1\t2', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with escaped bell characters', () => {
-    deepEqual(parseLiteral('"""1\\b2"""'), { type: 'Herestring', data: '1\b2', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with escaped vertical tabs', () => {
-    deepEqual(parseLiteral('"""1\\v2"""'), { type: 'Herestring', data: '1\v2', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with escaped form feeds', () => {
-    deepEqual(parseLiteral('"""1\\f2"""'), { type: 'Herestring', data: '1\f2', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with escaped hex digits', () => {
-    deepEqual(parseLiteral('"""1\\xae2"""'), { type: 'Herestring', data: '1\xae2', padding: [] });
-  });
-
-  it('parses triple-double-quoted strings with escaped unicode digits', () => {
-    deepEqual(parseLiteral('"""1\\u12342"""'), { type: 'Herestring', data: '1\u12342', padding: [] });
-  });
-
   it('parses quoted strings containing null characters', () => {
     deepEqual(parseLiteral('"\\0"'), { type: 'string', data: '\0' });
   });
@@ -95,100 +42,4 @@ describe('parseLiteral', () => {
   it('parses floats without a leading digit', () => {
     deepEqual(parseLiteral('.1'), { type: 'float', data: 0.1 });
   });
-
-  it('inserts proper padding with when parsing multi-line herestrings', () => {
-    deepEqual(parseLiteral("'''a\n b'''"), { type: 'Herestring', data: 'a\nb', padding: [[5, 6]] });
-  });
-
-  it('ignores the indentation level of the first line in herestrings', () => {
-    verifyHerestringMatchesCoffeeScript(`a
-      b`, 'a\nb');
-  });
-
-  it('removes leading nonempty indentation in herestrings', () => {
-    verifyHerestringMatchesCoffeeScript(`
- a
-  b
-c
-d`,
-      'a\n b\nc\nd');
-  });
-
-  it('preserves leading indentation on the first line in herestrings if necessary', () => {
-    verifyHerestringMatchesCoffeeScript(` a
-          b
-            c
-          d`, ' a\nb\n  c\nd');
-  });
-
-  it('removes indentation normally if the first full line is empty', () => {
-    verifyHerestringMatchesCoffeeScript(`
-
-  a
-  b
-  c`, '\na\nb\nc');
-  });
-
-  it('uses indentation 0 for herestrings if the first full line is nonempty and has indentation 0', () => {
-    verifyHerestringMatchesCoffeeScript(`
-a
-  b
- c
-d`,
-      'a\n  b\n c\nd');
-  });
-
-  it('removes indentation from the first line if possible', () => {
-    verifyHerestringMatchesCoffeeScript(`     a
-      b
-    c
-      d`,
-      ' a\n  b\nc\n  d');
-  });
-
-  it('keeps spacing in the second line if there are two lines and both are only whitespace', () => {
-    verifyHerestringMatchesCoffeeScript(`    
-   `,
-      '   ');
-  });
-
-  it('removes leading whitespace from herestrings with tabs', () => {
-    verifyHerestringMatchesCoffeeScript(`
-\t\t\t\ta
-\t\tb`,
-      '\t\ta\nb');
-  });
-
-  it('handles a string with a leading and trailing blank line', () => {
-    verifyHerestringMatchesCoffeeScript(`
-a
-`,
-      'a');
-  });
-
-  it('handles a string with a blank line with spaces in it', () => {
-    verifyHerestringMatchesCoffeeScript(`
-  a
- 
-  b`,
-      'a\n \nb');
-  });
-
-  it('handles a string where the last line is a blank line with spaces', () => {
-    verifyHerestringMatchesCoffeeScript(`
-  a
-  b
- `,
-      'a\nb');
-  });
-
-  function verifyHerestringMatchesCoffeeScript(stringContents, expectedResultString) {
-    let code = `"""${stringContents}"""`;
-    let decaffeinateParserResult = parseLiteral(code).data;
-    let coffeeScriptResult = JSON.parse(
-      CoffeeScript.tokens(code)[0][1].replace(/\t/g, '\\t')
-    );
-    deepEqual(decaffeinateParserResult, coffeeScriptResult);
-    deepEqual(decaffeinateParserResult, expectedResultString);
-  }
 });


### PR DESCRIPTION
Progress toward these issues:
https://github.com/decaffeinate/decaffeinate/issues/557
https://github.com/decaffeinate/decaffeinate/issues/556
https://github.com/decaffeinate/decaffeinate/issues/554
https://github.com/decaffeinate/decaffeinate/issues/406

This change reworks the string representation in the decaffeinate-parser AST to
better fit the new way of thinking about strings:

* A simple string like `"Hello world"` is seen as a template string with 0
  interpolations rather than as something different from a template string.
* Herestrings and regular strings generally just differ in how the lexer treats
  them, rather than them being fundamentally different types of nodes. The
  coffee-lex output was intentionally designed so that the same (or nearly the
  same) code path can be used to handle whitespace trimming in either case.

To move toward this approach, this change makes it so all types of strings have
the node type `String`. In particular, there is no longer a field for
`TemplateLiteral.padding`, since the same information is kept in the token
stream now (and it seemed more straightforward for decaffeinate to read the
information directly from the tokens than indirectly through
decaffeinate-parser). A new `Quasi` node type is where the actual string
contents live (even though I don't expect decaffeinate will ever use quasi
contents).

One nuance here is that I still want to keep the underlying JS value for
literals, e.g. an actual int 3 for a literal 3. So I kept `parseLiteral`, but
changed it to no longer handle herestrings, and rather than operating on the
actual code, it now operates on the code provided in the CoffeeScript AST.

Still to do after this is to refactor the string interpolation code so that it
can work with heregex templates. Also, the quasi positions are currently taken
from CoffeeScript's positions, which isn't exactly what I want (ideally in
`"a#{b}c"`, the first quasi would start at the `a`, but for now, it starts at
the open-quote).

BREAKING CHANGE: The TemplateLiteral and Herestring node types have been removed
in favor of String. The String node type now always has an array of quasis and
an array of expressions. A new Quasi node type has been introduced for string
quasis.