### PR TITLE
refactor: try every node with the new mappers with fallbacks

### DIFF
--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -348,7 +348,7 @@ export class Undefined extends Node {
 }
 
 export class Return extends Node {
-  readonly argument: Node | null;
+  readonly expression: Node | null;
 
   constructor(
     line: number,
@@ -357,10 +357,10 @@ export class Return extends Node {
     end: number,
     raw: string,
     virtual: boolean,
-    argument: Node | null
+    expression: Node | null
   ) {
     super('Return', line, column, start, end, raw, virtual);
-    this.argument = argument;
+    this.expression = expression;
   }
 }
 


### PR DESCRIPTION
This will allow us to make incremental progress on moving to the mapper functions without doing much to parser.js for a bit. Also, I renamed `Return#argument` to `Return#expression` to match the existing property name.

The downside of this is that it will likely increase parse times as we attempt to map a bunch of nodes we can't handle yet and unwind the stack. I haven't attempted to test this theory, but my gut says that it's not a big deal.