### PR TITLE
refactor: introduce `mapValue` for handling values

### DIFF
--- a/src/mappers/mapAny.ts
+++ b/src/mappers/mapAny.ts
@@ -1,4 +1,4 @@
-import { Arr, Base, Bool, Literal, Null, Return, Throw, Undefined } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Arr, Base, Bool, Literal, Null, Return, Throw, Undefined, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { inspect } from 'util';
 import { Node } from '../nodes';
 import ParseContext from '../util/ParseContext';
@@ -9,23 +9,40 @@ import mapNull from './mapNull';
 import mapReturn from './mapReturn';
 import mapThrow from './mapThrow';
 import mapUndefined from './mapUndefined';
+import mapValue from './mapValue';
 
 export default function mapAny(context: ParseContext, node: Base): Node {
+  if (node instanceof Value) {
+    return mapValue(context, node);
+  }
+
+  if (node instanceof Literal) {
+    return mapLiteral(context, node);
+  }
+
   if (node instanceof Arr) {
     return mapArr(context, node);
-  } else if (node instanceof Bool) {
-    return mapBool(context, node);
-  } else if (node instanceof Literal) {
-    return mapLiteral(context, node);
-  } else if (node instanceof Return) {
-    return mapReturn(context, node);
-  } else if (node instanceof Null) {
-    return mapNull(context, node);
-  } else if (node instanceof Throw) {
-    return mapThrow(context, node);
-  } else if (node instanceof Undefined) {
-    return mapUndefined(context, node);
-  } else {
-    throw new Error(`unhandled node type: ${node.constructor.name} (${inspect(node)})`);
   }
+
+  if (node instanceof Bool) {
+    return mapBool(context, node);
+  }
+
+  if (node instanceof Return) {
+    return mapReturn(context, node);
+  }
+
+  if (node instanceof Null) {
+    return mapNull(context, node);
+  }
+
+  if (node instanceof Throw) {
+    return mapThrow(context, node);
+  }
+
+  if (node instanceof Undefined) {
+    return mapUndefined(context, node);
+  }
+
+  throw new Error(`unhandled node type: ${node.constructor.name} (${inspect(node)})`);
 }

--- a/src/mappers/mapValue.ts
+++ b/src/mappers/mapValue.ts
@@ -1,0 +1,70 @@
+import { SourceType } from 'coffee-lex';
+import SourceToken from 'coffee-lex/dist/SourceToken';
+import { Access, Literal, LocationData, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { inspect } from 'util';
+import { MemberAccessOp, Node } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+
+export default function mapValue(context: ParseContext, node: Value): Node {
+  let result = mapAny(context, node.base);
+
+  for (let property of node.properties) {
+    if (property instanceof Access && !property.soak) {
+      let name = property.name;
+
+      if (!(name instanceof Literal)) {
+        throw new Error(`unexpected non-Literal property access name: ${inspect(name)}`);
+      }
+
+      let startToken = tokenAtLocation(context, property.locationData);
+
+      if (!startToken) {
+        throw new Error(`cannot find token at start of property: ${inspect(property)}`);
+      }
+
+      if (startToken.type === SourceType.PROTO) {
+        throw new Error(`TODO: cannot handle prototype access yet: ${inspect(property)}`);
+      }
+
+      let last = context.linesAndColumns.indexForLocation({
+        line: property.locationData.last_line,
+        column: property.locationData.last_column
+      });
+
+      result = new MemberAccessOp(
+        result.line,
+        result.column,
+        result.start,
+        last + 1,
+        context.source.slice(result.start, last + 1),
+        false,
+        result,
+        name.value
+      );
+    } else {
+      throw new Error(`TODO: cannot handle property yet: ${inspect(property)}`);
+    }
+  }
+
+  return result;
+}
+
+function tokenAtLocation(context: ParseContext, location: LocationData): SourceToken | null {
+  let start = context.linesAndColumns.indexForLocation({
+    line: location.first_line,
+    column: location.first_column
+  });
+
+  if (start === null) {
+    return null;
+  }
+
+  let startTokenIndex = context.sourceTokens.indexOfTokenContainingSourceIndex(start);
+
+  if (startTokenIndex === null) {
+    return null;
+  }
+
+  return context.sourceTokens.tokenAtIndex(startTokenIndex);
+}

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -152,6 +152,26 @@ export class Int extends Number {
   }
 }
 
+export class MemberAccessOp extends Node {
+  readonly expression: Node;
+  readonly memberName: string;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    expression: Node,
+    memberName: string
+  ) {
+    super('MemberAccessOp', line, column, start, end, raw, virtual);
+    this.expression = expression;
+    this.memberName = memberName;
+  }
+}
+
 export class Quasi extends Node {
   readonly data: string;
 


### PR DESCRIPTION
The main problem with doing this refactor in pieces is that they are mutually exclusive code paths. This means that once a call into `mapAny` or any of the concrete mappers happens within parser.js, all descendants of that node must be mappable with that system. Since most node types that contain children can contain essentially anything, this makes it tricky to do anything but all-or-nothing.

In this PR, I introduce not only a `mapValue` and the assiociated `Value` node, but a way to fall back to the old way of mapping. This way, if the mapper fails (likely because it cannot handle a particular node type), it will unwind back to the place we entered the mapper code path and continue as before. The downside is that we have to keep both code paths until we can switch everything over.