### PR TITLE
fix: use `Constructor` node even for external constructors

### DIFF
--- a/src/mappers/mapClass.ts
+++ b/src/mappers/mapClass.ts
@@ -1,7 +1,7 @@
 import { Assign, Class as CoffeeClass, Comment, Obj, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { inspect } from 'util';
 import {
-  AssignOp, Block, BoundFunction, BoundGeneratorFunction, Class, ClassProtoAssignOp, Constructor, Function,
+  AssignOp, Block, BoundFunction, BoundGeneratorFunction, Class, ClassProtoAssignOp, Constructor,
   Identifier, MemberAccessOp, Node, This
 } from '../nodes';
 import ParseContext from '../util/ParseContext';
@@ -29,7 +29,7 @@ export default function mapClass(context: ParseContext, node: CoffeeClass): Clas
             let value = mapAny(context, property.value);
             let Node = ClassProtoAssignOp;
 
-            if (key instanceof Identifier && key.data === 'constructor' && value instanceof Function) {
+            if (key instanceof Identifier && key.data === 'constructor') {
               Node = Constructor;
             } else if (key instanceof MemberAccessOp && key.expression instanceof This) {
               Node = AssignOp;

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -991,7 +991,7 @@ export class Constructor extends BaseAssignOp {
     end: number,
     raw: string,
     assignee: Node,
-    expression: BaseFunction
+    expression: Node
   ) {
     super('Constructor', line, column, start, end, raw, assignee, expression);
   }

--- a/test/examples/external-constructor/input.coffee
+++ b/test/examples/external-constructor/input.coffee
@@ -1,0 +1,3 @@
+f = ->
+class A
+  constructor: f

--- a/test/examples/external-constructor/output.json
+++ b/test/examples/external-constructor/output.json
@@ -1,0 +1,166 @@
+{
+  "type": "Program",
+  "line": 1,
+  "column": 1,
+  "range": [
+    0,
+    32
+  ],
+  "raw": "f = ->\nclass A\n  constructor: f\n",
+  "body": {
+    "type": "Block",
+    "line": 1,
+    "column": 1,
+    "range": [
+      0,
+      31
+    ],
+    "statements": [
+      {
+        "type": "AssignOp",
+        "line": 1,
+        "column": 1,
+        "range": [
+          0,
+          6
+        ],
+        "assignee": {
+          "type": "Identifier",
+          "line": 1,
+          "column": 1,
+          "raw": "f",
+          "range": [
+            0,
+            1
+          ],
+          "data": "f"
+        },
+        "expression": {
+          "type": "Function",
+          "line": 1,
+          "column": 5,
+          "range": [
+            4,
+            6
+          ],
+          "body": null,
+          "parameters": [],
+          "raw": "->"
+        },
+        "raw": "f = ->"
+      },
+      {
+        "type": "Class",
+        "line": 2,
+        "column": 1,
+        "range": [
+          7,
+          31
+        ],
+        "name": {
+          "type": "Identifier",
+          "line": 2,
+          "column": 7,
+          "raw": "A",
+          "range": [
+            13,
+            14
+          ],
+          "data": "A"
+        },
+        "nameAssignee": {
+          "type": "Identifier",
+          "line": 2,
+          "column": 7,
+          "raw": "A",
+          "range": [
+            13,
+            14
+          ],
+          "data": "A"
+        },
+        "body": {
+          "type": "Block",
+          "line": 3,
+          "column": 3,
+          "range": [
+            17,
+            31
+          ],
+          "statements": [
+            {
+              "type": "Constructor",
+              "line": 3,
+              "column": 3,
+              "range": [
+                17,
+                31
+              ],
+              "assignee": {
+                "type": "Identifier",
+                "line": 3,
+                "column": 3,
+                "raw": "constructor",
+                "range": [
+                  17,
+                  28
+                ],
+                "data": "constructor"
+              },
+              "expression": {
+                "type": "Identifier",
+                "line": 3,
+                "column": 16,
+                "raw": "f",
+                "range": [
+                  30,
+                  31
+                ],
+                "data": "f"
+              },
+              "raw": "constructor: f"
+            }
+          ],
+          "inline": false,
+          "raw": "constructor: f"
+        },
+        "boundMembers": [],
+        "parent": null,
+        "ctor": {
+          "type": "Constructor",
+          "line": 3,
+          "column": 3,
+          "range": [
+            17,
+            31
+          ],
+          "assignee": {
+            "type": "Identifier",
+            "line": 3,
+            "column": 3,
+            "raw": "constructor",
+            "range": [
+              17,
+              28
+            ],
+            "data": "constructor"
+          },
+          "expression": {
+            "type": "Identifier",
+            "line": 3,
+            "column": 16,
+            "raw": "f",
+            "range": [
+              30,
+              31
+            ],
+            "data": "f"
+          },
+          "raw": "constructor: f"
+        },
+        "raw": "class A\n  constructor: f"
+      }
+    ],
+    "raw": "f = ->\nclass A\n  constructor: f"
+  }
+}


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/830

Constructors are allowed to be arbitrary expressions in CoffeeScript, so I think
the right approach is for the parser to use the `Constructor` node even if the
value isn't a function, and decaffeinate will figure out the right way to handle
it.