### PR TITLE
refactor: move the fallback to `Identifier` to `mapLiteral`

### DIFF
--- a/src/mappers/mapLiteral.ts
+++ b/src/mappers/mapLiteral.ts
@@ -6,7 +6,6 @@ import isStringAtPosition from '../util/isStringAtPosition';
 import ParseContext from '../util/ParseContext';
 import parseNumber from '../util/parseNumber';
 import parseString from '../util/parseString';
-import { UnsupportedNodeError } from './mapAnyWithFallback';
 import mapBase from './mapBase';
 
 const HEREGEX_PATTERN = /^\/\/\/((?:.|\n)*)\/\/\/([gimy]*)$/;
@@ -92,5 +91,6 @@ export default function mapLiteral(context: ParseContext, node: Literal): Node {
     return new Quasi(line, column, start, end, raw, virtual, parseString(node.value));
   }
 
-  throw new UnsupportedNodeError(node);
+  // Fall back to identifiers.
+  return new Identifier(line, column, start, end, raw, virtual, node.value);
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -314,13 +314,6 @@ function convert(context) {
     }
 
     switch (type(node)) {
-      case 'Literal':
-        return mapAnyWithFallback(context, node, () =>
-          makeNode(context, 'Identifier', node.locationData, {
-            data: node.value
-          })
-        );
-
       case 'Value': {
         return mapAnyWithFallback(context, node, () => {
           let value = convertChild(node.base);


### PR DESCRIPTION
Since `Literal` doesn't have any children, it's pretty simple to handle the fallback in `mapLiteral` itself.