### PR TITLE
fix: don't crash when inline JS ends in a close-quote

### DIFF
--- a/test/examples/backticks-with-string-inside/input.coffee
+++ b/test/examples/backticks-with-string-inside/input.coffee
@@ -1,0 +1,1 @@
+`import foo from 'foo'`

--- a/test/examples/backticks-with-string-inside/output.json
+++ b/test/examples/backticks-with-string-inside/output.json
@@ -1,0 +1,33 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    24
+  ],
+  "raw": "`import foo from 'foo'`\n",
+  "body": {
+    "type": "Block",
+    "line": 1,
+    "column": 1,
+    "range": [
+      0,
+      23
+    ],
+    "statements": [
+      {
+        "type": "JavaScript",
+        "line": 1,
+        "column": 1,
+        "range": [
+          0,
+          23
+        ],
+        "data": "import foo from 'foo'",
+        "raw": "`import foo from 'foo'`"
+      }
+    ],
+    "raw": "`import foo from 'foo'`"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/576

Previously, we used string matching to figure out what type of literal the node
was, but this can't work by itself because inline JS just includes the JS
contents as the value, so `'a'` has the same CoffeeScript AST representation
whether or not it is surrounded in backticks. Instead, we can look at the
coffee-lex tokens and see if the literal corresponds to a `JS` token.

While I was at it, I also changed the heregex case to use tokens instead of
string matching.