### PR TITLE
fix: redo fix for floats with leading periods

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "babylon": "^6.14.1",
-    "coffee-lex": "^5.0.0",
+    "coffee-lex": "^5.0.2",
     "decaffeinate-coffeescript": "^1.10.0-patch9",
     "lines-and-columns": "^1.1.6"
   },

--- a/src/mappers/mapLiteral.ts
+++ b/src/mappers/mapLiteral.ts
@@ -39,7 +39,7 @@ export default function mapLiteral(context: ParseContext, node: Literal): Node {
     return new JavaScript(line, column, start, end, raw, virtual, node.value);
   }
 
-  if (startToken.type === SourceType.NUMBER || startToken.type === SourceType.DOT) {
+  if (startToken.type === SourceType.NUMBER) {
     if (raw.includes('.')) {
       return new Float(line, column, start, end, raw, virtual, parseNumber(node.value));
     } else {


### PR DESCRIPTION
This is the proper fix for decaffeinate/decaffeinate#682, specifically updating coffee-lex to lex numbers with a leading period as a single token.