### PR TITLE
chore: remove conventional changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "babel-register": "^6.7.2",
     "babelrc-rollup": "^3.0.0",
     "coffee-script-redux": "^2.0.0-beta8",
-    "cz-conventional-changelog": "^1.1.6",
     "mocha": "^3.0.0",
     "rollup": "^0.36.1",
     "rollup-plugin-babel": "^2.4.0",
@@ -50,10 +49,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/decaffeinate/decaffeinate-parser.git"
-  },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
   }
 }


### PR DESCRIPTION
This doesn't really affect anything; I've never really used it. This does not remove semantic-release.