### PR TITLE
test: add a test for a post-while starting with a `loop` token

### DIFF
--- a/test/examples/post-while-with-loop/input.coffee
+++ b/test/examples/post-while-with-loop/input.coffee
@@ -1,0 +1,1 @@
+loop a while b

--- a/test/examples/post-while-with-loop/output.json
+++ b/test/examples/post-while-with-loop/output.json
@@ -1,0 +1,92 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    15
+  ],
+  "raw": "loop a while b\n",
+  "body": {
+    "type": "Block",
+    "line": 1,
+    "column": 1,
+    "range": [
+      0,
+      14
+    ],
+    "statements": [
+      {
+        "type": "Loop",
+        "line": 1,
+        "column": 1,
+        "range": [
+          0,
+          14
+        ],
+        "body": {
+          "type": "Block",
+          "line": 1,
+          "column": 6,
+          "range": [
+            5,
+            14
+          ],
+          "statements": [
+            {
+              "type": "While",
+              "line": 1,
+              "column": 6,
+              "range": [
+                5,
+                14
+              ],
+              "condition": {
+                "type": "Identifier",
+                "line": 1,
+                "column": 14,
+                "range": [
+                  13,
+                  14
+                ],
+                "raw": "b",
+                "data": "b"
+              },
+              "guard": null,
+              "body": {
+                "type": "Block",
+                "line": 1,
+                "column": 6,
+                "range": [
+                  5,
+                  6
+                ],
+                "raw": "a",
+                "statements": [
+                  {
+                    "type": "Identifier",
+                    "line": 1,
+                    "column": 6,
+                    "range": [
+                      5,
+                      6
+                    ],
+                    "raw": "a",
+                    "data": "a"
+                  }
+                ],
+                "inline": true
+              },
+              "isUntil": false,
+              "raw": "a while b"
+            }
+          ],
+          "raw": "a while b",
+          "inline": true
+        },
+        "raw": "loop a while b"
+      }
+    ],
+    "raw": "loop a while b"
+  }
+}


### PR DESCRIPTION
I suspected that this might fail because we look for a `LOOP` token at the start of the `While` node. If this does pass, perhaps it indicates that the "start" of the `While` node is actually the `WHILE` token rather than the prefixed body.