### PR TITLE
fix: only consider comparison operations in chained comparisons

### DIFF
--- a/src/util/isChainedComparison.ts
+++ b/src/util/isChainedComparison.ts
@@ -1,28 +1,11 @@
 import { Base, Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 
+import isComparisonOperator from './isComparisonOperator';
+
 export default function isChainedComparison(node: Base): boolean {
   if (node instanceof Op && isComparisonOperator(node)) {
     return isComparisonOperator(node.first) || (node.second ? isComparisonOperator(node.second) : false);
   } else {
     return false;
-  }
-}
-
-function isComparisonOperator(node: Base): boolean {
-  if (!(node instanceof Op)) {
-    return false;
-  }
-
-  switch (node.operator) {
-    case '<':
-    case '>':
-    case '<=':
-    case '>=':
-    case '===':
-    case '!==':
-      return true;
-
-    default:
-      return false;
   }
 }

--- a/src/util/isComparisonOperator.ts
+++ b/src/util/isComparisonOperator.ts
@@ -1,0 +1,20 @@
+import { Base, Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+
+export default function isComparisonOperator(node: Base): boolean {
+  if (!(node instanceof Op)) {
+    return false;
+  }
+
+  switch (node.operator) {
+    case '<':
+    case '>':
+    case '<=':
+    case '>=':
+    case '===':
+    case '!==':
+      return true;
+
+    default:
+      return false;
+  }
+}

--- a/src/util/unwindChainedComparison.ts
+++ b/src/util/unwindChainedComparison.ts
@@ -1,15 +1,22 @@
 import { Base, Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { inspect } from 'util';
+
+import isComparisonOperator from './isComparisonOperator';
 
 export default function unwindChainedComparison(node: Op): Array<Base> {
   let operands: Array<Base> = [];
 
   for (let link: Base = node;;) {
-    if (link instanceof Op) {
+    if (link instanceof Op && isComparisonOperator(link)) {
       let { first, second } = link;
 
       if (!second) {
         operands = [link, ...operands];
         break;
+      }
+
+      if (!second) {
+        throw new Error(`unexpected unary operator inside chained comparison: ${inspect(node)}`);
       }
 
       operands = [second, ...operands];

--- a/src/util/unwindChainedComparison.ts
+++ b/src/util/unwindChainedComparison.ts
@@ -11,11 +11,6 @@ export default function unwindChainedComparison(node: Op): Array<Base> {
       let { first, second } = link;
 
       if (!second) {
-        operands = [link, ...operands];
-        break;
-      }
-
-      if (!second) {
         throw new Error(`unexpected unary operator inside chained comparison: ${inspect(node)}`);
       }
 

--- a/test/examples/chained-comparison-with-other-operators/input.coffee
+++ b/test/examples/chained-comparison-with-other-operators/input.coffee
@@ -1,0 +1,1 @@
+Math.PI/2 < angle < 3*Math.PI/2

--- a/test/examples/chained-comparison-with-other-operators/output.json
+++ b/test/examples/chained-comparison-with-other-operators/output.json
@@ -1,0 +1,190 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    32
+  ],
+  "raw": "Math.PI/2 < angle < 3*Math.PI/2\n",
+  "body": {
+    "type": "Block",
+    "line": 1,
+    "column": 1,
+    "range": [
+      0,
+      31
+    ],
+    "statements": [
+      {
+        "type": "ChainedComparisonOp",
+        "line": 1,
+        "column": 1,
+        "range": [
+          0,
+          31
+        ],
+        "operands": [
+          {
+            "type": "DivideOp",
+            "line": 1,
+            "column": 1,
+            "range": [
+              0,
+              9
+            ],
+            "left": {
+              "type": "MemberAccessOp",
+              "line": 1,
+              "column": 1,
+              "range": [
+                0,
+                7
+              ],
+              "expression": {
+                "type": "Identifier",
+                "line": 1,
+                "column": 1,
+                "raw": "Math",
+                "range": [
+                  0,
+                  4
+                ],
+                "data": "Math"
+              },
+              "member": {
+                "type": "Identifier",
+                "line": 1,
+                "column": 6,
+                "raw": "PI",
+                "range": [
+                  5,
+                  7
+                ],
+                "data": "PI"
+              },
+              "raw": "Math.PI"
+            },
+            "right": {
+              "type": "Int",
+              "line": 1,
+              "column": 9,
+              "raw": "2",
+              "range": [
+                8,
+                9
+              ],
+              "data": 2
+            },
+            "raw": "Math.PI/2"
+          },
+          {
+            "type": "Identifier",
+            "line": 1,
+            "column": 13,
+            "raw": "angle",
+            "range": [
+              12,
+              17
+            ],
+            "data": "angle"
+          },
+          {
+            "type": "DivideOp",
+            "line": 1,
+            "column": 21,
+            "range": [
+              20,
+              31
+            ],
+            "left": {
+              "type": "MultiplyOp",
+              "line": 1,
+              "column": 21,
+              "range": [
+                20,
+                29
+              ],
+              "left": {
+                "type": "Int",
+                "line": 1,
+                "column": 21,
+                "raw": "3",
+                "range": [
+                  20,
+                  21
+                ],
+                "data": 3
+              },
+              "right": {
+                "type": "MemberAccessOp",
+                "line": 1,
+                "column": 23,
+                "range": [
+                  22,
+                  29
+                ],
+                "expression": {
+                  "type": "Identifier",
+                  "line": 1,
+                  "column": 23,
+                  "raw": "Math",
+                  "range": [
+                    22,
+                    26
+                  ],
+                  "data": "Math"
+                },
+                "member": {
+                  "type": "Identifier",
+                  "line": 1,
+                  "column": 28,
+                  "raw": "PI",
+                  "range": [
+                    27,
+                    29
+                  ],
+                  "data": "PI"
+                },
+                "raw": "Math.PI"
+              },
+              "raw": "3*Math.PI"
+            },
+            "right": {
+              "type": "Int",
+              "line": 1,
+              "column": 31,
+              "raw": "2",
+              "range": [
+                30,
+                31
+              ],
+              "data": 2
+            },
+            "raw": "3*Math.PI/2"
+          }
+        ],
+        "operators": [
+          {
+            "operator": "<",
+            "token": {
+              "type": 39,
+              "start": 10,
+              "end": 11
+            }
+          },
+          {
+            "operator": "<",
+            "token": {
+              "type": 39,
+              "start": 18,
+              "end": 19
+            }
+          }
+        ],
+        "raw": "Math.PI/2 < angle < 3*Math.PI/2"
+      }
+    ],
+    "raw": "Math.PI/2 < angle < 3*Math.PI/2"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/811

We can't just traverse down any binary operator, there's a specific set of
comparison operators that are eligible for chained comparisons. We already had
this elsewhere in the code, so I just extracted that function and used it.