### PR TITLE
fix: match obscure whitespace characters when parsing heregexes

### DIFF
--- a/src/mappers/mapLiteral.ts
+++ b/src/mappers/mapLiteral.ts
@@ -9,7 +9,7 @@ import parseRegExp from '../util/parseRegExp';
 import parseString from '../util/parseString';
 import mapBase from './mapBase';
 
-const HEREGEX_PATTERN = /^\/\/\/((?:.|\n)*)\/\/\/([gimy]*)$/;
+const HEREGEX_PATTERN = /^\/\/\/((?:.|\s)*)\/\/\/([gimy]*)$/;
 
 export default function mapLiteral(context: ParseContext, node: Literal): Node {
   let { line, column, start, end, raw, virtual } = mapBase(context, node);

--- a/test/examples/heregex-with-strange-whitespace/input.coffee
+++ b/test/examples/heregex-with-strange-whitespace/input.coffee
@@ -1,0 +1,2 @@
+# This has a \u2028 character in it.
+/// ///

--- a/test/examples/heregex-with-strange-whitespace/output.json
+++ b/test/examples/heregex-with-strange-whitespace/output.json
@@ -1,0 +1,56 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    45
+  ],
+  "raw": "# This has a \\u2028 character in it.\n/// ///\n",
+  "body": {
+    "type": "Block",
+    "line": 2,
+    "column": 1,
+    "range": [
+      37,
+      44
+    ],
+    "statements": [
+      {
+        "type": "Heregex",
+        "line": 2,
+        "column": 1,
+        "range": [
+          37,
+          44
+        ],
+        "raw": "/// ///",
+        "quasis": [
+          {
+            "type": "Quasi",
+            "line": 2,
+            "column": 1,
+            "range": [
+              37,
+              44
+            ],
+            "raw": "/// ///",
+            "data": "/(?:)/"
+          }
+        ],
+        "expressions": [],
+        "flags": {
+          "global": false,
+          "ignoreCase": false,
+          "multiline": false,
+          "sticky": false,
+          "g": false,
+          "i": false,
+          "m": false,
+          "y": false
+        }
+      }
+    ],
+    "raw": "/// ///"
+  }
+}


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/672

In JS regexes, `.` matches everything except newline characters. The characters
`\u2028` and `\u2029` are considered newline characters in this sense but aren't
matched by `\n`. To make sure we match every character, we can match `\s`, which
gets all forms of whitespace.