### PR TITLE
refactor: extract handling of `Param` to `mapParam`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "babylon": "^6.14.1",
     "coffee-lex": "^5.0.2",
-    "decaffeinate-coffeescript": "^1.10.0-patch9",
+    "decaffeinate-coffeescript": "^1.10.0-patch10",
     "lines-and-columns": "^1.1.6"
   },
   "devDependencies": {

--- a/src/mappers/mapAny.ts
+++ b/src/mappers/mapAny.ts
@@ -1,4 +1,4 @@
-import { Arr, Base, Bool, Literal, Null, Return, Throw, Undefined, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Arr, Base, Bool, Literal, Null, Param, Return, Throw, Undefined, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Node } from '../nodes';
 import ParseContext from '../util/ParseContext';
 import { UnsupportedNodeError } from './mapAnyWithFallback';
@@ -6,6 +6,7 @@ import mapArr from './mapArr';
 import mapBool from './mapBool';
 import mapLiteral from './mapLiteral';
 import mapNull from './mapNull';
+import mapParam from './mapParam';
 import mapReturn from './mapReturn';
 import mapThrow from './mapThrow';
 import mapUndefined from './mapUndefined';
@@ -26,6 +27,10 @@ export default function mapAny(context: ParseContext, node: Base): Node {
 
   if (node instanceof Bool) {
     return mapBool(context, node);
+  }
+
+  if (node instanceof Param) {
+    return mapParam(context, node);
   }
 
   if (node instanceof Return) {

--- a/src/mappers/mapParam.ts
+++ b/src/mappers/mapParam.ts
@@ -1,0 +1,21 @@
+import { Param } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { DefaultParam, Node, Rest } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import mapBase from './mapBase';
+
+export default function mapParam(context: ParseContext, node: Param): Node {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let param = mapAny(context, node.name);
+
+  if (node.value) {
+    let value = mapAny(context, node.value);
+    return new DefaultParam(line, column, start, end, raw, virtual, param, value);
+  }
+
+  if (node.splat) {
+    return new Rest(line, column, start, end, raw, virtual, param);
+  }
+
+  return param;
+}

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -432,6 +432,43 @@ export class ArrayInitialiser extends Node {
   }
 }
 
+export class DefaultParam extends Node {
+  readonly param: Node;
+  readonly default: Node;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    param: Node,
+    defaultValue: Node
+  ) {
+    super('DefaultParam', line, column, start, end, raw, virtual);
+    this.param = param;
+    this.default = defaultValue;
+  }
+}
+
+export class Rest extends Node {
+  readonly expression: Node;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    expression: Node
+  ) {
+    super('Rest', line, column, start, end, raw, virtual);
+    this.expression = expression;
+  }
+}
+
 export type DecaffeinateNode =
   Bool |
   Null |


### PR DESCRIPTION
We can't remove the old implementation because parameter default values can contain essentially arbitrary code.