### PR TITLE
refactor: remove virtual nodes

### DIFF
--- a/src/mappers/mapArr.ts
+++ b/src/mappers/mapArr.ts
@@ -5,7 +5,7 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapArr(context: ParseContext, node: Arr): ArrayInitialiser {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   let members = node.objects.map(object => mapAny(context, object));
-  return new ArrayInitialiser(line, column, start, end, raw, virtual, members);
+  return new ArrayInitialiser(line, column, start, end, raw, members);
 }

--- a/src/mappers/mapAssign.ts
+++ b/src/mappers/mapAssign.ts
@@ -10,10 +10,10 @@ export default function mapAssign(context: ParseContext, node: Assign): AssignOp
     throw new UnsupportedNodeError(node);
   }
 
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   return new AssignOp(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     mapAny(context, node.variable),
     mapAny(context, node.value)
   );

--- a/src/mappers/mapBase.ts
+++ b/src/mappers/mapBase.ts
@@ -48,5 +48,5 @@ export default function mapBase(context: ParseContext, node: Base): Node {
   end = lastTokenOfNode.end;
   let raw = context.source.slice(start, end);
 
-  return new Node('Node', line, column, start, end, raw, false);
+  return new Node('Node', line, column, start, end, raw);
 }

--- a/src/mappers/mapBlock.ts
+++ b/src/mappers/mapBlock.ts
@@ -11,13 +11,13 @@ export default function mapBlock(context: ParseContext, node: CoffeeBlock): Bloc
     throw new UnsupportedNodeError(node);
   }
 
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   let previousTokenIndex = context.sourceTokens.indexOfTokenNearSourceIndex(start - 1);
   let previousToken = previousTokenIndex ? context.sourceTokens.tokenAtIndex(previousTokenIndex) : null;
   let inline = previousToken ? previousToken.type !== SourceType.NEWLINE : false;
 
   return new Block(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     node.expressions
       .filter(expression => !(expression instanceof Comment))
       .map(expression => mapAny(context, expression)),

--- a/src/mappers/mapBool.ts
+++ b/src/mappers/mapBool.ts
@@ -4,6 +4,6 @@ import ParseContext from '../util/ParseContext';
 import mapBase from './mapBase';
 
 export default function mapBool(context: ParseContext, node: CoffeeBool): Bool {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
-  return new Bool(line, column, start, end, raw, virtual, JSON.parse(node.val));
+  let { line, column, start, end, raw } = mapBase(context, node);
+  return new Bool(line, column, start, end, raw, JSON.parse(node.val));
 }

--- a/src/mappers/mapCall.ts
+++ b/src/mappers/mapCall.ts
@@ -13,7 +13,7 @@ import { UnsupportedNodeError } from './mapAnyWithFallback';
 import mapBase from './mapBase';
 
 export default function mapCall(context: ParseContext, node: Call): Node {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   if (node.do || isHeregexTemplateNode(node, context)) {
     throw new UnsupportedNodeError(node);
@@ -37,8 +37,7 @@ export default function mapCall(context: ParseContext, node: Call): Node {
         column,
         start,
         end,
-        raw,
-        virtual
+        raw
       );
     }
 
@@ -61,14 +60,12 @@ export default function mapCall(context: ParseContext, node: Call): Node {
       start,
       end,
       raw,
-      virtual,
       new Super(
         superLocation.line + 1,
         superLocation.column + 1,
         superToken.start,
         superToken.end,
-        context.source.slice(superToken.start, superToken.end),
-        false
+        context.source.slice(superToken.start, superToken.end)
       ),
       args
     );
@@ -87,7 +84,6 @@ export default function mapCall(context: ParseContext, node: Call): Node {
       start,
       end,
       raw,
-      virtual,
       callee,
       args
     );
@@ -99,7 +95,6 @@ export default function mapCall(context: ParseContext, node: Call): Node {
     start,
     end,
     raw,
-    virtual,
     callee,
     args
   );
@@ -111,7 +106,7 @@ function mapNewOp(context: ParseContext, node: Call): NewOp {
     throw new UnsupportedNodeError(node);
   }
 
-  let { end, virtual } = mapBase(context, node);
+  let { end } = mapBase(context, node);
   let callee = mapAny(context, node.variable);
   let args = node.args.map(arg => mapAny(context, arg));
 
@@ -149,7 +144,6 @@ function mapNewOp(context: ParseContext, node: Call): NewOp {
     newToken.start,
     end,
     context.source.slice(newToken.start, end),
-    virtual,
     callee,
     args
   );

--- a/src/mappers/mapClass.ts
+++ b/src/mappers/mapClass.ts
@@ -9,7 +9,7 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapClass(context: ParseContext, node: CoffeeClass): Class {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   let body: Block | null = null;
   let ctor: Constructor | null = null;
@@ -37,7 +37,6 @@ export default function mapClass(context: ParseContext, node: CoffeeClass): Clas
             let assignment = new Node(
               key.line, key.column, key.start, value.end,
               context.source.slice(key.start, value.end),
-              false,
               key,
               value
             );
@@ -70,7 +69,6 @@ export default function mapClass(context: ParseContext, node: CoffeeClass): Clas
         firstStatement.start,
         lastStatement.end,
         context.source.slice(firstStatement.start, lastStatement.end),
-        false,
         statements,
         false
       );
@@ -81,7 +79,7 @@ export default function mapClass(context: ParseContext, node: CoffeeClass): Clas
   let parent = node.parent ? mapAny(context, node.parent) : null;
 
   return new Class(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     nameAssignee,
     nameAssignee,
     body,

--- a/src/mappers/mapCode.ts
+++ b/src/mappers/mapCode.ts
@@ -6,12 +6,12 @@ import mapBase from './mapBase';
 import mapBlock from './mapBlock';
 
 export default function mapCode(context: ParseContext, node: Code): BaseFunction {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   let Node = getNodeTypeForCode(node);
 
   return new Node(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     node.params.map(param => mapAny(context, param)),
     mapBlock(context, node.body)
   );

--- a/src/mappers/mapExistence.ts
+++ b/src/mappers/mapExistence.ts
@@ -5,6 +5,6 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapExistence(context: ParseContext, node: Existence): UnaryExistsOp {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
-  return new UnaryExistsOp(line, column, start, end, raw, virtual, mapAny(context, node.expression));
+  let { line, column, start, end, raw } = mapBase(context, node);
+  return new UnaryExistsOp(line, column, start, end, raw, mapAny(context, node.expression));
 }

--- a/src/mappers/mapExtends.ts
+++ b/src/mappers/mapExtends.ts
@@ -5,9 +5,9 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapExtends(context: ParseContext, node: Extends): ExtendsOp {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   return new ExtendsOp(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     mapAny(context, node.child),
     mapAny(context, node.parent)
   );

--- a/src/mappers/mapFor.ts
+++ b/src/mappers/mapFor.ts
@@ -6,7 +6,7 @@ import mapBase from './mapBase';
 import mapBlock from './mapBlock';
 
 export default function mapFor(context: ParseContext, node: CoffeeFor): For {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   let keyAssignee = node.index ? mapAny(context, node.index) : null;
   let valAssignee = node.name ? mapAny(context, node.name) : null;
@@ -18,7 +18,7 @@ export default function mapFor(context: ParseContext, node: CoffeeFor): For {
     let isOwn = node.own;
 
     return new ForOf(
-      line, column, start, end, raw, virtual,
+      line, column, start, end, raw,
       keyAssignee,
       valAssignee,
       target,
@@ -30,7 +30,7 @@ export default function mapFor(context: ParseContext, node: CoffeeFor): For {
     let step = node.step ? mapAny(context, node.step) : null;
 
     return new ForIn(
-      line, column, start, end, raw, virtual,
+      line, column, start, end, raw,
       keyAssignee,
       valAssignee,
       target,

--- a/src/mappers/mapIf.ts
+++ b/src/mappers/mapIf.ts
@@ -8,7 +8,7 @@ import mapBase from './mapBase';
 import mapBlock from './mapBlock';
 
 export default function mapIf(context: ParseContext, node: If): Conditional {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   let condition = mapAny(context, node.condition);
   let consequent = mapBlock(context, node.body);
@@ -40,7 +40,7 @@ export default function mapIf(context: ParseContext, node: If): Conditional {
   }
 
   return new Conditional(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     condition,
     consequent,
     alternate,

--- a/src/mappers/mapIn.ts
+++ b/src/mappers/mapIn.ts
@@ -8,7 +8,7 @@ import mapBase from './mapBase';
 export default function mapIn(context: ParseContext, node: CoffeeIn): InOp {
   // We don't use the `negated` flag on `node` because it gets set to
   // `true` when a parent `If` is an `unless`.
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   let left = mapAny(context, node.object);
   let right = mapAny(context, node.array);
   let isNot = false;
@@ -28,7 +28,7 @@ export default function mapIn(context: ParseContext, node: CoffeeIn): InOp {
       isNot = context.source.slice(relationToken.start, relationToken.end) !== 'in';
 
       return new InOp(
-        line, column, start, end, raw, virtual,
+        line, column, start, end, raw,
         left,
         right,
         isNot

--- a/src/mappers/mapLiteral.ts
+++ b/src/mappers/mapLiteral.ts
@@ -12,10 +12,10 @@ import mapBase from './mapBase';
 const HEREGEX_PATTERN = /^\/\/\/((?:.|\s)*)\/\/\/([gimy]*)$/;
 
 export default function mapLiteral(context: ParseContext, node: Literal): Node {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   if (node.value === 'this') {
-    return new This(line, column, start, end, raw, virtual);
+    return new This(line, column, start, end, raw);
   }
 
   let startTokenIndex = context.sourceTokens.indexOfTokenContainingSourceIndex(start);
@@ -36,33 +36,33 @@ export default function mapLiteral(context: ParseContext, node: Literal): Node {
     // Sometimes the CoffeeScript AST contains a string object instead of a
     // string primitive. Convert to string primitive if necessary.
     let value = node.value.valueOf();
-    return new Identifier(line, column, start, end, raw, virtual, value);
+    return new Identifier(line, column, start, end, raw, value);
   }
 
   if (startToken.type === SourceType.JS) {
-    return new JavaScript(line, column, start, end, raw, virtual, node.value);
+    return new JavaScript(line, column, start, end, raw, node.value);
   }
 
   if (startToken.type === SourceType.NUMBER) {
     if (raw.includes('.')) {
-      return new Float(line, column, start, end, raw, virtual, parseNumber(node.value));
+      return new Float(line, column, start, end, raw, parseNumber(node.value));
     } else {
-      return new Int(line, column, start, end, raw, virtual, parseNumber(node.value));
+      return new Int(line, column, start, end, raw, parseNumber(node.value));
     }
   }
 
   if (startToken.type === SourceType.REGEXP) {
     let regExp = parseRegExp(node.value);
     return new Regex(
-      line, column, start, end, raw, virtual,
+      line, column, start, end, raw,
       regExp.pattern, RegexFlags.parse(regExp.flags)
     );
   }
 
   if (isStringAtPosition(start, end, context)) {
     return new String(
-      line, column, start, end, raw, virtual,
-      [new Quasi(line, column, start, end, raw, virtual, parseString(node.value))],
+      line, column, start, end, raw,
+      [new Quasi(line, column, start, end, raw, parseString(node.value))],
       []
     );
   }
@@ -77,8 +77,8 @@ export default function mapLiteral(context: ParseContext, node: Literal): Node {
     let flags = match[2];
 
     return new Heregex(
-      line, column, start, end, raw, virtual,
-      [new Quasi(line, column, start, end, raw, virtual, node.value)],
+      line, column, start, end, raw,
+      [new Quasi(line, column, start, end, raw, node.value)],
       [],
       RegexFlags.parse(flags)
     );
@@ -100,17 +100,17 @@ export default function mapLiteral(context: ParseContext, node: Literal): Node {
     // is actually a quasi that CoffeeScript is calling a string, then
     // just return a Quasi node, and higher-up code should insert it
     // into a string interpolation.
-    return new Quasi(line, column, start, end, raw, virtual, parseString(node.value));
+    return new Quasi(line, column, start, end, raw, parseString(node.value));
   }
 
   if (startToken.type === SourceType.BREAK) {
-    return new Break(line, column, start, end, raw, virtual);
+    return new Break(line, column, start, end, raw);
   }
 
   if (startToken.type === SourceType.CONTINUE) {
-    return new Continue(line, column, start, end, raw, virtual);
+    return new Continue(line, column, start, end, raw);
   }
 
   // Fall back to identifiers.
-  return new Identifier(line, column, start, end, raw, virtual, node.value);
+  return new Identifier(line, column, start, end, raw, node.value);
 }

--- a/src/mappers/mapNull.ts
+++ b/src/mappers/mapNull.ts
@@ -4,6 +4,6 @@ import ParseContext from '../util/ParseContext';
 import mapBase from './mapBase';
 
 export default function mapNull(context: ParseContext, node: CoffeeNull): Null {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
-  return new Null(line, column, start, end, raw, virtual);
+  let { line, column, start, end, raw } = mapBase(context, node);
+  return new Null(line, column, start, end, raw);
 }

--- a/src/mappers/mapObj.ts
+++ b/src/mappers/mapObj.ts
@@ -7,7 +7,7 @@ import mapBase from './mapBase';
 import mapValue from './mapValue';
 
 export default function mapObj(context: ParseContext, node: Obj): ObjectInitialiser {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   let members: Array<ObjectInitialiserMember> = node.properties.map(property => {
     if (property instanceof Value) {
@@ -19,12 +19,12 @@ export default function mapObj(context: ParseContext, node: Obj): ObjectInitiali
       }
 
       return new ObjectInitialiserMember(
-        value.line, value.column, value.start, value.end, value.raw, value.virtual,
+        value.line, value.column, value.start, value.end, value.raw,
         value,
         value
       );
     } else if (property instanceof Assign && property.context === 'object') {
-      let { line, column, start, end, raw, virtual } = mapBase(context, property);
+      let { line, column, start, end, raw } = mapBase(context, property);
 
       let key = mapAny(context, property.variable);
       let expression = mapAny(context, property.value);
@@ -34,7 +34,7 @@ export default function mapObj(context: ParseContext, node: Obj): ObjectInitiali
       }
 
       return new ObjectInitialiserMember(
-        line, column, start, end, raw, virtual,
+        line, column, start, end, raw,
         key,
         expression
       );
@@ -44,7 +44,7 @@ export default function mapObj(context: ParseContext, node: Obj): ObjectInitiali
   });
 
   return new ObjectInitialiser(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     members
   );
 }

--- a/src/mappers/mapOp.ts
+++ b/src/mappers/mapOp.ts
@@ -20,7 +20,7 @@ export default function mapOp(context: ParseContext, node: CoffeeOp): Node {
 }
 
 function mapChainedComparisonOp(context: ParseContext, node: CoffeeOp) {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   let coffeeOperands = unwindChainedComparison(node);
   let operands = coffeeOperands.map(operand => mapAny(context, operand));
   let operators: Array<OperatorInfo> = [];
@@ -38,7 +38,6 @@ function mapChainedComparisonOp(context: ParseContext, node: CoffeeOp) {
     start,
     end,
     raw,
-    virtual,
     operands,
     operators
   );
@@ -70,17 +69,17 @@ function mapEqualityOp(context: ParseContext, node: CoffeeOp) {
 }
 
 function mapSubtractOp(context: ParseContext, node: CoffeeOp): Op {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   if (node.second) {
     return new SubtractOp(
-      line, column, start, end, raw, virtual,
+      line, column, start, end, raw,
       mapAny(context, node.first),
       mapAny(context, node.second)
     );
   } else {
     return new UnaryNegateOp(
-      line, column, start, end, raw, virtual,
+      line, column, start, end, raw,
       mapAny(context, node.first)
     );
   }
@@ -93,21 +92,20 @@ interface IBinaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node
   ): BinaryOp;
 }
 
 function mapBinaryOp<T extends IBinaryOp>(context: ParseContext, node: CoffeeOp, Op: T): BinaryOp {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   if (!node.second) {
     throw new Error(`unexpected '${node.operator}' operator with only one operand: ${inspect(node)}`);
   }
 
   return new Op(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     mapAny(context, node.first),
     mapAny(context, node.second)
   );
@@ -118,27 +116,27 @@ function mapMultiplyOp(context: ParseContext, node: CoffeeOp): MultiplyOp {
 }
 
 function mapYieldOp(context: ParseContext, node: CoffeeOp): YieldReturn | Yield {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   if (node.first instanceof CoffeeReturn) {
     let expression = node.first.expression;
     return new YieldReturn(
-      line, column, start, end, raw, virtual,
+      line, column, start, end, raw,
       expression ? mapAny(context, expression) : null,
     );
   } else {
     return new Yield(
-      line, column, start, end, raw, virtual,
+      line, column, start, end, raw,
       mapAny(context, node.first)
     );
   }
 }
 
 function mapYieldFromOp(context: ParseContext, node: CoffeeOp): YieldFrom {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   return new YieldFrom(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     mapAny(context, node.first)
   );
 }

--- a/src/mappers/mapParam.ts
+++ b/src/mappers/mapParam.ts
@@ -5,16 +5,16 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapParam(context: ParseContext, node: Param): Node {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   let param = mapAny(context, node.name);
 
   if (node.value) {
     let value = mapAny(context, node.value);
-    return new DefaultParam(line, column, start, end, raw, virtual, param, value);
+    return new DefaultParam(line, column, start, end, raw, param, value);
   }
 
   if (node.splat) {
-    return new Rest(line, column, start, end, raw, virtual, param);
+    return new Rest(line, column, start, end, raw, param);
   }
 
   return param;

--- a/src/mappers/mapParens.ts
+++ b/src/mappers/mapParens.ts
@@ -23,7 +23,6 @@ export default function mapParens(context: ParseContext, node: Parens): Node {
         left.start,
         right.end,
         context.source.slice(left.start, right.end),
-        false,
         left,
         right
       )

--- a/src/mappers/mapRange.ts
+++ b/src/mappers/mapRange.ts
@@ -5,10 +5,10 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapRange(context: ParseContext, node: CoffeeRange): Range {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   return new Range(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     mapAny(context, node.from),
     mapAny(context, node.to),
     !node.exclusive

--- a/src/mappers/mapReturn.ts
+++ b/src/mappers/mapReturn.ts
@@ -5,7 +5,7 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapReturn(context: ParseContext, node: CoffeeReturn): Return {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   let argument = node.expression ? mapAny(context, node.expression) : null;
-  return new Return(line, column, start, end, raw, virtual, argument);
+  return new Return(line, column, start, end, raw, argument);
 }

--- a/src/mappers/mapSplat.ts
+++ b/src/mappers/mapSplat.ts
@@ -5,6 +5,6 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapSplat(context: ParseContext, node: Splat): Spread {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
-  return new Spread(line, column, start, end, raw, virtual, mapAny(context, node.name));
+  let { line, column, start, end, raw } = mapBase(context, node);
+  return new Spread(line, column, start, end, raw, mapAny(context, node.name));
 }

--- a/src/mappers/mapSwitch.ts
+++ b/src/mappers/mapSwitch.ts
@@ -8,7 +8,7 @@ import mapBase from './mapBase';
 import mapBlock from './mapBlock';
 
 export default function mapSwitch(context: ParseContext, node: CoffeeSwitch): Switch {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   let expression = node.subject ? mapAny(context, node.subject) : null;
   let cases = node.cases.map(([conditions, body]) => {
@@ -29,14 +29,13 @@ export default function mapSwitch(context: ParseContext, node: CoffeeSwitch): Sw
     return new SwitchCase(
       caseLine + 1, caseColumn + 1, whenToken.start, consequent.end,
       context.source.slice(whenToken.start, consequent.end),
-      false,
       switchConditions,
       consequent
     );
   });
 
   return new Switch(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     expression,
     cases,
     node.otherwise ? mapBlock(context, node.otherwise) : null

--- a/src/mappers/mapThrow.ts
+++ b/src/mappers/mapThrow.ts
@@ -5,7 +5,7 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapThrow(context: ParseContext, node: CoffeeThrow): Throw {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   let expression = node.expression ? mapAny(context, node.expression) : null;
-  return new Throw(line, column, start, end, raw, virtual, expression);
+  return new Throw(line, column, start, end, raw, expression);
 }

--- a/src/mappers/mapTry.ts
+++ b/src/mappers/mapTry.ts
@@ -5,10 +5,10 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapTry(context: ParseContext, node: CoffeeTry): Try {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
 
   return new Try(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     node.attempt ? mapAny(context, node.attempt) : null,
     node.errorVariable ? mapAny(context, node.errorVariable) : null,
     node.recovery ? mapAny(context, node.recovery) : null,

--- a/src/mappers/mapUndefined.ts
+++ b/src/mappers/mapUndefined.ts
@@ -4,6 +4,6 @@ import ParseContext from '../util/ParseContext';
 import mapBase from './mapBase';
 
 export default function mapUndefined(context: ParseContext, node: CoffeeUndefined): Undefined {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
-  return new Undefined(line, column, start, end, raw, virtual);
+  let { line, column, start, end, raw } = mapBase(context, node);
+  return new Undefined(line, column, start, end, raw);
 }

--- a/src/mappers/mapValue.ts
+++ b/src/mappers/mapValue.ts
@@ -50,7 +50,6 @@ export default function mapValue(context: ParseContext, node: Value): Node {
           result.start,
           last + 1,
           context.source.slice(result.start, last + 1),
-          false,
           result
         );
       } else {
@@ -68,7 +67,6 @@ export default function mapValue(context: ParseContext, node: Value): Node {
           result.start,
           last + 1,
           context.source.slice(result.start, last + 1),
-          false,
           result,
           member
         );

--- a/src/mappers/mapWhile.ts
+++ b/src/mappers/mapWhile.ts
@@ -6,19 +6,19 @@ import mapAny from './mapAny';
 import mapBase from './mapBase';
 
 export default function mapWhile(context: ParseContext, node: CoffeeWhile): While | Loop {
-  let { line, column, start, end, raw, virtual } = mapBase(context, node);
+  let { line, column, start, end, raw } = mapBase(context, node);
   let startTokenIndex = context.sourceTokens.indexOfTokenStartingAtSourceIndex(start);
   let startToken = startTokenIndex && context.sourceTokens.tokenAtIndex(startTokenIndex);
 
   if (startToken && startToken.type === SourceType.LOOP) {
     return new Loop(
-      line, column, start, end, raw, virtual,
+      line, column, start, end, raw,
       node.body ? mapAny(context, node.body) : null
     );
   }
 
   return new While(
-    line, column, start, end, raw, virtual,
+    line, column, start, end, raw,
     mapAny(context, node.condition),
     node.guard ? mapAny(context, node.guard) : null,
     node.body ? mapAny(context, node.body) : null,

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -10,12 +10,6 @@ export interface RealNode {
   column: number;
   range: [number, number];
   raw: string;
-  virtual: false;
-}
-
-export interface VirtualNode {
-  type: string;
-  virtual: true;
 }
 
 export class Node {
@@ -26,7 +20,6 @@ export class Node {
   readonly end: number;
   readonly range: [number, number];
   readonly raw: string;
-  readonly virtual: boolean;
 
   constructor(
     type: string,
@@ -35,7 +28,6 @@ export class Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean
   ) {
     this.type = type;
     this.line = line;
@@ -44,7 +36,6 @@ export class Node {
     this.end = end;
     this.range = [start, end];
     this.raw = raw;
-    this.virtual = virtual;
   }
 }
 
@@ -57,10 +48,9 @@ export class Identifier extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     data: string
   ) {
-    super('Identifier', line, column, start, end, raw, virtual);
+    super('Identifier', line, column, start, end, raw);
     this.data = data;
   }
 }
@@ -74,19 +64,18 @@ export class Bool extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     data: boolean
   ) {
-    super('Bool', line, column, start, end, raw, virtual);
+    super('Bool', line, column, start, end, raw);
     this.data = data;
   }
 
   static true(): Bool {
-    return new Bool(0, 0, 0, 0, '', true, true);
+    return new Bool(0, 0, 0, 0, '', true);
   }
 
   static false(): Bool {
-    return new Bool(0, 0, 0, 0, '', true, false);
+    return new Bool(0, 0, 0, 0, '', false);
   }
 }
 
@@ -99,10 +88,9 @@ export class JavaScript extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     data: string
   ) {
-    super('JavaScript', line, column, start, end, raw, virtual);
+    super('JavaScript', line, column, start, end, raw);
     this.data = data;
   }
 }
@@ -117,10 +105,9 @@ export class Number extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     data: number
   ) {
-    super(type, line, column, start, end, raw, virtual);
+    super(type, line, column, start, end, raw);
     this.data = data;
   }
 }
@@ -132,10 +119,9 @@ export class Float extends Number {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     data: number
   ) {
-    super('Float', line, column, start, end, raw, virtual, data);
+    super('Float', line, column, start, end, raw, data);
   }
 }
 
@@ -146,10 +132,9 @@ export class Int extends Number {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     data: number
   ) {
-    super('Int', line, column, start, end, raw, virtual, data);
+    super('Int', line, column, start, end, raw, data);
   }
 }
 
@@ -163,10 +148,9 @@ export abstract class AccessOp extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super(type, line, column, start, end, raw, virtual);
+    super(type, line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -180,11 +164,10 @@ export class MemberAccessOp extends AccessOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node,
     member: Identifier
   ) {
-    super('MemberAccessOp', line, column, start, end, raw, virtual, expression);
+    super('MemberAccessOp', line, column, start, end, raw, expression);
     this.member = member;
   }
 }
@@ -196,10 +179,9 @@ export class ProtoMemberAccessOp extends AccessOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super('ProtoMemberAccessOp', line, column, start, end, raw, virtual, expression);
+    super('ProtoMemberAccessOp', line, column, start, end, raw, expression);
   }
 }
 
@@ -212,11 +194,10 @@ export class SoakedMemberAccessOp extends AccessOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node,
     member: Identifier
   ) {
-    super('SoakedMemberAccessOp', line, column, start, end, raw, virtual, expression);
+    super('SoakedMemberAccessOp', line, column, start, end, raw, expression);
     this.member = member;
   }
 }
@@ -228,10 +209,9 @@ export class SoakedProtoMemberAccessOp extends AccessOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super('SoakedProtoMemberAccessOp', line, column, start, end, raw, virtual, expression);
+    super('SoakedProtoMemberAccessOp', line, column, start, end, raw, expression);
   }
 }
 
@@ -244,10 +224,9 @@ export class Quasi extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     data: string
   ) {
-    super('Quasi', line, column, start, end, raw, virtual);
+    super('Quasi', line, column, start, end, raw);
     this.data = data;
   }
 }
@@ -262,11 +241,10 @@ export class String extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     quasis: Array<Quasi>,
     expressions: Array<Node>
   ) {
-    super('String', line, column, start, end, raw, virtual);
+    super('String', line, column, start, end, raw);
     this.quasis = quasis;
     this.expressions = expressions;
   }
@@ -281,10 +259,9 @@ export class ObjectInitialiser extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     members: Array<ObjectInitialiserMember>
   ) {
-    super('ObjectInitialiser', line, column, start, end, raw, virtual);
+    super('ObjectInitialiser', line, column, start, end, raw);
     this.members = members;
   }
 }
@@ -299,11 +276,10 @@ export class ObjectInitialiserMember extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     key: String | Identifier,
     expression: Node
   ) {
-    super('ObjectInitialiserMember', line, column, start, end, raw, virtual);
+    super('ObjectInitialiserMember', line, column, start, end, raw);
     this.key = key;
     this.expression = expression;
   }
@@ -321,13 +297,12 @@ export class Conditional extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     condition: Node,
     consequent: Block,
     alternate: Block | null,
     isUnless: boolean
   ) {
-    super('Conditional', line, column, start, end, raw, virtual);
+    super('Conditional', line, column, start, end, raw);
     this.condition = condition;
     this.consequent = consequent;
     this.alternate = alternate;
@@ -344,10 +319,9 @@ export class Program extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     body: Block
   ) {
-    super('Program', line, column, start, end, raw, virtual);
+    super('Program', line, column, start, end, raw);
     this.body = body;
   }
 }
@@ -362,11 +336,10 @@ export class Block extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     statements: Array<Node>,
     inline: boolean
   ) {
-    super('Block', line, column, start, end, raw, virtual);
+    super('Block', line, column, start, end, raw);
     this.statements = statements;
     this.inline = inline;
   }
@@ -381,10 +354,9 @@ export class Loop extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     body: Node | null
   ) {
-    super('Loop', line, column, start, end, raw, virtual);
+    super('Loop', line, column, start, end, raw);
     this.body = body;
   }
 }
@@ -401,13 +373,12 @@ export class While extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     condition: Node,
     guard: Node | null,
     body: Node | null,
     isUntil: boolean
   ) {
-    super('While', line, column, start, end, raw, virtual);
+    super('While', line, column, start, end, raw);
     this.condition = condition;
     this.guard = guard;
     this.body = body;
@@ -429,14 +400,13 @@ export abstract class For extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     keyAssignee: Node | null,
     valAssignee: Node | null,
     target: Node,
     filter: Node | null,
     body: Block
   ) {
-    super(type, line, column, start, end, raw, virtual);
+    super(type, line, column, start, end, raw);
     this.keyAssignee = keyAssignee;
     this.valAssignee = valAssignee;
     this.target = target;
@@ -454,7 +424,6 @@ export class ForOf extends For {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     keyAssignee: Node | null,
     valAssignee: Node | null,
     target: Node,
@@ -462,7 +431,7 @@ export class ForOf extends For {
     body: Block,
     isOwn: boolean,
   ) {
-    super('ForOf', line, column, start, end, raw, virtual, keyAssignee, valAssignee, target, filter, body);
+    super('ForOf', line, column, start, end, raw, keyAssignee, valAssignee, target, filter, body);
     this.isOwn = isOwn;
   }
 }
@@ -476,7 +445,6 @@ export class ForIn extends For {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     keyAssignee: Node | null,
     valAssignee: Node | null,
     target: Node,
@@ -484,7 +452,7 @@ export class ForIn extends For {
     body: Block,
     step: Node | null
   ) {
-    super('ForIn', line, column, start, end, raw, virtual, keyAssignee, valAssignee, target, filter, body);
+    super('ForIn', line, column, start, end, raw, keyAssignee, valAssignee, target, filter, body);
     this.step = step;
   }
 }
@@ -500,12 +468,11 @@ export class Switch extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node | null,
     cases: Array<SwitchCase>,
     alternate: Block | null
   ) {
-    super('Switch', line, column, start, end, raw, virtual);
+    super('Switch', line, column, start, end, raw);
     this.expression = expression;
     this.cases = cases;
     this.alternate = alternate;
@@ -522,11 +489,10 @@ export class SwitchCase extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     conditions: Array<Node>,
     consequent: Block
   ) {
-    super('SwitchCase', line, column, start, end, raw, virtual);
+    super('SwitchCase', line, column, start, end, raw);
     this.conditions = conditions;
     this.consequent = consequent;
   }
@@ -599,12 +565,11 @@ export class Heregex extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     quasis: Array<Quasi>,
     expressions: Array<Node>,
     flags: RegexFlags
   ) {
-    super('Heregex', line, column, start, end, raw, virtual);
+    super('Heregex', line, column, start, end, raw);
     this.quasis = quasis;
     this.expressions = expressions;
     this.flags = flags;
@@ -618,9 +583,8 @@ export class Null extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean
   ) {
-    super('Null', line, column, start, end, raw, virtual);
+    super('Null', line, column, start, end, raw);
   }
 }
 
@@ -631,9 +595,8 @@ export class Undefined extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean
   ) {
-    super('Undefined', line, column, start, end, raw, virtual);
+    super('Undefined', line, column, start, end, raw);
   }
 }
 
@@ -647,11 +610,10 @@ export class Regex extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     pattern: string,
     flags: RegexFlags
   ) {
-    super('Regex', line, column, start, end, raw, virtual);
+    super('Regex', line, column, start, end, raw);
     this.pattern = pattern;
     this.flags = flags;
   }
@@ -666,10 +628,9 @@ export class Return extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node | null
   ) {
-    super('Return', line, column, start, end, raw, virtual);
+    super('Return', line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -683,10 +644,9 @@ export class YieldReturn extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node | null
   ) {
-    super('YieldReturn', line, column, start, end, raw, virtual);
+    super('YieldReturn', line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -698,9 +658,8 @@ export class This extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean
   ) {
-    super('This', line, column, start, end, raw, virtual);
+    super('This', line, column, start, end, raw);
   }
 }
 
@@ -713,10 +672,9 @@ export class Throw extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node | null
   ) {
-    super('Throw', line, column, start, end, raw, virtual);
+    super('Throw', line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -730,10 +688,9 @@ export class ArrayInitialiser extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     members: Array<Node>
   ) {
-    super('ArrayInitialiser', line, column, start, end, raw, virtual);
+    super('ArrayInitialiser', line, column, start, end, raw);
     this.members = members;
   }
 }
@@ -748,11 +705,10 @@ export class DefaultParam extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     param: Node,
     defaultValue: Node
   ) {
-    super('DefaultParam', line, column, start, end, raw, virtual);
+    super('DefaultParam', line, column, start, end, raw);
     this.param = param;
     this.default = defaultValue;
   }
@@ -767,10 +723,9 @@ export class Rest extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super('Rest', line, column, start, end, raw, virtual);
+    super('Rest', line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -782,9 +737,8 @@ export class Break extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean
   ) {
-    super('Break', line, column, start, end, raw, virtual);
+    super('Break', line, column, start, end, raw);
   }
 }
 
@@ -795,9 +749,8 @@ export class Continue extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean
   ) {
-    super('Continue', line, column, start, end, raw, virtual);
+    super('Continue', line, column, start, end, raw);
   }
 }
 
@@ -810,10 +763,9 @@ export class Spread extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super('Spread', line, column, start, end, raw, virtual);
+    super('Spread', line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -829,12 +781,11 @@ export class Range extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node,
     isInclusive: boolean
   ) {
-    super('Range', line, column, start, end, raw, virtual);
+    super('Range', line, column, start, end, raw);
     this.left = left;
     this.right = right;
     this.isInclusive = isInclusive;
@@ -852,11 +803,10 @@ export abstract class BinaryOp extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node
   ) {
-    super(type, line, column, start, end, raw, virtual);
+    super(type, line, column, start, end, raw);
     this.left = left;
     this.right = right;
   }
@@ -872,10 +822,9 @@ export abstract class UnaryOp extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super(type, line, column, start, end, raw, virtual);
+    super(type, line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -890,11 +839,10 @@ export class ChainedComparisonOp extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     operands: Array<Node>,
     operators: Array<OperatorInfo>
   ) {
-    super('ChainedComparisonOp', line, column, start, end, raw, virtual);
+    super('ChainedComparisonOp', line, column, start, end, raw);
     this.operands = operands;
     this.operators = operators;
   }
@@ -919,11 +867,10 @@ export class EQOp extends BinaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node
   ) {
-    super('EQOp', line, column, start, end, raw, virtual, left, right);
+    super('EQOp', line, column, start, end, raw, left, right);
   }
 }
 
@@ -934,11 +881,10 @@ export class SubtractOp extends BinaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node
   ) {
-    super('SubtractOp', line, column, start, end, raw, virtual, left, right);
+    super('SubtractOp', line, column, start, end, raw, left, right);
   }
 }
 
@@ -949,11 +895,10 @@ export class MultiplyOp extends BinaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node
   ) {
-    super('MultiplyOp', line, column, start, end, raw, virtual, left, right);
+    super('MultiplyOp', line, column, start, end, raw, left, right);
   }
 }
 
@@ -964,10 +909,9 @@ export class UnaryExistsOp extends UnaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super('UnaryExistsOp', line, column, start, end, raw, virtual, expression);
+    super('UnaryExistsOp', line, column, start, end, raw, expression);
   }
 }
 
@@ -978,10 +922,9 @@ export class UnaryNegateOp extends UnaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node
   ) {
-    super('UnaryNegateOp', line, column, start, end, raw, virtual, left);
+    super('UnaryNegateOp', line, column, start, end, raw, left);
   }
 }
 
@@ -994,12 +937,11 @@ export class InOp extends BinaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node,
     isNot: boolean
   ) {
-    super('InOp', line, column, start, end, raw, virtual, left, right);
+    super('InOp', line, column, start, end, raw, left, right);
     this.isNot = isNot;
   }
 }
@@ -1015,11 +957,10 @@ export class BaseAssignOp extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     assignee: Node,
     expression: Node
   ) {
-    super(type, line, column, start, end, raw, virtual);
+    super(type, line, column, start, end, raw);
     this.assignee = assignee;
     this.expression = expression;
   }
@@ -1032,11 +973,10 @@ export class AssignOp extends BaseAssignOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     assignee: Node,
     expression: Node
   ) {
-    super('AssignOp', line, column, start, end, raw, virtual, assignee, expression);
+    super('AssignOp', line, column, start, end, raw, assignee, expression);
   }
 }
 
@@ -1047,11 +987,10 @@ export class ExtendsOp extends BinaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node
   ) {
-    super('ExtendsOp', line, column, start, end, raw, virtual, left, right);
+    super('ExtendsOp', line, column, start, end, raw, left, right);
   }
 }
 
@@ -1062,11 +1001,10 @@ export class SeqOp extends BinaryOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     left: Node,
     right: Node
   ) {
-    super('SeqOp', line, column, start, end, raw, virtual, left, right);
+    super('SeqOp', line, column, start, end, raw, left, right);
   }
 }
 
@@ -1079,10 +1017,9 @@ export class Yield extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super('Yield', line, column, start, end, raw, virtual);
+    super('Yield', line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -1096,10 +1033,9 @@ export class YieldFrom extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     expression: Node
   ) {
-    super('YieldFrom', line, column, start, end, raw, virtual);
+    super('YieldFrom', line, column, start, end, raw);
     this.expression = expression;
   }
 }
@@ -1115,11 +1051,10 @@ export abstract class BaseFunction extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     parameters: Array<Node>,
     body: Block
   ) {
-    super(type, line, column, start, end, raw, virtual);
+    super(type, line, column, start, end, raw);
     this.parameters = parameters;
     this.body = body;
   }
@@ -1132,11 +1067,10 @@ export class Function extends BaseFunction {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     parameters: Array<Node>,
     body: Block
   ) {
-    super('Function', line, column, start, end, raw, virtual, parameters, body);
+    super('Function', line, column, start, end, raw, parameters, body);
   }
 }
 
@@ -1147,11 +1081,10 @@ export class BoundFunction extends BaseFunction {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     parameters: Array<Node>,
     body: Block
   ) {
-    super('BoundFunction', line, column, start, end, raw, virtual, parameters, body);
+    super('BoundFunction', line, column, start, end, raw, parameters, body);
   }
 }
 
@@ -1162,11 +1095,10 @@ export class GeneratorFunction extends BaseFunction {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     parameters: Array<Node>,
     body: Block
   ) {
-    super('GeneratorFunction', line, column, start, end, raw, virtual, parameters, body);
+    super('GeneratorFunction', line, column, start, end, raw, parameters, body);
   }
 }
 
@@ -1177,11 +1109,10 @@ export class BoundGeneratorFunction extends BaseFunction {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     parameters: Array<Node>,
     body: Block
   ) {
-    super('BoundGeneratorFunction', line, column, start, end, raw, virtual, parameters, body);
+    super('BoundGeneratorFunction', line, column, start, end, raw, parameters, body);
   }
 }
 
@@ -1197,13 +1128,12 @@ export class Try extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     body: Node | null,
     catchAssignee: Node | null,
     catchBody: Node | null,
     finallyBody: Node | null
   ) {
-    super('Try', line, column, start, end, raw, virtual);
+    super('Try', line, column, start, end, raw);
     this.body = body;
     this.catchAssignee = catchAssignee;
     this.catchBody = catchBody;
@@ -1218,11 +1148,10 @@ export class Constructor extends BaseAssignOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     assignee: Node,
     expression: BaseFunction
   ) {
-    super('Constructor', line, column, start, end, raw, virtual, assignee, expression);
+    super('Constructor', line, column, start, end, raw, assignee, expression);
   }
 }
 
@@ -1233,11 +1162,10 @@ export class ClassProtoAssignOp extends BaseAssignOp {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     assignee: Node,
     expression: Node
   ) {
-    super('ClassProtoAssignOp', line, column, start, end, raw, virtual, assignee, expression);
+    super('ClassProtoAssignOp', line, column, start, end, raw, assignee, expression);
   }
 }
 
@@ -1255,7 +1183,6 @@ export class Class extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     nameAssignee: Node | null,
     name: Node | null,
     body: Block | null,
@@ -1263,7 +1190,7 @@ export class Class extends Node {
     parent: Node | null,
     ctor: Constructor | null
   ) {
-    super('Class', line, column, start, end, raw, virtual);
+    super('Class', line, column, start, end, raw);
     this.nameAssignee = nameAssignee;
     this.name = name;
     this.body = body;
@@ -1283,11 +1210,10 @@ export class FunctionApplication extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     fn: Node,
     args: Array<Node>
   ) {
-    super('FunctionApplication', line, column, start, end, raw, virtual);
+    super('FunctionApplication', line, column, start, end, raw);
     this.function = fn;
     this.arguments = args;
   }
@@ -1303,11 +1229,10 @@ export class SoakedFunctionApplication extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     fn: Node,
     args: Array<Node>
   ) {
-    super('SoakedFunctionApplication', line, column, start, end, raw, virtual);
+    super('SoakedFunctionApplication', line, column, start, end, raw);
     this.function = fn;
     this.arguments = args;
   }
@@ -1320,9 +1245,8 @@ export class Super extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean
   ) {
-    super('Super', line, column, start, end, raw, virtual);
+    super('Super', line, column, start, end, raw);
   }
 }
 
@@ -1333,9 +1257,8 @@ export class BareSuperFunctionApplication extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean
   ) {
-    super('BareSuperFunctionApplication', line, column, start, end, raw, virtual);
+    super('BareSuperFunctionApplication', line, column, start, end, raw);
   }
 }
 
@@ -1349,24 +1272,17 @@ export class NewOp extends Node {
     start: number,
     end: number,
     raw: string,
-    virtual: boolean,
     ctor: Node,
     args: Array<Node>
   ) {
-    super('NewOp', line, column, start, end, raw, virtual);
+    super('NewOp', line, column, start, end, raw);
     this.ctor = ctor;
     this.arguments = args;
   }
 }
 
-export type DecaffeinateNode =
-  Bool |
-  Null |
-  RealNode |
-  VirtualNode;
-
 // tslint:disable-next-line:no-any
-export function makeRealNode(context: ParseContext, type: string, loc: LocationData, attrs: any = {}): RealNode {
+export function makeRealNode(context: ParseContext, type: string, loc: LocationData, attrs: any = {}): Node {
   // tslint:disable-next-line:no-any
   let result: any = { type };
   let start = context.linesAndColumns.indexForLocation({ line: loc.first_line, column: loc.first_column });
@@ -1435,41 +1351,10 @@ export function makeRealNode(context: ParseContext, type: string, loc: LocationD
 }
 
 // tslint:disable-next-line:no-any
-export function makeVirtualNode(type: string, attrs: any = {}): VirtualNode {
-  // tslint:disable-next-line:no-any
-  let result: any = {
-    type,
-    virtual: true
-  };
-
-  for (let key in attrs) {
-    if (attrs.hasOwnProperty(key)) {
-      let value = attrs[key];
-      result[key] = value;
-      if (value && result.range) {
-        (Array.isArray(value) ? value : [value]).forEach(node => {
-          if (node.range) {
-            // Expand the range to contain all the children.
-            if (result.range[0] > node.range[0]) {
-              result.range[0] = node.range[0];
-            }
-            if (result.range[1] < node.range[1]) {
-              result.range[1] = node.range[1];
-            }
-          }
-        });
-      }
-    }
+export default function makeNode(context: ParseContext, type: string, loc: LocationData, attrs: any = {}): Node {
+  if (!loc) {
+    throw new Error(`location data must be provided for node type: ${type}`);
   }
 
-  return result;
-}
-
-// tslint:disable-next-line:no-any
-export default function makeNode(context: ParseContext, type: string, loc: LocationData, attrs: any = {}): DecaffeinateNode {
-  if (loc) {
-    return makeRealNode(context, type, loc, attrs);
-  } else {
-    return makeVirtualNode(type, attrs);
-  }
+  return makeRealNode(context, type, loc, attrs);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -33,17 +33,6 @@ function stripExtraInfo(node) {
     for (let key in node) {
       if (node.range && (key === 'start' || key === 'end')) {
         delete node[key];
-      } else if (key === 'virtual') {
-        if (node[key] === false) {
-          delete node[key];
-        } else {
-          delete node.line;
-          delete node.column;
-          delete node.start;
-          delete node.end;
-          delete node.range;
-          delete node.raw;
-        }
       } else {
         stripExtraInfo(node[key]);
       }


### PR DESCRIPTION
BREAKING CHANGE: This is technically a breaking change since the `virtual` property is no longer present, even though it previously was only ever false. They're no longer needed since we removed all the nodes that required them.