### PR TITLE
refactor: add mappers for a few `Op` node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "babylon": "^6.14.1",
     "coffee-lex": "^6.0.0",
-    "decaffeinate-coffeescript": "^1.10.0-patch15",
+    "decaffeinate-coffeescript": "^1.10.0-patch17",
     "lines-and-columns": "^1.1.6"
   },
   "devDependencies": {

--- a/src/mappers/mapAny.ts
+++ b/src/mappers/mapAny.ts
@@ -1,6 +1,6 @@
 import {
-  Arr, Assign, Base, Block, Bool, Class, Code, Existence, Extends, For, If, In, Literal, Null, Obj, Param, Parens,
-  Range, Return, Splat, Switch, Throw, Try, Undefined, Value, While
+  Arr, Assign, Base, Block, Bool, Class, Code, Existence, Extends, For, If, In, Literal, Null, Obj, Op, Param,
+  Parens, Range, Return, Splat, Switch, Throw, Try, Undefined, Value, While
 } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Node } from '../nodes';
 import ParseContext from '../util/ParseContext';
@@ -19,6 +19,7 @@ import mapIn from './mapIn';
 import mapLiteral from './mapLiteral';
 import mapNull from './mapNull';
 import mapObj from './mapObj';
+import mapOp from './mapOp';
 import mapParam from './mapParam';
 import mapParens from './mapParens';
 import mapRange from './mapRange';
@@ -38,6 +39,10 @@ export default function mapAny(context: ParseContext, node: Base): Node {
 
   if (node instanceof Literal) {
     return mapLiteral(context, node);
+  }
+
+  if (node instanceof Op) {
+    return mapOp(context, node);
   }
 
   if (node instanceof Arr) {

--- a/src/mappers/mapOp.ts
+++ b/src/mappers/mapOp.ts
@@ -1,0 +1,50 @@
+import { Op as CoffeeOp } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { inspect } from 'util';
+import { MultiplyOp, Op, SubtractOp, UnaryNegateOp } from '../nodes';
+import ParseContext from '../util/ParseContext';
+import mapAny from './mapAny';
+import { UnsupportedNodeError } from './mapAnyWithFallback';
+import mapBase from './mapBase';
+
+export default function mapOp(context: ParseContext, node: CoffeeOp): Op {
+  switch (node.operator) {
+    case '-':
+      return mapSubtractOp(context, node);
+
+    case '*':
+      return mapMultiplyOp(context, node);
+  }
+
+  throw new UnsupportedNodeError(node);
+}
+
+function mapSubtractOp(context: ParseContext, node: CoffeeOp): Op {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+
+  if (node.second) {
+    return new SubtractOp(
+      line, column, start, end, raw, virtual,
+      mapAny(context, node.first),
+      mapAny(context, node.second)
+    );
+  } else {
+    return new UnaryNegateOp(
+      line, column, start, end, raw, virtual,
+      mapAny(context, node.first)
+    );
+  }
+}
+
+function mapMultiplyOp(context: ParseContext, node: CoffeeOp) {
+  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+
+  if (!node.second) {
+    throw new Error(`unexpected '*' operator with only one operand: ${inspect(node)}`);
+  }
+
+  return new MultiplyOp(
+    line, column, start, end, raw, virtual,
+    mapAny(context, node.first),
+    mapAny(context, node.second)
+  );
+}

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -783,23 +783,6 @@ export class Continue extends Node {
   }
 }
 
-export class UnaryExistsOp extends Node {
-  readonly expression: Node;
-
-  constructor(
-    line: number,
-    column: number,
-    start: number,
-    end: number,
-    raw: string,
-    virtual: boolean,
-    expression: Node
-  ) {
-    super('UnaryExistsOp', line, column, start, end, raw, virtual);
-    this.expression = expression;
-  }
-}
-
 export class Spread extends Node {
   readonly expression: Node;
 
@@ -858,6 +841,84 @@ export class BinaryOp extends Node {
     super(type, line, column, start, end, raw, virtual);
     this.left = left;
     this.right = right;
+  }
+}
+
+export class UnaryOp extends Node {
+  readonly expression: Node;
+
+  constructor(
+    type: string,
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    expression: Node
+  ) {
+    super(type, line, column, start, end, raw, virtual);
+    this.expression = expression;
+  }
+}
+
+export type Op = UnaryOp | BinaryOp;
+
+export class SubtractOp extends BinaryOp {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    left: Node,
+    right: Node
+  ) {
+    super('SubtractOp', line, column, start, end, raw, virtual, left, right);
+  }
+}
+
+export class MultiplyOp extends BinaryOp {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    left: Node,
+    right: Node
+  ) {
+    super('MultiplyOp', line, column, start, end, raw, virtual, left, right);
+  }
+}
+
+export class UnaryExistsOp extends UnaryOp {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    expression: Node
+  ) {
+    super('UnaryExistsOp', line, column, start, end, raw, virtual, expression);
+  }
+}
+
+export class UnaryNegateOp extends UnaryOp {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    left: Node
+  ) {
+    super('UnaryNegateOp', line, column, start, end, raw, virtual, left);
   }
 }
 

--- a/src/util/isChainedComparison.ts
+++ b/src/util/isChainedComparison.ts
@@ -2,7 +2,7 @@ import { Base, Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 
 export default function isChainedComparison(node: Base): boolean {
   if (node instanceof Op && isComparisonOperator(node)) {
-    return isComparisonOperator(node.first) || isComparisonOperator(node.second);
+    return isComparisonOperator(node.first) || (node.second ? isComparisonOperator(node.second) : false);
   } else {
     return false;
   }


### PR DESCRIPTION
All CoffeeScript operators are represented using the `Op` node, but with different `operator` values. This adds mappers for just the `-` and `*` operators.