### PR TITLE
refactor: change template literal handling to operate on CoffeeScript nodes

### DIFF
--- a/src/util/ParseContext.ts
+++ b/src/util/ParseContext.ts
@@ -39,7 +39,7 @@ export default class ParseContext {
         return null;
       }
 
-      return [start, end];
+      return [start, end + 1];
     }
   }
 

--- a/src/util/isImplicitPlusOp.ts
+++ b/src/util/isImplicitPlusOp.ts
@@ -1,23 +1,18 @@
+import { Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import isPlusTokenBetweenRanges from './isPlusTokenBetweenRanges';
 import ParseContext from './ParseContext';
-
-export type Op = {
-  type: string;
-  left: {
-    range: [number, number];
-  };
-  right: {
-    range: [number, number];
-  };
-};
 
 /**
  * Determine if the operator is a fake + operator for string interpolation.
  */
 export default function isImplicitPlusOp(op: Op, context: ParseContext): boolean {
-  if (op.type !== 'PlusOp') {
+  if (op.operator !== '+' || !op.second) {
     return false;
   }
-
-  return !isPlusTokenBetweenRanges(op.left.range, op.right.range, context);
+  let firstRange = context.getRange(op.first);
+  let secondRange = context.getRange(op.second);
+  if (!firstRange || !secondRange) {
+    throw new Error('Expected valid location data on plus operation.');
+  }
+  return !isPlusTokenBetweenRanges(firstRange, secondRange, context);
 }


### PR DESCRIPTION
Previously, we would convert to decaffeinate-parser nodes, which also meant that
we had to know up-front when something would be a quasi. Now, we instead find
the unmapped template literal expressions and then map them later. This should
make it easier to handle some remaining cases of empty string interpolations,
and also provide a better path for moving all of the template literal code to
typescript/mappers.