### PR TITLE
refactor: add several mappers for various node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "babylon": "^6.14.1",
     "coffee-lex": "^6.0.0",
-    "decaffeinate-coffeescript": "^1.10.0-patch10",
+    "decaffeinate-coffeescript": "^1.10.0-patch12",
     "lines-and-columns": "^1.1.6"
   },
   "devDependencies": {

--- a/src/mappers/mapAny.ts
+++ b/src/mappers/mapAny.ts
@@ -1,17 +1,25 @@
-import { Arr, Base, Bool, Existence, Literal, Null, Param, Return, Throw, Undefined, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Arr, Base, Block, Bool, Code, Existence, Extends, For, Literal, Null, Param, Parens, Range, Return, Splat, Throw, Try, Undefined, Value, While } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Node } from '../nodes';
 import ParseContext from '../util/ParseContext';
 import { UnsupportedNodeError } from './mapAnyWithFallback';
 import mapArr from './mapArr';
+import mapBlock from './mapBlock';
 import mapBool from './mapBool';
+import mapCode from './mapCode';
 import mapExistence from './mapExistence';
+import mapExtends from './mapExtends';
 import mapLiteral from './mapLiteral';
 import mapNull from './mapNull';
 import mapParam from './mapParam';
+import mapParens from './mapParens';
+import mapRange from './mapRange';
 import mapReturn from './mapReturn';
+import mapSplat from './mapSplat';
 import mapThrow from './mapThrow';
+import mapTry from './mapTry';
 import mapUndefined from './mapUndefined';
 import mapValue from './mapValue';
+import mapWhile from './mapWhile';
 
 export default function mapAny(context: ParseContext, node: Base): Node {
   if (node instanceof Value) {
@@ -42,6 +50,10 @@ export default function mapAny(context: ParseContext, node: Base): Node {
     return mapNull(context, node);
   }
 
+  if (node instanceof Parens) {
+    return mapParens(context, node);
+  }
+
   if (node instanceof Throw) {
     return mapThrow(context, node);
   }
@@ -50,8 +62,36 @@ export default function mapAny(context: ParseContext, node: Base): Node {
     return mapUndefined(context, node);
   }
 
+  if (node instanceof Block) {
+    return mapBlock(context, node);
+  }
+
+  if (node instanceof Code) {
+    return mapCode(context, node);
+  }
+
+  if (node instanceof While && !(node instanceof For)) {
+    return mapWhile(context, node);
+  }
+
+  if (node instanceof Try) {
+    return mapTry(context, node);
+  }
+
   if (node instanceof Existence) {
     return mapExistence(context, node);
+  }
+
+  if (node instanceof Splat) {
+    return mapSplat(context, node);
+  }
+
+  if (node instanceof Range) {
+    return mapRange(context, node);
+  }
+
+  if (node instanceof Extends) {
+    return mapExtends(context, node);
   }
 
   throw new UnsupportedNodeError(node);

--- a/src/mappers/mapBlock.ts
+++ b/src/mappers/mapBlock.ts
@@ -1,0 +1,24 @@
+import { SourceType } from 'coffee-lex';
+import { Block as CoffeeBlock } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Block } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import { UnsupportedNodeError } from './mapAnyWithFallback';
+import mapBase from './mapBase';
+
+export default function mapBlock(context: ParseContext, node: CoffeeBlock): Block {
+  if (node.expressions.length === 0) {
+    throw new UnsupportedNodeError(node);
+  }
+
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let previousTokenIndex = context.sourceTokens.indexOfTokenNearSourceIndex(start - 1);
+  let previousToken = previousTokenIndex ? context.sourceTokens.tokenAtIndex(previousTokenIndex) : null;
+  let inline = previousToken ? previousToken.type !== SourceType.NEWLINE : false;
+
+  return new Block(
+    line, column, start, end, raw, virtual,
+    node.expressions.map(expression => mapAny(context, expression)),
+    inline
+  );
+}

--- a/src/mappers/mapCode.ts
+++ b/src/mappers/mapCode.ts
@@ -1,0 +1,21 @@
+import { Code } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { BaseFunction, Function } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import { UnsupportedNodeError } from './mapAnyWithFallback';
+import mapBase from './mapBase';
+import mapBlock from './mapBlock';
+
+export default function mapCode(context: ParseContext, node: Code): BaseFunction {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+
+  if (node.bound || node.isGenerator) {
+    throw new UnsupportedNodeError(node);
+  }
+
+  return new Function(
+    line, column, start, end, raw, virtual,
+    node.params.map(param => mapAny(context, param)),
+    mapBlock(context, node.body)
+  );
+}

--- a/src/mappers/mapExtends.ts
+++ b/src/mappers/mapExtends.ts
@@ -1,0 +1,14 @@
+import { Extends } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { ExtendsOp } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import mapBase from './mapBase';
+
+export default function mapExtends(context: ParseContext, node: Extends): ExtendsOp {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  return new ExtendsOp(
+    line, column, start, end, raw, virtual,
+    mapAny(context, node.child),
+    mapAny(context, node.parent)
+  );
+}

--- a/src/mappers/mapParens.ts
+++ b/src/mappers/mapParens.ts
@@ -1,0 +1,31 @@
+import { Block, Parens } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Node, SeqOp } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+
+export default function mapParens(context: ParseContext, node: Parens): Node {
+  if (!(node.body instanceof Block)) {
+    return mapAny(context, node.body);
+  }
+
+  let { expressions } = node.body;
+
+  if (expressions.length === 1) {
+    return mapAny(context, expressions[0]);
+  }
+
+  return expressions
+    .map(expression => mapAny(context, expression))
+    .reduceRight((right, left) =>
+      new SeqOp(
+        left.line,
+        left.column,
+        left.start,
+        right.end,
+        context.source.slice(left.start, right.end),
+        false,
+        left,
+        right
+      )
+    );
+}

--- a/src/mappers/mapRange.ts
+++ b/src/mappers/mapRange.ts
@@ -1,0 +1,16 @@
+import { Range as CoffeeRange } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Range } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import mapBase from './mapBase';
+
+export default function mapRange(context: ParseContext, node: CoffeeRange): Range {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+
+  return new Range(
+    line, column, start, end, raw, virtual,
+    mapAny(context, node.from),
+    mapAny(context, node.to),
+    !node.exclusive
+  );
+}

--- a/src/mappers/mapSplat.ts
+++ b/src/mappers/mapSplat.ts
@@ -1,0 +1,10 @@
+import { Splat } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Spread } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import mapBase from './mapBase';
+
+export default function mapSplat(context: ParseContext, node: Splat): Spread {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  return new Spread(line, column, start, end, raw, virtual, mapAny(context, node.name));
+}

--- a/src/mappers/mapTry.ts
+++ b/src/mappers/mapTry.ts
@@ -1,0 +1,17 @@
+import { Try as CoffeeTry } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Try } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import mapBase from './mapBase';
+
+export default function mapTry(context: ParseContext, node: CoffeeTry): Try {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+
+  return new Try(
+    line, column, start, end, raw, virtual,
+    node.attempt ? mapAny(context, node.attempt) : null,
+    node.errorVariable ? mapAny(context, node.errorVariable) : null,
+    node.recovery ? mapAny(context, node.recovery) : null,
+    node.ensure ? mapAny(context, node.ensure) : null
+  );
+}

--- a/src/mappers/mapWhile.ts
+++ b/src/mappers/mapWhile.ts
@@ -1,0 +1,27 @@
+import { SourceType } from 'coffee-lex';
+import { While as CoffeeWhile } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Loop, While } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import mapBase from './mapBase';
+
+export default function mapWhile(context: ParseContext, node: CoffeeWhile): While | Loop {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let startTokenIndex = context.sourceTokens.indexOfTokenStartingAtSourceIndex(start);
+  let startToken = startTokenIndex && context.sourceTokens.tokenAtIndex(startTokenIndex);
+
+  if (startToken && startToken.type === SourceType.LOOP) {
+    return new Loop(
+      line, column, start, end, raw, virtual,
+      node.body ? mapAny(context, node.body) : null
+    );
+  }
+
+  return new While(
+    line, column, start, end, raw, virtual,
+    mapAny(context, node.condition),
+    node.guard ? mapAny(context, node.guard) : null,
+    node.body ? mapAny(context, node.body) : null,
+    node.condition.inverted === true
+  );
+}

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -211,6 +211,7 @@ export class String extends Node {
 
 export class Block extends Node {
   readonly statements: Array<Node>;
+  readonly inline: boolean;
 
   constructor(
     line: number,
@@ -219,15 +220,17 @@ export class Block extends Node {
     end: number,
     raw: string,
     virtual: boolean,
-    statements: Array<Node>
+    statements: Array<Node>,
+    inline: boolean
   ) {
     super('Block', line, column, start, end, raw, virtual);
     this.statements = statements;
+    this.inline = inline;
   }
 }
 
 export class Loop extends Node {
-  readonly body: Block;
+  readonly body: Node | null;
 
   constructor(
     line: number,
@@ -236,10 +239,36 @@ export class Loop extends Node {
     end: number,
     raw: string,
     virtual: boolean,
-    body: Block
+    body: Node | null
   ) {
     super('Loop', line, column, start, end, raw, virtual);
     this.body = body;
+  }
+}
+
+export class While extends Node {
+  readonly condition: Node;
+  readonly guard: Node | null;
+  readonly body: Node | null;
+  readonly isUntil: boolean;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    condition: Node,
+    guard: Node | null,
+    body: Node | null,
+    isUntil: boolean
+  ) {
+    super('While', line, column, start, end, raw, virtual);
+    this.condition = condition;
+    this.guard = guard;
+    this.body = body;
+    this.isUntil = isUntil;
   }
 }
 
@@ -509,6 +538,206 @@ export class UnaryExistsOp extends Node {
   ) {
     super('UnaryExistsOp', line, column, start, end, raw, virtual);
     this.expression = expression;
+  }
+}
+
+export class Spread extends Node {
+  readonly expression: Node;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    expression: Node
+  ) {
+    super('Spread', line, column, start, end, raw, virtual);
+    this.expression = expression;
+  }
+}
+
+export class Range extends Node {
+  readonly left: Node;
+  readonly right: Node;
+  readonly isInclusive: boolean;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    left: Node,
+    right: Node,
+    isInclusive: boolean
+  ) {
+    super('Range', line, column, start, end, raw, virtual);
+    this.left = left;
+    this.right = right;
+    this.isInclusive = isInclusive;
+  }
+}
+
+export class BinaryOp extends Node {
+  readonly left: Node;
+  readonly right: Node;
+
+  constructor(
+    type: string,
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    left: Node,
+    right: Node
+  ) {
+    super(type, line, column, start, end, raw, virtual);
+    this.left = left;
+    this.right = right;
+  }
+}
+
+export class ExtendsOp extends BinaryOp {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    left: Node,
+    right: Node
+  ) {
+    super('ExtendsOp', line, column, start, end, raw, virtual, left, right);
+  }
+}
+
+export class SeqOp extends BinaryOp {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    left: Node,
+    right: Node
+  ) {
+    super('SeqOp', line, column, start, end, raw, virtual, left, right);
+  }
+}
+
+abstract class BaseFunction extends Node {
+  readonly parameters: Array<Node>;
+  readonly body: Block;
+
+  constructor(
+    type: string,
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    parameters: Array<Node>,
+    body: Block
+  ) {
+    super(type, line, column, start, end, raw, virtual);
+    this.parameters = parameters;
+    this.body = body;
+  }
+}
+
+export { BaseFunction };
+
+export class Function extends BaseFunction {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    parameters: Array<Node>,
+    body: Block
+  ) {
+    super('Function', line, column, start, end, raw, virtual, parameters, body);
+  }
+}
+
+export class BoundFunction extends BaseFunction {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    parameters: Array<Node>,
+    body: Block
+  ) {
+    super('BoundFunction', line, column, start, end, raw, virtual, parameters, body);
+  }
+}
+
+export class GeneratorFunction extends BaseFunction {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    parameters: Array<Node>,
+    body: Block
+  ) {
+    super('GeneratorFunction', line, column, start, end, raw, virtual, parameters, body);
+  }
+}
+
+export class BoundGeneratorFunction extends BaseFunction {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    parameters: Array<Node>,
+    body: Block
+  ) {
+    super('BoundGeneratorFunction', line, column, start, end, raw, virtual, parameters, body);
+  }
+}
+
+export class Try extends Node {
+  readonly body: Node | null;
+  readonly catchAssignee: Node | null;
+  readonly catchBody: Node | null;
+  readonly finallyBody: Node | null;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    body: Node | null,
+    catchAssignee: Node | null,
+    catchBody: Node | null,
+    finallyBody: Node | null
+  ) {
+    super('Try', line, column, start, end, raw, virtual);
+    this.body = body;
+    this.catchAssignee = catchAssignee;
+    this.catchBody = catchBody;
+    this.finallyBody = finallyBody;
   }
 }
 

--- a/test/examples/for-comprehension/output.json
+++ b/test/examples/for-comprehension/output.json
@@ -23,7 +23,7 @@
           "column": 1,
           "range": [ 0, 1 ],
           "raw": "a",
-          "inline": false,
+          "inline": true,
           "statements": [
             {
               "type": "Identifier",

--- a/test/examples/post-for/output.json
+++ b/test/examples/post-for/output.json
@@ -58,7 +58,7 @@
             }
           ],
           "raw": "a",
-          "inline": false
+          "inline": true
         },
         "target": {
           "type": "Identifier",

--- a/test/examples/while-on-one-line/output.json
+++ b/test/examples/while-on-one-line/output.json
@@ -25,7 +25,7 @@
           "column": 1,
           "range": [ 0, 1 ],
           "raw": "a",
-          "inline": false,
+          "inline": true,
           "statements": [
             {
               "type": "Identifier",


### PR DESCRIPTION
I did a bunch at once to coalesce the type errors that I had to fix in decaffeinate-coffeescript into a single version bump (11→12). The only change in this commit that should affect the output in a meaningful way is that some `Block` nodes which were not previously considered inline now are considered inline. This is due to a change from looking at source code for a preceding newline to using the tokens from coffee-lex, which is hopefully more accurate.