### PR TITLE
refactor: add mapper support for `super` calls and soaked calls

### DIFF
--- a/src/mappers/mapCall.ts
+++ b/src/mappers/mapCall.ts
@@ -1,8 +1,12 @@
 import SourceType from 'coffee-lex/dist/SourceType';
-import { Call } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Call, Splat } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { inspect } from 'util';
-import { FunctionApplication, NewOp, Node } from '../nodes';
+import {
+  BareSuperFunctionApplication, FunctionApplication, NewOp, Node, SoakedFunctionApplication,
+  Super
+} from '../nodes';
 import isHeregexTemplateNode from '../util/isHeregexTemplateNode';
+import locationsEqual from '../util/locationsEqual';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
 import { UnsupportedNodeError } from './mapAnyWithFallback';
@@ -11,20 +15,82 @@ import mapBase from './mapBase';
 export default function mapCall(context: ParseContext, node: Call): Node {
   let { line, column, start, end, raw, virtual } = mapBase(context, node);
 
-  if (node.isSuper || node.soak || node.do || isHeregexTemplateNode(node, context)) {
+  if (node.do || isHeregexTemplateNode(node, context)) {
     throw new UnsupportedNodeError(node);
   }
+
+  let args = node.args.map(arg => mapAny(context, arg));
 
   if (!node.variable) {
     // This should only happen when `isSuper` is true.
-    throw new UnsupportedNodeError(node);
+    if (!node.isSuper) {
+      throw new Error(`callee unexpectedly null in non-super call: ${inspect(node)}`);
+    }
+
+    if (
+      node.args.length === 1 &&
+      node.args[0] instanceof Splat &&
+      locationsEqual(node.args[0].locationData, node.locationData)
+    ) {
+      return new BareSuperFunctionApplication(
+        line,
+        column,
+        start,
+        end,
+        raw,
+        virtual
+      );
+    }
+
+    let superIndex = context.sourceTokens.indexOfTokenStartingAtSourceIndex(start);
+    let superToken = superIndex && context.sourceTokens.tokenAtIndex(superIndex);
+
+    if (!superToken || superToken.type !== SourceType.SUPER) {
+      throw new Error(`unable to find SUPER token in 'super' function call: ${inspect(node)}`);
+    }
+
+    let superLocation = context.linesAndColumns.locationForIndex(superToken.start);
+
+    if (!superLocation) {
+      throw new Error(`unable to locate SUPER token for 'super' function call: ${inspect(node)}`);
+    }
+
+    return new FunctionApplication(
+      line,
+      column,
+      start,
+      end,
+      raw,
+      virtual,
+      new Super(
+        superLocation.line + 1,
+        superLocation.column + 1,
+        superToken.start,
+        superToken.end,
+        context.source.slice(superToken.start, superToken.end),
+        false
+      ),
+      args
+    );
   }
 
   let callee = mapAny(context, node.variable);
-  let args = node.args.map(arg => mapAny(context, arg));
 
   if (node.isNew) {
     return mapNewOp(context, node);
+  }
+
+  if (node.soak) {
+    return new SoakedFunctionApplication(
+      line,
+      column,
+      start,
+      end,
+      raw,
+      virtual,
+      callee,
+      args
+    );
   }
 
   return new FunctionApplication(

--- a/src/mappers/mapClass.ts
+++ b/src/mappers/mapClass.ts
@@ -47,6 +47,10 @@ export default function mapClass(context: ParseContext, node: CoffeeClass): Clas
             if (assignment instanceof ClassProtoAssignOp && (assignment.expression instanceof BoundFunction || assignment.expression instanceof BoundGeneratorFunction)) {
               boundMethods.push(assignment);
             }
+
+            if (assignment instanceof Constructor) {
+              ctor = assignment;
+            }
           } else {
             throw new Error(`unexpected class assignment: ${inspect(property)}`);
           }

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -1293,6 +1293,52 @@ export class FunctionApplication extends Node {
   }
 }
 
+export class SoakedFunctionApplication extends Node {
+  readonly function: Node;
+  readonly arguments: Array<Node>;
+
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean,
+    fn: Node,
+    args: Array<Node>
+  ) {
+    super('SoakedFunctionApplication', line, column, start, end, raw, virtual);
+    this.function = fn;
+    this.arguments = args;
+  }
+}
+
+export class Super extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean
+  ) {
+    super('Super', line, column, start, end, raw, virtual);
+  }
+}
+
+export class BareSuperFunctionApplication extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    virtual: boolean
+  ) {
+    super('BareSuperFunctionApplication', line, column, start, end, raw, virtual);
+  }
+}
+
 export class NewOp extends Node {
   readonly ctor: Node;
   readonly arguments: Array<Node>;

--- a/src/parser.js
+++ b/src/parser.js
@@ -355,18 +355,7 @@ function convert(context: ParseContext, map: (context: ParseContext, node: Base,
           } else if (node.isSuper) {
             if (node.args.length === 1 && type(node.args[0]) === 'Splat' && locationsEqual(node.args[0].locationData, node.locationData)) {
               // Virtual splat argument.
-              return makeNode(context, 'FunctionApplication', node.locationData, {
-                function: makeNode(context, 'Super', node.locationData),
-                arguments: [{
-                  type: 'Spread',
-                  virtual: true,
-                  expression: {
-                    type: 'Identifier',
-                    data: 'arguments',
-                    virtual: true
-                  }
-                }]
-              });
+              return makeNode(context, 'BareSuperFunctionApplication', node.locationData);
             }
             const superLocationData = {
               first_line: node.locationData.first_line,

--- a/test/examples/class-super-call/output.json
+++ b/test/examples/class-super-call/output.json
@@ -92,33 +92,12 @@
                   ],
                   "statements": [
                     {
-                      "type": "FunctionApplication",
+                      "type": "BareSuperFunctionApplication",
                       "line": 3,
                       "column": 5,
                       "range": [
                         44,
                         49
-                      ],
-                      "function": {
-                        "type": "Super",
-                        "line": 3,
-                        "column": 5,
-                        "range": [
-                          44,
-                          49
-                        ],
-                        "raw": "super"
-                      },
-                      "arguments": [
-                        {
-                          "type": "Spread",
-                          "virtual": true,
-                          "expression": {
-                            "type": "Identifier",
-                            "data": "arguments",
-                            "virtual": true
-                          }
-                        }
                       ],
                       "raw": "super"
                     }
@@ -273,33 +252,12 @@
               ],
               "statements": [
                 {
-                  "type": "FunctionApplication",
+                  "type": "BareSuperFunctionApplication",
                   "line": 3,
                   "column": 5,
                   "range": [
                     44,
                     49
-                  ],
-                  "function": {
-                    "type": "Super",
-                    "line": 3,
-                    "column": 5,
-                    "range": [
-                      44,
-                      49
-                    ],
-                    "raw": "super"
-                  },
-                  "arguments": [
-                    {
-                      "type": "Spread",
-                      "virtual": true,
-                      "expression": {
-                        "type": "Identifier",
-                        "data": "arguments",
-                        "virtual": true
-                      }
-                    }
                   ],
                   "raw": "super"
                 }


### PR DESCRIPTION
BREAKING CHANGE: Previously, we made a bare super call (i.e. `super`) just another `FunctionApplication` with a virtual spread argument. This replaces the whole call with a new node type, `BareSuperFunctionApplication`, with no callee or arguments.