### PR TITLE
fix: use proper location data for parenthesized class values

### DIFF
--- a/src/mappers/mapClass.ts
+++ b/src/mappers/mapClass.ts
@@ -24,6 +24,7 @@ export default function mapClass(context: ParseContext, node: CoffeeClass): Clas
           if (property instanceof Comment) {
             continue;
           } else if (property instanceof Assign) {
+            let { line, column, start, end, raw } = mapBase(context, property);
             let key = mapAny(context, property.variable);
             let value = mapAny(context, property.value);
             let Node = ClassProtoAssignOp;
@@ -35,8 +36,7 @@ export default function mapClass(context: ParseContext, node: CoffeeClass): Clas
             }
 
             let assignment = new Node(
-              key.line, key.column, key.start, value.end,
-              context.source.slice(key.start, value.end),
+              line, column, start, end, raw,
               key,
               value
             );

--- a/test/examples/class-with-parenthesized-value/input.coffee
+++ b/test/examples/class-with-parenthesized-value/input.coffee
@@ -1,0 +1,2 @@
+class A
+  b: (c)

--- a/test/examples/class-with-parenthesized-value/output.json
+++ b/test/examples/class-with-parenthesized-value/output.json
@@ -1,0 +1,102 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "class A\n  b: (c)\n",
+  "body": {
+    "type": "Block",
+    "line": 1,
+    "column": 1,
+    "range": [
+      0,
+      16
+    ],
+    "statements": [
+      {
+        "type": "Class",
+        "line": 1,
+        "column": 1,
+        "range": [
+          0,
+          16
+        ],
+        "name": {
+          "type": "Identifier",
+          "line": 1,
+          "column": 7,
+          "raw": "A",
+          "range": [
+            6,
+            7
+          ],
+          "data": "A"
+        },
+        "nameAssignee": {
+          "type": "Identifier",
+          "line": 1,
+          "column": 7,
+          "raw": "A",
+          "range": [
+            6,
+            7
+          ],
+          "data": "A"
+        },
+        "body": {
+          "type": "Block",
+          "line": 2,
+          "column": 3,
+          "range": [
+            10,
+            16
+          ],
+          "statements": [
+            {
+              "type": "ClassProtoAssignOp",
+              "line": 2,
+              "column": 3,
+              "range": [
+                10,
+                16
+              ],
+              "assignee": {
+                "type": "Identifier",
+                "line": 2,
+                "column": 3,
+                "raw": "b",
+                "range": [
+                  10,
+                  11
+                ],
+                "data": "b"
+              },
+              "expression": {
+                "type": "Identifier",
+                "line": 2,
+                "column": 7,
+                "raw": "c",
+                "range": [
+                  14,
+                  15
+                ],
+                "data": "c"
+              },
+              "raw": "b: (c)"
+            }
+          ],
+          "inline": false,
+          "raw": "b: (c)"
+        },
+        "boundMembers": [],
+        "parent": null,
+        "ctor": null,
+        "raw": "class A\n  b: (c)"
+      }
+    ],
+    "raw": "class A\n  b: (c)"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/813

As with a few other cases, it's not actually safe to say that the range of a
node is from the start of the leftmost child to the end of the rightmost child,
since nodes can be wrapped in parens, so we call `mapBase` instead.