### PR TITLE
fix: map `break` and `continue` to `Break` and `Continue` nodes

### DIFF
--- a/src/mappers/mapLiteral.ts
+++ b/src/mappers/mapLiteral.ts
@@ -1,7 +1,7 @@
 import SourceType from 'coffee-lex/dist/SourceType';
 import { Literal } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { inspect } from 'util';
-import { Float, Heregex, Identifier, Int, JavaScript, Node, Quasi, Regex, RegexFlags, String, This } from '../nodes';
+import { Break, Continue, Float, Heregex, Identifier, Int, JavaScript, Node, Quasi, Regex, RegexFlags, String, This } from '../nodes';
 import isStringAtPosition from '../util/isStringAtPosition';
 import ParseContext from '../util/ParseContext';
 import parseNumber from '../util/parseNumber';
@@ -101,6 +101,14 @@ export default function mapLiteral(context: ParseContext, node: Literal): Node {
     // just return a Quasi node, and higher-up code should insert it
     // into a string interpolation.
     return new Quasi(line, column, start, end, raw, virtual, parseString(node.value));
+  }
+
+  if (startToken.type === SourceType.BREAK) {
+    return new Break(line, column, start, end, raw, virtual);
+  }
+
+  if (startToken.type === SourceType.CONTINUE) {
+    return new Continue(line, column, start, end, raw, virtual);
   }
 
   // Fall back to identifiers.

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -469,6 +469,32 @@ export class Rest extends Node {
   }
 }
 
+export class Break extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean
+  ) {
+    super('Break', line, column, start, end, raw, virtual);
+  }
+}
+
+export class Continue extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean
+  ) {
+    super('Continue', line, column, start, end, raw, virtual);
+  }
+}
+
 export type DecaffeinateNode =
   Bool |
   Null |

--- a/test/examples/break/input.coffee
+++ b/test/examples/break/input.coffee
@@ -1,0 +1,2 @@
+loop
+  break

--- a/test/examples/break/output.json
+++ b/test/examples/break/output.json
@@ -1,0 +1,55 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    13
+  ],
+  "raw": "loop\n  break\n",
+  "body": {
+    "type": "Block",
+    "line": 1,
+    "column": 1,
+    "range": [
+      0,
+      12
+    ],
+    "statements": [
+      {
+        "type": "Loop",
+        "line": 1,
+        "column": 1,
+        "range": [
+          0,
+          12
+        ],
+        "body": {
+          "type": "Block",
+          "line": 2,
+          "column": 3,
+          "range": [
+            7,
+            12
+          ],
+          "statements": [
+            {
+              "type": "Break",
+              "line": 2,
+              "column": 3,
+              "range": [
+                7,
+                12
+              ],
+              "raw": "break"
+            }
+          ],
+          "raw": "break",
+          "inline": false
+        },
+        "raw": "loop\n  break"
+      }
+    ],
+    "raw": "loop\n  break"
+  }
+}

--- a/test/examples/continue/input.coffee
+++ b/test/examples/continue/input.coffee
@@ -1,0 +1,2 @@
+loop
+  continue

--- a/test/examples/continue/output.json
+++ b/test/examples/continue/output.json
@@ -1,0 +1,55 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    16
+  ],
+  "raw": "loop\n  continue\n",
+  "body": {
+    "type": "Block",
+    "line": 1,
+    "column": 1,
+    "range": [
+      0,
+      15
+    ],
+    "statements": [
+      {
+        "type": "Loop",
+        "line": 1,
+        "column": 1,
+        "range": [
+          0,
+          15
+        ],
+        "body": {
+          "type": "Block",
+          "line": 2,
+          "column": 3,
+          "range": [
+            7,
+            15
+          ],
+          "statements": [
+            {
+              "type": "Continue",
+              "line": 2,
+              "column": 3,
+              "range": [
+                7,
+                15
+              ],
+              "raw": "continue"
+            }
+          ],
+          "raw": "continue",
+          "inline": false
+        },
+        "raw": "loop\n  continue"
+      }
+    ],
+    "raw": "loop\n  continue"
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: Previously, these statements were mapped to `Identifier`, which was fine because decaffeinate just passed them through anyway. However, it's not the right representation for these statements so this introduces new nodes to represent them.

Fixes #92