### PR TITLE
refactor: introduce a `Loop` node type

### DIFF
--- a/test/examples/loop/output.json
+++ b/test/examples/loop/output.json
@@ -2,47 +2,55 @@
   "type": "Program",
   "line": 1,
   "column": 1,
-  "range": [ 0, 8 ],
+  "range": [
+    0,
+    8
+  ],
   "raw": "loop\n  a",
   "body": {
     "type": "Block",
     "line": 1,
     "column": 1,
-    "range": [ 0, 8 ],
-    "raw": "loop\n  a",
+    "range": [
+      0,
+      8
+    ],
     "statements": [
       {
-        "type": "While",
+        "type": "Loop",
         "line": 1,
         "column": 1,
-        "range": [ 0, 8 ],
-        "raw": "loop\n  a",
-        "isUntil": false,
-        "guard": null,
+        "range": [
+          0,
+          8
+        ],
         "body": {
           "type": "Block",
           "line": 2,
           "column": 3,
-          "range": [ 7, 8 ],
-          "raw": "a",
-          "inline": false,
+          "range": [
+            7,
+            8
+          ],
           "statements": [
             {
               "type": "Identifier",
               "line": 2,
               "column": 3,
-              "range": [ 7, 8 ],
+              "range": [
+                7,
+                8
+              ],
               "raw": "a",
               "data": "a"
             }
-          ]
+          ],
+          "raw": "a",
+          "inline": false
         },
-        "condition": {
-          "type": "Bool",
-          "data": true,
-          "virtual": true
-        }
+        "raw": "loop\n  a"
       }
-    ]
+    ],
+    "raw": "loop\n  a"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Rather than a `While` node with a virtual condition
and null for other properties, this introduces a new `Loop` node that
only has a body.