### PR TITLE
fix: create `Identifier` nodes for unknown literals

### DIFF
--- a/src/mappers/mapLiteral.ts
+++ b/src/mappers/mapLiteral.ts
@@ -6,6 +6,7 @@ import isStringAtPosition from '../util/isStringAtPosition';
 import ParseContext from '../util/ParseContext';
 import parseNumber from '../util/parseNumber';
 import parseString from '../util/parseString';
+import { UnsupportedNodeError } from './mapAnyWithFallback';
 import mapBase from './mapBase';
 
 const HEREGEX_PATTERN = /^\/\/\/((?:.|\n)*)\/\/\/([gimy]*)$/;
@@ -91,10 +92,5 @@ export default function mapLiteral(context: ParseContext, node: Literal): Node {
     return new Quasi(line, column, start, end, raw, virtual, parseString(node.value));
   }
 
-  throw new Error(
-    `cannot handle literal: ${inspect(node)}
-hint:
-  first token=${inspect(startToken)} (${SourceType[startToken.type]})
-  last token=${inspect(lastToken)} (${SourceType[lastToken.type]})`
-  );
+  throw new UnsupportedNodeError(node);
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -314,6 +314,13 @@ function convert(context) {
     }
 
     switch (type(node)) {
+      case 'Literal':
+        return mapAnyWithFallback(context, node, () =>
+          makeNode(context, 'Identifier', node.locationData, {
+            data: node.value
+          })
+        );
+
       case 'Value': {
         return mapAnyWithFallback(context, node, () => {
           let value = convertChild(node.base);


### PR DESCRIPTION
This replicates the old (incorrect) behavior of creating `Identifier` nodes for `Literal` nodes that we don't know how to parse. This should make decaffeinate work with decaffeinate-parser again.