### PR TITLE
fix: use the right decaffeinate-coffeescript when installing with yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "babylon": "^6.14.1",
     "coffee-lex": "^7.0.0",
-    "decaffeinate-coffeescript": "^1.10.0-patch21",
+    "decaffeinate-coffeescript": "1.10.0-patch21",
     "lines-and-columns": "^1.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/931

By using an exact version of decaffeinate-coffeescript, we can avoid differences
between npm and yarn when resolving the right version.