### PR TITLE
test: check examples with and without mappers

### DIFF
--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -334,6 +334,23 @@ export class Conditional extends Node {
   }
 }
 
+export class Program extends Node {
+  readonly body: Block;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    body: Block
+  ) {
+    super('Program', line, column, start, end, raw, virtual);
+    this.body = body;
+  }
+}
+
 export class Block extends Node {
   readonly statements: Array<Node>;
   readonly inline: boolean;

--- a/test/test.js
+++ b/test/test.js
@@ -1,24 +1,32 @@
 import { deepEqual } from 'assert';
 import { join } from 'path';
+import { inspect } from 'util';
 import { parse } from '../src/parser';
 import { readFileSync, readdirSync, writeFileSync } from 'fs';
 
 let examplesPath = join(__dirname, 'examples');
 
-readdirSync(examplesPath).forEach(entry => {
-  let dir = join(examplesPath, entry);
-  let configPath = join(dir, '_config.js');
-  let config = requireOptional(configPath) || {};
-  let testFn = config.only ? it.only : config.skip ? it.skip : it;
+runWithOptions({ useMappers: true, useFallback: process.env['USE_FALLBACK'] !== 'false' });
+runWithOptions({ useMappers: false });
 
-  testFn(config.description || entry, () => {
-    let input = readFileSync(join(dir, 'input.coffee'), { encoding: 'utf8' });
-    let actual = stripExtraInfo(parse(input));
-    writeFileSync(join(dir, '_actual.json'), JSON.stringify(actual, null, 2), { encoding: 'utf8' });
-    let expected = JSON.parse(readFileSync(join(dir, 'output.json'), { encoding: 'utf8' }));
-    deepEqual(actual, expected);
+function runWithOptions(parseOptions: { useMappers?: boolean, useFallback?: boolean }) {
+  context(`examples ${inspect(parseOptions)}`, () => {
+    readdirSync(examplesPath).forEach(entry => {
+      let dir = join(examplesPath, entry);
+      let configPath = join(dir, '_config.js');
+      let config = requireOptional(configPath) || {};
+      let testFn = config.only ? it.only : config.skip ? it.skip : it;
+
+      testFn(config.description || entry, () => {
+        let input = readFileSync(join(dir, 'input.coffee'), { encoding: 'utf8' });
+        let actual = stripExtraInfo(parse(input, parseOptions));
+        writeFileSync(join(dir, '_actual.json'), JSON.stringify(actual, null, 2), { encoding: 'utf8' });
+        let expected = JSON.parse(readFileSync(join(dir, 'output.json'), { encoding: 'utf8' }));
+        deepEqual(actual, expected);
+      });
+    });
   });
-});
+}
 
 function stripExtraInfo(node) {
   if (node && typeof node === 'object') {


### PR DESCRIPTION
The approach of using fallbacks when necessary has allowed us to do the transition to mappers/TypeScript in pieces. This is good, but it has the downside that bugs in the fallback code may be masked when a mapper works with the example code but not with real code which triggers the buggy fallback. This commit runs all examples twice, once with mappers+fallbacks, the other with only fallbacks. Doing so ensures that both code paths work as expected. To run with only mappers (and thus see what is left to port), run with `USE_FALLBACK=false`.