### PR TITLE
fix: improve performance when adjusting node bounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dist/"
   ],
   "dependencies": {
-    "coffee-lex": "^4.2.3",
+    "coffee-lex": "^4.3.0",
     "decaffeinate-coffeescript": "^1.10.0-patch5",
     "lines-and-columns": "^1.1.5"
   },

--- a/src/parser.js
+++ b/src/parser.js
@@ -976,7 +976,7 @@ function convert(context) {
             token.type !== COMMENT &&
             token.type !== HERECOMMENT
           );
-        });
+        }, context.sourceTokens.indexOfTokenNearSourceIndex(result.range[1]));
 
         let lastTokenOfNode = context.sourceTokens.tokenAtIndex(lastTokenIndexOfNode);
         result.range[1] = lastTokenOfNode.end;


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/612

Previously, we did a linear search from the end of the token list until we found
a token in the right place. Now, we start the search from just after the end of
the node. We still include the bounds as part of the predicate, since
`indexOfTokenNearSourceIndex` just gives a good upper bound but not necessarily
an exact starting point.