### PR TITLE
test: update test data to be canonical

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babylon": "^6.14.1",
     "coffee-lex": "^7.0.0",
     "decaffeinate-coffeescript": "1.10.0-patch23",
+    "json-stable-stringify": "^1.0.1",
     "lines-and-columns": "^1.1.6"
   },
   "devDependencies": {

--- a/test/examples/addition/output.json
+++ b/test/examples/addition/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "3 + 4",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "3 + 4",
     "statements": [
       {
-        "type": "PlusOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "3 + 4",
         "left": {
-          "type": "Int",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "3",
-          "data": 3
-        },
-        "right": {
-          "type": "Int",
+          "data": 3,
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "3",
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "3 + 4",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": 4,
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "4",
-          "data": 4
-        }
+          "type": "Int"
+        },
+        "type": "PlusOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "3 + 4",
+  "type": "Program"
 }

--- a/test/examples/array-with-multiple-members/output.json
+++ b/test/examples/array-with-multiple-members/output.json
@@ -1,49 +1,67 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "[1, 2, 3]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "[1, 2, 3]",
     "statements": [
       {
-        "type": "ArrayInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "[1, 2, 3]",
+        "line": 1,
         "members": [
           {
-            "type": "Int",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 2 ],
+            "data": 1,
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
             "raw": "1",
-            "data": 1
+            "type": "Int"
           },
           {
-            "type": "Int",
-            "line": 1,
             "column": 5,
-            "range": [ 4, 5 ],
+            "data": 2,
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
             "raw": "2",
-            "data": 2
+            "type": "Int"
           },
           {
-            "type": "Int",
-            "line": 1,
             "column": 8,
-            "range": [ 7, 8 ],
+            "data": 3,
+            "line": 1,
+            "range": [
+              7,
+              8
+            ],
             "raw": "3",
-            "data": 3
+            "type": "Int"
           }
-        ]
+        ],
+        "range": [
+          0,
+          9
+        ],
+        "raw": "[1, 2, 3]",
+        "type": "ArrayInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "[1, 2, 3]",
+  "type": "Program"
 }

--- a/test/examples/array-with-single-member/output.json
+++ b/test/examples/array-with-single-member/output.json
@@ -1,33 +1,45 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "[1]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 3 ],
+    "line": 1,
+    "range": [
+      0,
+      3
+    ],
     "raw": "[1]",
     "statements": [
       {
-        "type": "ArrayInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 3 ],
-        "raw": "[1]",
+        "line": 1,
         "members": [
           {
-            "type": "Int",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 2 ],
+            "data": 1,
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
             "raw": "1",
-            "data": 1
+            "type": "Int"
           }
-        ]
+        ],
+        "range": [
+          0,
+          3
+        ],
+        "raw": "[1]",
+        "type": "ArrayInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "[1]",
+  "type": "Program"
 }

--- a/test/examples/assign/output.json
+++ b/test/examples/assign/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "a = 1",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "a = 1",
     "statements": [
       {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "a = 1",
         "assignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "expression": {
-          "type": "Int",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "column": 1,
+        "expression": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": 1,
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "1",
-          "data": 1
-        }
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a = 1",
+        "type": "AssignOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a = 1",
+  "type": "Program"
 }

--- a/test/examples/backticks-with-string-inside/output.json
+++ b/test/examples/backticks-with-string-inside/output.json
@@ -1,33 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      23
+    ],
+    "raw": "`import foo from 'foo'`",
+    "statements": [
+      {
+        "column": 1,
+        "data": "import foo from 'foo'",
+        "line": 1,
+        "range": [
+          0,
+          23
+        ],
+        "raw": "`import foo from 'foo'`",
+        "type": "JavaScript"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     24
   ],
   "raw": "`import foo from 'foo'`\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      23
-    ],
-    "statements": [
-      {
-        "type": "JavaScript",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          23
-        ],
-        "data": "import foo from 'foo'",
-        "raw": "`import foo from 'foo'`"
-      }
-    ],
-    "raw": "`import foo from 'foo'`"
-  }
+  "type": "Program"
 }

--- a/test/examples/bitshift-left/output.json
+++ b/test/examples/bitshift-left/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a << b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a << b",
     "statements": [
       {
-        "type": "LeftShiftOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a << b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a << b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "LeftShiftOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a << b",
+  "type": "Program"
 }

--- a/test/examples/bitshift-right-unsigned/output.json
+++ b/test/examples/bitshift-right-unsigned/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "a >>> b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 7 ],
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
     "raw": "a >>> b",
     "statements": [
       {
-        "type": "UnsignedRightShiftOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 7 ],
-        "raw": "a >>> b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          7
+        ],
+        "raw": "a >>> b",
+        "right": {
           "column": 7,
-          "range": [ 6, 7 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "UnsignedRightShiftOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "a >>> b",
+  "type": "Program"
 }

--- a/test/examples/bitshift-right/output.json
+++ b/test/examples/bitshift-right/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a >> b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a >> b",
     "statements": [
       {
-        "type": "SignedRightShiftOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a >> b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a >> b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "SignedRightShiftOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a >> b",
+  "type": "Program"
 }

--- a/test/examples/bitwise-and/output.json
+++ b/test/examples/bitwise-and/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "a & b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "a & b",
     "statements": [
       {
-        "type": "BitAndOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "a & b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a & b",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "BitAndOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a & b",
+  "type": "Program"
 }

--- a/test/examples/bitwise-or/output.json
+++ b/test/examples/bitwise-or/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "a | b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "a | b",
     "statements": [
       {
-        "type": "BitOrOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "a | b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a | b",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "BitOrOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a | b",
+  "type": "Program"
 }

--- a/test/examples/bitwise-xor/output.json
+++ b/test/examples/bitwise-xor/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "a ^ b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "a ^ b",
     "statements": [
       {
-        "type": "BitXorOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "a ^ b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a ^ b",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "BitXorOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a ^ b",
+  "type": "Program"
 }

--- a/test/examples/block-comment-in-function/output.json
+++ b/test/examples/block-comment-in-function/output.json
@@ -1,45 +1,47 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      18
+    ],
+    "raw": "->\n  ###\n  a\n  ###",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            5,
+            18
+          ],
+          "raw": "###\n  a\n  ###",
+          "statements": [
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          18
+        ],
+        "raw": "->\n  ###\n  a\n  ###",
+        "type": "Function"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     19
   ],
   "raw": "->\n  ###\n  a\n  ###\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      18
-    ],
-    "statements": [
-      {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          18
-        ],
-        "body": {
-          "type": "Block",
-          "line": 2,
-          "column": 3,
-          "range": [
-            5,
-            18
-          ],
-          "statements": [],
-          "raw": "###\n  a\n  ###",
-          "inline": false
-        },
-        "parameters": [],
-        "raw": "->\n  ###\n  a\n  ###"
-      }
-    ],
-    "raw": "->\n  ###\n  a\n  ###"
-  }
+  "type": "Program"
 }

--- a/test/examples/block-comment-only-file/output.json
+++ b/test/examples/block-comment-only-file/output.json
@@ -1,11 +1,11 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": null,
   "column": 1,
-  "raw": "###\n# hey there\n###\n",
+  "line": 1,
   "range": [
     0,
     0
   ],
-  "body": null
+  "raw": "###\n# hey there\n###\n",
+  "type": "Program"
 }

--- a/test/examples/block-comment/output.json
+++ b/test/examples/block-comment/output.json
@@ -1,24 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 21 ],
-  "raw": "###\n# hey there\n###\na",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 21 ],
+    "line": 1,
+    "range": [
+      0,
+      21
+    ],
     "raw": "###\n# hey there\n###\na",
     "statements": [
       {
-        "type": "Identifier",
-        "line": 4,
         "column": 1,
-        "range": [ 20, 21 ],
+        "data": "a",
+        "line": 4,
+        "range": [
+          20,
+          21
+        ],
         "raw": "a",
-        "data": "a"
+        "type": "Identifier"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    21
+  ],
+  "raw": "###\n# hey there\n###\na",
+  "type": "Program"
 }

--- a/test/examples/bound-function-with-parameters/output.json
+++ b/test/examples/bound-function-with-parameters/output.json
@@ -1,42 +1,57 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "(a, b) =>",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "(a, b) =>",
     "statements": [
       {
-        "type": "BoundFunction",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "(a, b) =>",
         "body": null,
+        "column": 1,
+        "line": 1,
         "parameters": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 2 ],
+            "data": "a",
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 5,
-            "range": [ 4, 5 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           }
-        ]
+        ],
+        "range": [
+          0,
+          9
+        ],
+        "raw": "(a, b) =>",
+        "type": "BoundFunction"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "(a, b) =>",
+  "type": "Program"
 }

--- a/test/examples/bound-generator-function/output.json
+++ b/test/examples/bound-generator-function/output.json
@@ -1,67 +1,68 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      10
+    ],
+    "raw": "=> yield 3",
+    "statements": [
+      {
+        "body": {
+          "column": 4,
+          "inline": true,
+          "line": 1,
+          "range": [
+            3,
+            10
+          ],
+          "raw": "yield 3",
+          "statements": [
+            {
+              "column": 4,
+              "expression": {
+                "column": 10,
+                "data": 3,
+                "line": 1,
+                "range": [
+                  9,
+                  10
+                ],
+                "raw": "3",
+                "type": "Int"
+              },
+              "line": 1,
+              "range": [
+                3,
+                10
+              ],
+              "raw": "yield 3",
+              "type": "Yield"
+            }
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          10
+        ],
+        "raw": "=> yield 3",
+        "type": "BoundGeneratorFunction"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     11
   ],
   "raw": "=> yield 3\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      10
-    ],
-    "statements": [
-      {
-        "type": "BoundGeneratorFunction",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          10
-        ],
-        "body": {
-          "type": "Block",
-          "line": 1,
-          "column": 4,
-          "range": [
-            3,
-            10
-          ],
-          "statements": [
-            {
-              "type": "Yield",
-              "line": 1,
-              "column": 4,
-              "range": [
-                3,
-                10
-              ],
-              "expression": {
-                "type": "Int",
-                "line": 1,
-                "column": 10,
-                "range": [
-                  9,
-                  10
-                ],
-                "data": 3,
-                "raw": "3"
-              },
-              "raw": "yield 3"
-            }
-          ],
-          "raw": "yield 3",
-          "inline": true
-        },
-        "parameters": [],
-        "raw": "=> yield 3"
-      }
-    ],
-    "raw": "=> yield 3"
-  }
+  "type": "Program"
 }

--- a/test/examples/break/output.json
+++ b/test/examples/break/output.json
@@ -1,55 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
+    "raw": "loop\n  break",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            7,
+            12
+          ],
+          "raw": "break",
+          "statements": [
+            {
+              "column": 3,
+              "line": 2,
+              "range": [
+                7,
+                12
+              ],
+              "raw": "break",
+              "type": "Break"
+            }
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "loop\n  break",
+        "type": "Loop"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     13
   ],
   "raw": "loop\n  break\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      12
-    ],
-    "statements": [
-      {
-        "type": "Loop",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          12
-        ],
-        "body": {
-          "type": "Block",
-          "line": 2,
-          "column": 3,
-          "range": [
-            7,
-            12
-          ],
-          "statements": [
-            {
-              "type": "Break",
-              "line": 2,
-              "column": 3,
-              "range": [
-                7,
-                12
-              ],
-              "raw": "break"
-            }
-          ],
-          "raw": "break",
-          "inline": false
-        },
-        "raw": "loop\n  break"
-      }
-    ],
-    "raw": "loop\n  break"
-  }
+  "type": "Program"
 }

--- a/test/examples/call-dynamic-member-access-result/output.json
+++ b/test/examples/call-dynamic-member-access-result/output.json
@@ -1,47 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "a[b]()\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
+    "raw": "a[b]()",
     "statements": [
       {
-        "type": "FunctionApplication",
-        "line": 1,
+        "arguments": [
+        ],
         "column": 1,
-        "range": [ 0, 6 ],
         "function": {
-          "type": "DynamicMemberAccessOp",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 4 ],
           "expression": {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
-            "range": [ 0, 1 ],
             "data": "a",
-            "raw": "a"
+            "line": 1,
+            "range": [
+              0,
+              1
+            ],
+            "raw": "a",
+            "type": "Identifier"
           },
           "indexingExpr": {
-            "type": "Identifier",
-            "line": 1,
             "column": 3,
-            "range": [ 2, 3 ],
             "data": "b",
-            "raw": "b"
+            "line": 1,
+            "range": [
+              2,
+              3
+            ],
+            "raw": "b",
+            "type": "Identifier"
           },
-          "raw": "a[b]"
+          "line": 1,
+          "range": [
+            0,
+            4
+          ],
+          "raw": "a[b]",
+          "type": "DynamicMemberAccessOp"
         },
-        "arguments": [],
-        "raw": "a[b]()"
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a[b]()",
+        "type": "FunctionApplication"
       }
     ],
-    "raw": "a[b]()"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "a[b]()\n",
+  "type": "Program"
 }

--- a/test/examples/chain-calls-with-parens/output.json
+++ b/test/examples/chain-calls-with-parens/output.json
@@ -1,158 +1,160 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      56
+    ],
+    "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
+    "statements": [
+      {
+        "arguments": [
+          {
+            "column": 15,
+            "expressions": [
+            ],
+            "line": 3,
+            "quasis": [
+              {
+                "column": 16,
+                "data": "MyCtrl",
+                "line": 3,
+                "range": [
+                  40,
+                  46
+                ],
+                "raw": "MyCtrl",
+                "type": "Quasi"
+              }
+            ],
+            "range": [
+              39,
+              47
+            ],
+            "raw": "'MyCtrl'",
+            "type": "String"
+          },
+          {
+            "column": 25,
+            "data": "MyCtrl",
+            "line": 3,
+            "range": [
+              49,
+              55
+            ],
+            "raw": "MyCtrl",
+            "type": "Identifier"
+          }
+        ],
+        "column": 1,
+        "function": {
+          "column": 1,
+          "expression": {
+            "arguments": [
+              {
+                "column": 11,
+                "expressions": [
+                ],
+                "line": 2,
+                "quasis": [
+                  {
+                    "column": 12,
+                    "data": "app",
+                    "line": 2,
+                    "range": [
+                      19,
+                      22
+                    ],
+                    "raw": "app",
+                    "type": "Quasi"
+                  }
+                ],
+                "range": [
+                  18,
+                  23
+                ],
+                "raw": "'app'",
+                "type": "String"
+              }
+            ],
+            "column": 1,
+            "function": {
+              "column": 1,
+              "expression": {
+                "column": 1,
+                "data": "angular",
+                "line": 1,
+                "range": [
+                  0,
+                  7
+                ],
+                "raw": "angular",
+                "type": "Identifier"
+              },
+              "line": 1,
+              "member": {
+                "column": 4,
+                "data": "module",
+                "line": 2,
+                "range": [
+                  11,
+                  17
+                ],
+                "raw": "module",
+                "type": "Identifier"
+              },
+              "range": [
+                0,
+                17
+              ],
+              "raw": "angular\n  .module",
+              "type": "MemberAccessOp"
+            },
+            "line": 1,
+            "range": [
+              0,
+              24
+            ],
+            "raw": "angular\n  .module('app')",
+            "type": "FunctionApplication"
+          },
+          "line": 1,
+          "member": {
+            "column": 4,
+            "data": "controller",
+            "line": 3,
+            "range": [
+              28,
+              38
+            ],
+            "raw": "controller",
+            "type": "Identifier"
+          },
+          "range": [
+            0,
+            38
+          ],
+          "raw": "angular\n  .module('app')\n  .controller",
+          "type": "MemberAccessOp"
+        },
+        "line": 1,
+        "range": [
+          0,
+          56
+        ],
+        "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
+        "type": "FunctionApplication"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     56
   ],
   "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      56
-    ],
-    "statements": [
-      {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          56
-        ],
-        "function": {
-          "type": "MemberAccessOp",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            38
-          ],
-          "expression": {
-            "type": "FunctionApplication",
-            "line": 1,
-            "column": 1,
-            "range": [
-              0,
-              24
-            ],
-            "function": {
-              "type": "MemberAccessOp",
-              "line": 1,
-              "column": 1,
-              "range": [
-                0,
-                17
-              ],
-              "expression": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 1,
-                "raw": "angular",
-                "range": [
-                  0,
-                  7
-                ],
-                "data": "angular"
-              },
-              "member": {
-                "type": "Identifier",
-                "line": 2,
-                "column": 4,
-                "raw": "module",
-                "range": [
-                  11,
-                  17
-                ],
-                "data": "module"
-              },
-              "raw": "angular\n  .module"
-            },
-            "arguments": [
-              {
-                "type": "String",
-                "line": 2,
-                "column": 11,
-                "raw": "'app'",
-                "range": [
-                  18,
-                  23
-                ],
-                "quasis": [
-                  {
-                    "type": "Quasi",
-                    "line": 2,
-                    "column": 12,
-                    "raw": "app",
-                    "range": [
-                      19,
-                      22
-                    ],
-                    "data": "app"
-                  }
-                ],
-                "expressions": []
-              }
-            ],
-            "raw": "angular\n  .module('app')"
-          },
-          "member": {
-            "type": "Identifier",
-            "line": 3,
-            "column": 4,
-            "raw": "controller",
-            "range": [
-              28,
-              38
-            ],
-            "data": "controller"
-          },
-          "raw": "angular\n  .module('app')\n  .controller"
-        },
-        "arguments": [
-          {
-            "type": "String",
-            "line": 3,
-            "column": 15,
-            "raw": "'MyCtrl'",
-            "range": [
-              39,
-              47
-            ],
-            "quasis": [
-              {
-                "type": "Quasi",
-                "line": 3,
-                "column": 16,
-                "raw": "MyCtrl",
-                "range": [
-                  40,
-                  46
-                ],
-                "data": "MyCtrl"
-              }
-            ],
-            "expressions": []
-          },
-          {
-            "type": "Identifier",
-            "line": 3,
-            "column": 25,
-            "raw": "MyCtrl",
-            "range": [
-              49,
-              55
-            ],
-            "data": "MyCtrl"
-          }
-        ],
-        "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)"
-      }
-    ],
-    "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)"
-  }
+  "type": "Program"
 }

--- a/test/examples/chain-calls-without-indent/output.json
+++ b/test/examples/chain-calls-without-indent/output.json
@@ -1,147 +1,149 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      40
+    ],
+    "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+    "statements": [
+      {
+        "arguments": [
+          {
+            "column": 8,
+            "expressions": [
+            ],
+            "line": 3,
+            "quasis": [
+              {
+                "column": 9,
+                "data": "bar",
+                "line": 3,
+                "range": [
+                  36,
+                  39
+                ],
+                "raw": "bar",
+                "type": "Quasi"
+              }
+            ],
+            "range": [
+              35,
+              40
+            ],
+            "raw": "'bar'",
+            "type": "String"
+          }
+        ],
+        "column": 1,
+        "function": {
+          "column": 1,
+          "expression": {
+            "arguments": [
+              {
+                "column": 8,
+                "expressions": [
+                ],
+                "line": 2,
+                "quasis": [
+                  {
+                    "column": 9,
+                    "data": "foo",
+                    "line": 2,
+                    "range": [
+                      23,
+                      26
+                    ],
+                    "raw": "foo",
+                    "type": "Quasi"
+                  }
+                ],
+                "range": [
+                  22,
+                  27
+                ],
+                "raw": "'foo'",
+                "type": "String"
+              }
+            ],
+            "column": 1,
+            "function": {
+              "column": 1,
+              "expression": {
+                "column": 1,
+                "data": "$stateProvider",
+                "line": 1,
+                "range": [
+                  0,
+                  14
+                ],
+                "raw": "$stateProvider",
+                "type": "Identifier"
+              },
+              "line": 1,
+              "member": {
+                "column": 2,
+                "data": "state",
+                "line": 2,
+                "range": [
+                  16,
+                  21
+                ],
+                "raw": "state",
+                "type": "Identifier"
+              },
+              "range": [
+                0,
+                21
+              ],
+              "raw": "$stateProvider\n.state",
+              "type": "MemberAccessOp"
+            },
+            "line": 1,
+            "range": [
+              0,
+              27
+            ],
+            "raw": "$stateProvider\n.state 'foo'",
+            "type": "FunctionApplication"
+          },
+          "line": 1,
+          "member": {
+            "column": 2,
+            "data": "state",
+            "line": 3,
+            "range": [
+              29,
+              34
+            ],
+            "raw": "state",
+            "type": "Identifier"
+          },
+          "range": [
+            0,
+            34
+          ],
+          "raw": "$stateProvider\n.state 'foo'\n.state",
+          "type": "MemberAccessOp"
+        },
+        "line": 1,
+        "range": [
+          0,
+          40
+        ],
+        "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+        "type": "FunctionApplication"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     40
   ],
   "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      40
-    ],
-    "statements": [
-      {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          40
-        ],
-        "function": {
-          "type": "MemberAccessOp",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            34
-          ],
-          "expression": {
-            "type": "FunctionApplication",
-            "line": 1,
-            "column": 1,
-            "range": [
-              0,
-              27
-            ],
-            "function": {
-              "type": "MemberAccessOp",
-              "line": 1,
-              "column": 1,
-              "range": [
-                0,
-                21
-              ],
-              "expression": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 1,
-                "raw": "$stateProvider",
-                "range": [
-                  0,
-                  14
-                ],
-                "data": "$stateProvider"
-              },
-              "member": {
-                "type": "Identifier",
-                "line": 2,
-                "column": 2,
-                "raw": "state",
-                "range": [
-                  16,
-                  21
-                ],
-                "data": "state"
-              },
-              "raw": "$stateProvider\n.state"
-            },
-            "arguments": [
-              {
-                "type": "String",
-                "line": 2,
-                "column": 8,
-                "raw": "'foo'",
-                "range": [
-                  22,
-                  27
-                ],
-                "quasis": [
-                  {
-                    "type": "Quasi",
-                    "line": 2,
-                    "column": 9,
-                    "raw": "foo",
-                    "range": [
-                      23,
-                      26
-                    ],
-                    "data": "foo"
-                  }
-                ],
-                "expressions": []
-              }
-            ],
-            "raw": "$stateProvider\n.state 'foo'"
-          },
-          "member": {
-            "type": "Identifier",
-            "line": 3,
-            "column": 2,
-            "raw": "state",
-            "range": [
-              29,
-              34
-            ],
-            "data": "state"
-          },
-          "raw": "$stateProvider\n.state 'foo'\n.state"
-        },
-        "arguments": [
-          {
-            "type": "String",
-            "line": 3,
-            "column": 8,
-            "raw": "'bar'",
-            "range": [
-              35,
-              40
-            ],
-            "quasis": [
-              {
-                "type": "Quasi",
-                "line": 3,
-                "column": 9,
-                "raw": "bar",
-                "range": [
-                  36,
-                  39
-                ],
-                "data": "bar"
-              }
-            ],
-            "expressions": []
-          }
-        ],
-        "raw": "$stateProvider\n.state 'foo'\n.state 'bar'"
-      }
-    ],
-    "raw": "$stateProvider\n.state 'foo'\n.state 'bar'"
-  }
+  "type": "Program"
 }

--- a/test/examples/chain-calls-without-parens/output.json
+++ b/test/examples/chain-calls-without-parens/output.json
@@ -1,147 +1,149 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      40
+    ],
+    "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+    "statements": [
+      {
+        "arguments": [
+          {
+            "column": 8,
+            "expressions": [
+            ],
+            "line": 3,
+            "quasis": [
+              {
+                "column": 9,
+                "data": "bar",
+                "line": 3,
+                "range": [
+                  36,
+                  39
+                ],
+                "raw": "bar",
+                "type": "Quasi"
+              }
+            ],
+            "range": [
+              35,
+              40
+            ],
+            "raw": "'bar'",
+            "type": "String"
+          }
+        ],
+        "column": 1,
+        "function": {
+          "column": 1,
+          "expression": {
+            "arguments": [
+              {
+                "column": 8,
+                "expressions": [
+                ],
+                "line": 2,
+                "quasis": [
+                  {
+                    "column": 9,
+                    "data": "foo",
+                    "line": 2,
+                    "range": [
+                      23,
+                      26
+                    ],
+                    "raw": "foo",
+                    "type": "Quasi"
+                  }
+                ],
+                "range": [
+                  22,
+                  27
+                ],
+                "raw": "'foo'",
+                "type": "String"
+              }
+            ],
+            "column": 1,
+            "function": {
+              "column": 1,
+              "expression": {
+                "column": 1,
+                "data": "$stateProvider",
+                "line": 1,
+                "range": [
+                  0,
+                  14
+                ],
+                "raw": "$stateProvider",
+                "type": "Identifier"
+              },
+              "line": 1,
+              "member": {
+                "column": 2,
+                "data": "state",
+                "line": 2,
+                "range": [
+                  16,
+                  21
+                ],
+                "raw": "state",
+                "type": "Identifier"
+              },
+              "range": [
+                0,
+                21
+              ],
+              "raw": "$stateProvider\n.state",
+              "type": "MemberAccessOp"
+            },
+            "line": 1,
+            "range": [
+              0,
+              27
+            ],
+            "raw": "$stateProvider\n.state 'foo'",
+            "type": "FunctionApplication"
+          },
+          "line": 1,
+          "member": {
+            "column": 2,
+            "data": "state",
+            "line": 3,
+            "range": [
+              29,
+              34
+            ],
+            "raw": "state",
+            "type": "Identifier"
+          },
+          "range": [
+            0,
+            34
+          ],
+          "raw": "$stateProvider\n.state 'foo'\n.state",
+          "type": "MemberAccessOp"
+        },
+        "line": 1,
+        "range": [
+          0,
+          40
+        ],
+        "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+        "type": "FunctionApplication"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     40
   ],
   "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      40
-    ],
-    "statements": [
-      {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          40
-        ],
-        "function": {
-          "type": "MemberAccessOp",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            34
-          ],
-          "expression": {
-            "type": "FunctionApplication",
-            "line": 1,
-            "column": 1,
-            "range": [
-              0,
-              27
-            ],
-            "function": {
-              "type": "MemberAccessOp",
-              "line": 1,
-              "column": 1,
-              "range": [
-                0,
-                21
-              ],
-              "expression": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 1,
-                "raw": "$stateProvider",
-                "range": [
-                  0,
-                  14
-                ],
-                "data": "$stateProvider"
-              },
-              "member": {
-                "type": "Identifier",
-                "line": 2,
-                "column": 2,
-                "raw": "state",
-                "range": [
-                  16,
-                  21
-                ],
-                "data": "state"
-              },
-              "raw": "$stateProvider\n.state"
-            },
-            "arguments": [
-              {
-                "type": "String",
-                "line": 2,
-                "column": 8,
-                "raw": "'foo'",
-                "range": [
-                  22,
-                  27
-                ],
-                "quasis": [
-                  {
-                    "type": "Quasi",
-                    "line": 2,
-                    "column": 9,
-                    "raw": "foo",
-                    "range": [
-                      23,
-                      26
-                    ],
-                    "data": "foo"
-                  }
-                ],
-                "expressions": []
-              }
-            ],
-            "raw": "$stateProvider\n.state 'foo'"
-          },
-          "member": {
-            "type": "Identifier",
-            "line": 3,
-            "column": 2,
-            "raw": "state",
-            "range": [
-              29,
-              34
-            ],
-            "data": "state"
-          },
-          "raw": "$stateProvider\n.state 'foo'\n.state"
-        },
-        "arguments": [
-          {
-            "type": "String",
-            "line": 3,
-            "column": 8,
-            "raw": "'bar'",
-            "range": [
-              35,
-              40
-            ],
-            "quasis": [
-              {
-                "type": "Quasi",
-                "line": 3,
-                "column": 9,
-                "raw": "bar",
-                "range": [
-                  36,
-                  39
-                ],
-                "data": "bar"
-              }
-            ],
-            "expressions": []
-          }
-        ],
-        "raw": "$stateProvider\n.state 'foo'\n.state 'bar'"
-      }
-    ],
-    "raw": "$stateProvider\n.state 'foo'\n.state 'bar'"
-  }
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-equals/output.json
+++ b/test/examples/chained-comparison-equals/output.json
@@ -1,85 +1,85 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    12
-  ],
-  "raw": "a == b == c\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       11
     ],
+    "raw": "a == b == c",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          11
-        ],
+        "line": 1,
         "operands": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
+            "data": "a",
+            "line": 1,
             "range": [
               0,
               1
             ],
-            "data": "a",
-            "raw": "a"
+            "raw": "a",
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 6,
+            "data": "b",
+            "line": 1,
             "range": [
               5,
               6
             ],
-            "data": "b",
-            "raw": "b"
+            "raw": "b",
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 11,
+            "data": "c",
+            "line": 1,
             "range": [
               10,
               11
             ],
-            "data": "c",
-            "raw": "c"
+            "raw": "c",
+            "type": "Identifier"
           }
         ],
         "operators": [
           {
             "operator": "==",
             "token": {
-              "type": 39,
+              "end": 4,
               "start": 2,
-              "end": 4
+              "type": 39
             }
           },
           {
             "operator": "==",
             "token": {
-              "type": 39,
+              "end": 9,
               "start": 7,
-              "end": 9
+              "type": 39
             }
           }
         ],
-        "raw": "a == b == c"
+        "range": [
+          0,
+          11
+        ],
+        "raw": "a == b == c",
+        "type": "ChainedComparisonOp"
       }
     ],
-    "raw": "a == b == c"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "a == b == c\n",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-extended/output.json
+++ b/test/examples/chained-comparison-extended/output.json
@@ -1,99 +1,123 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 17 ],
-  "raw": "a < b < c < d < e",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
     "raw": "a < b < c < d < e",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 17 ],
-        "raw": "a < b < c < d < e",
+        "line": 1,
         "operands": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
-            "range": [ 0, 1 ],
+            "data": "a",
+            "line": 1,
+            "range": [
+              0,
+              1
+            ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 5,
-            "range": [ 4, 5 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 9,
-            "range": [ 8, 9 ],
+            "data": "c",
+            "line": 1,
+            "range": [
+              8,
+              9
+            ],
             "raw": "c",
-            "data": "c"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 13,
-            "range": [ 12, 13 ],
+            "data": "d",
+            "line": 1,
+            "range": [
+              12,
+              13
+            ],
             "raw": "d",
-            "data": "d"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 17,
-            "range": [ 16, 17 ],
+            "data": "e",
+            "line": 1,
+            "range": [
+              16,
+              17
+            ],
             "raw": "e",
-            "data": "e"
+            "type": "Identifier"
           }
         ],
         "operators": [
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 3,
               "start": 2,
-              "end": 3
+              "type": 39
             }
           },
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 7,
               "start": 6,
-              "end": 7
+              "type": 39
             }
           },
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 11,
               "start": 10,
-              "end": 11
+              "type": 39
             }
           },
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 15,
               "start": 14,
-              "end": 15
+              "type": 39
             }
           }
-        ]
+        ],
+        "range": [
+          0,
+          17
+        ],
+        "raw": "a < b < c < d < e",
+        "type": "ChainedComparisonOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "a < b < c < d < e",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-greater-than/output.json
+++ b/test/examples/chained-comparison-greater-than/output.json
@@ -1,67 +1,85 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "a > b > c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "a > b > c",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "a > b > c",
+        "line": 1,
         "operands": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
-            "range": [ 0, 1 ],
+            "data": "a",
+            "line": 1,
+            "range": [
+              0,
+              1
+            ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 5,
-            "range": [ 4, 5 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 9,
-            "range": [ 8, 9 ],
+            "data": "c",
+            "line": 1,
+            "range": [
+              8,
+              9
+            ],
             "raw": "c",
-            "data": "c"
+            "type": "Identifier"
           }
         ],
         "operators": [
           {
             "operator": ">",
             "token": {
-              "type": 39,
+              "end": 3,
               "start": 2,
-              "end": 3
+              "type": 39
             }
           },
           {
             "operator": ">",
             "token": {
-              "type": 39,
+              "end": 7,
               "start": 6,
-              "end": 7
+              "type": 39
             }
           }
-        ]
+        ],
+        "range": [
+          0,
+          9
+        ],
+        "raw": "a > b > c",
+        "type": "ChainedComparisonOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "a > b > c",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-less-than/output.json
+++ b/test/examples/chained-comparison-less-than/output.json
@@ -1,67 +1,85 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "a < b < c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "a < b < c",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "a < b < c",
+        "line": 1,
         "operands": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
-            "range": [ 0, 1 ],
+            "data": "a",
+            "line": 1,
+            "range": [
+              0,
+              1
+            ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 5,
-            "range": [ 4, 5 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 9,
-            "range": [ 8, 9 ],
+            "data": "c",
+            "line": 1,
+            "range": [
+              8,
+              9
+            ],
             "raw": "c",
-            "data": "c"
+            "type": "Identifier"
           }
         ],
         "operators": [
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 3,
               "start": 2,
-              "end": 3
+              "type": 39
             }
           },
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 7,
               "start": 6,
-              "end": 7
+              "type": 39
             }
           }
-        ]
+        ],
+        "range": [
+          0,
+          9
+        ],
+        "raw": "a < b < c",
+        "type": "ChainedComparisonOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "a < b < c",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-mixed/output.json
+++ b/test/examples/chained-comparison-mixed/output.json
@@ -1,67 +1,85 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "a < b > c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "a < b > c",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "a < b > c",
+        "line": 1,
         "operands": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
-            "range": [ 0, 1 ],
+            "data": "a",
+            "line": 1,
+            "range": [
+              0,
+              1
+            ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 5,
-            "range": [ 4, 5 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 9,
-            "range": [ 8, 9 ],
+            "data": "c",
+            "line": 1,
+            "range": [
+              8,
+              9
+            ],
             "raw": "c",
-            "data": "c"
+            "type": "Identifier"
           }
         ],
         "operators": [
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 3,
               "start": 2,
-              "end": 3
+              "type": 39
             }
           },
           {
             "operator": ">",
             "token": {
-              "type": 39,
+              "end": 7,
               "start": 6,
-              "end": 7
+              "type": 39
             }
           }
-        ]
+        ],
+        "range": [
+          0,
+          9
+        ],
+        "raw": "a < b > c",
+        "type": "ChainedComparisonOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "a < b > c",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-nested/output.json
+++ b/test/examples/chained-comparison-nested/output.json
@@ -1,137 +1,137 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    24
-  ],
-  "raw": "(a == b == c) == d == e\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       23
     ],
+    "raw": "(a == b == c) == d == e",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          23
-        ],
+        "line": 1,
         "operands": [
           {
-            "type": "ChainedComparisonOp",
-            "line": 1,
             "column": 2,
-            "range": [
-              1,
-              12
-            ],
+            "line": 1,
             "operands": [
               {
-                "type": "Identifier",
-                "line": 1,
                 "column": 2,
+                "data": "a",
+                "line": 1,
                 "range": [
                   1,
                   2
                 ],
                 "raw": "a",
-                "data": "a"
+                "type": "Identifier"
               },
               {
-                "type": "Identifier",
-                "line": 1,
                 "column": 7,
+                "data": "b",
+                "line": 1,
                 "range": [
                   6,
                   7
                 ],
                 "raw": "b",
-                "data": "b"
+                "type": "Identifier"
               },
               {
-                "type": "Identifier",
-                "line": 1,
                 "column": 12,
+                "data": "c",
+                "line": 1,
                 "range": [
                   11,
                   12
                 ],
                 "raw": "c",
-                "data": "c"
+                "type": "Identifier"
               }
             ],
             "operators": [
               {
                 "operator": "==",
                 "token": {
-                  "type": 39,
+                  "end": 5,
                   "start": 3,
-                  "end": 5
+                  "type": 39
                 }
               },
               {
                 "operator": "==",
                 "token": {
-                  "type": 39,
+                  "end": 10,
                   "start": 8,
-                  "end": 10
+                  "type": 39
                 }
               }
             ],
-            "raw": "a == b == c"
+            "range": [
+              1,
+              12
+            ],
+            "raw": "a == b == c",
+            "type": "ChainedComparisonOp"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 18,
+            "data": "d",
+            "line": 1,
             "range": [
               17,
               18
             ],
             "raw": "d",
-            "data": "d"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 23,
+            "data": "e",
+            "line": 1,
             "range": [
               22,
               23
             ],
             "raw": "e",
-            "data": "e"
+            "type": "Identifier"
           }
         ],
         "operators": [
           {
             "operator": "==",
             "token": {
-              "type": 39,
+              "end": 16,
               "start": 14,
-              "end": 16
+              "type": 39
             }
           },
           {
             "operator": "==",
             "token": {
-              "type": 39,
+              "end": 21,
               "start": 19,
-              "end": 21
+              "type": 39
             }
           }
         ],
-        "raw": "(a == b == c) == d == e"
+        "range": [
+          0,
+          23
+        ],
+        "raw": "(a == b == c) == d == e",
+        "type": "ChainedComparisonOp"
       }
     ],
-    "raw": "(a == b == c) == d == e"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    24
+  ],
+  "raw": "(a == b == c) == d == e\n",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-not-equal/output.json
+++ b/test/examples/chained-comparison-not-equal/output.json
@@ -1,85 +1,85 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    12
-  ],
-  "raw": "a != b != c\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       11
     ],
+    "raw": "a != b != c",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          11
-        ],
+        "line": 1,
         "operands": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
+            "data": "a",
+            "line": 1,
             "range": [
               0,
               1
             ],
-            "data": "a",
-            "raw": "a"
+            "raw": "a",
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 6,
+            "data": "b",
+            "line": 1,
             "range": [
               5,
               6
             ],
-            "data": "b",
-            "raw": "b"
+            "raw": "b",
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 11,
+            "data": "c",
+            "line": 1,
             "range": [
               10,
               11
             ],
-            "data": "c",
-            "raw": "c"
+            "raw": "c",
+            "type": "Identifier"
           }
         ],
         "operators": [
           {
             "operator": "!=",
             "token": {
-              "type": 39,
+              "end": 4,
               "start": 2,
-              "end": 4
+              "type": 39
             }
           },
           {
             "operator": "!=",
             "token": {
-              "type": 39,
+              "end": 9,
               "start": 7,
-              "end": 9
+              "type": 39
             }
           }
         ],
-        "raw": "a != b != c"
+        "range": [
+          0,
+          11
+        ],
+        "raw": "a != b != c",
+        "type": "ChainedComparisonOp"
       }
     ],
-    "raw": "a != b != c"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "a != b != c\n",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-three/output.json
+++ b/test/examples/chained-comparison-three/output.json
@@ -1,104 +1,104 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    17
-  ],
-  "raw": "a == b == c == d\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       16
     ],
+    "raw": "a == b == c == d",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          16
-        ],
+        "line": 1,
         "operands": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
+            "data": "a",
+            "line": 1,
             "range": [
               0,
               1
             ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 6,
+            "data": "b",
+            "line": 1,
             "range": [
               5,
               6
             ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 11,
+            "data": "c",
+            "line": 1,
             "range": [
               10,
               11
             ],
             "raw": "c",
-            "data": "c"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 16,
+            "data": "d",
+            "line": 1,
             "range": [
               15,
               16
             ],
             "raw": "d",
-            "data": "d"
+            "type": "Identifier"
           }
         ],
         "operators": [
           {
             "operator": "==",
             "token": {
-              "type": 39,
+              "end": 4,
               "start": 2,
-              "end": 4
+              "type": 39
             }
           },
           {
             "operator": "==",
             "token": {
-              "type": 39,
+              "end": 9,
               "start": 7,
-              "end": 9
+              "type": 39
             }
           },
           {
             "operator": "==",
             "token": {
-              "type": 39,
+              "end": 14,
               "start": 12,
-              "end": 14
+              "type": 39
             }
           }
         ],
-        "raw": "a == b == c == d"
+        "range": [
+          0,
+          16
+        ],
+        "raw": "a == b == c == d",
+        "type": "ChainedComparisonOp"
       }
     ],
-    "raw": "a == b == c == d"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "a == b == c == d\n",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-with-increment/output.json
+++ b/test/examples/chained-comparison-with-increment/output.json
@@ -1,95 +1,95 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    8
-  ],
-  "raw": "0<++c<2\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       7
     ],
+    "raw": "0<++c<2",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          7
-        ],
+        "line": 1,
         "operands": [
           {
-            "type": "Int",
-            "line": 1,
             "column": 1,
+            "data": 0,
+            "line": 1,
             "range": [
               0,
               1
             ],
             "raw": "0",
-            "data": 0
+            "type": "Int"
           },
           {
-            "type": "PreIncrementOp",
-            "line": 1,
             "column": 3,
-            "range": [
-              2,
-              5
-            ],
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 5,
+              "data": "c",
+              "line": 1,
               "range": [
                 4,
                 5
               ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             },
-            "raw": "++c"
+            "line": 1,
+            "range": [
+              2,
+              5
+            ],
+            "raw": "++c",
+            "type": "PreIncrementOp"
           },
           {
-            "type": "Int",
-            "line": 1,
             "column": 7,
+            "data": 2,
+            "line": 1,
             "range": [
               6,
               7
             ],
             "raw": "2",
-            "data": 2
+            "type": "Int"
           }
         ],
         "operators": [
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 2,
               "start": 1,
-              "end": 2
+              "type": 39
             }
           },
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 6,
               "start": 5,
-              "end": 6
+              "type": 39
             }
           }
         ],
-        "raw": "0<++c<2"
+        "range": [
+          0,
+          7
+        ],
+        "raw": "0<++c<2",
+        "type": "ChainedComparisonOp"
       }
     ],
-    "raw": "0<++c<2"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    8
+  ],
+  "raw": "0<++c<2\n",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-with-other-operators/output.json
+++ b/test/examples/chained-comparison-with-other-operators/output.json
@@ -1,190 +1,190 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    32
-  ],
-  "raw": "Math.PI/2 < angle < 3*Math.PI/2\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       31
     ],
+    "raw": "Math.PI/2 < angle < 3*Math.PI/2",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          31
-        ],
+        "line": 1,
         "operands": [
           {
-            "type": "DivideOp",
-            "line": 1,
             "column": 1,
-            "range": [
-              0,
-              9
-            ],
             "left": {
-              "type": "MemberAccessOp",
-              "line": 1,
               "column": 1,
-              "range": [
-                0,
-                7
-              ],
               "expression": {
-                "type": "Identifier",
-                "line": 1,
                 "column": 1,
-                "raw": "Math",
+                "data": "Math",
+                "line": 1,
                 "range": [
                   0,
                   4
                 ],
-                "data": "Math"
+                "raw": "Math",
+                "type": "Identifier"
               },
+              "line": 1,
               "member": {
-                "type": "Identifier",
-                "line": 1,
                 "column": 6,
-                "raw": "PI",
+                "data": "PI",
+                "line": 1,
                 "range": [
                   5,
                   7
                 ],
-                "data": "PI"
+                "raw": "PI",
+                "type": "Identifier"
               },
-              "raw": "Math.PI"
+              "range": [
+                0,
+                7
+              ],
+              "raw": "Math.PI",
+              "type": "MemberAccessOp"
             },
+            "line": 1,
+            "range": [
+              0,
+              9
+            ],
+            "raw": "Math.PI/2",
             "right": {
-              "type": "Int",
-              "line": 1,
               "column": 9,
-              "raw": "2",
+              "data": 2,
+              "line": 1,
               "range": [
                 8,
                 9
               ],
-              "data": 2
+              "raw": "2",
+              "type": "Int"
             },
-            "raw": "Math.PI/2"
+            "type": "DivideOp"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 13,
-            "raw": "angle",
+            "data": "angle",
+            "line": 1,
             "range": [
               12,
               17
             ],
-            "data": "angle"
+            "raw": "angle",
+            "type": "Identifier"
           },
           {
-            "type": "DivideOp",
-            "line": 1,
             "column": 21,
-            "range": [
-              20,
-              31
-            ],
             "left": {
-              "type": "MultiplyOp",
-              "line": 1,
               "column": 21,
-              "range": [
-                20,
-                29
-              ],
               "left": {
-                "type": "Int",
-                "line": 1,
                 "column": 21,
-                "raw": "3",
+                "data": 3,
+                "line": 1,
                 "range": [
                   20,
                   21
                 ],
-                "data": 3
+                "raw": "3",
+                "type": "Int"
               },
+              "line": 1,
+              "range": [
+                20,
+                29
+              ],
+              "raw": "3*Math.PI",
               "right": {
-                "type": "MemberAccessOp",
-                "line": 1,
                 "column": 23,
-                "range": [
-                  22,
-                  29
-                ],
                 "expression": {
-                  "type": "Identifier",
-                  "line": 1,
                   "column": 23,
-                  "raw": "Math",
+                  "data": "Math",
+                  "line": 1,
                   "range": [
                     22,
                     26
                   ],
-                  "data": "Math"
+                  "raw": "Math",
+                  "type": "Identifier"
                 },
+                "line": 1,
                 "member": {
-                  "type": "Identifier",
-                  "line": 1,
                   "column": 28,
-                  "raw": "PI",
+                  "data": "PI",
+                  "line": 1,
                   "range": [
                     27,
                     29
                   ],
-                  "data": "PI"
+                  "raw": "PI",
+                  "type": "Identifier"
                 },
-                "raw": "Math.PI"
+                "range": [
+                  22,
+                  29
+                ],
+                "raw": "Math.PI",
+                "type": "MemberAccessOp"
               },
-              "raw": "3*Math.PI"
+              "type": "MultiplyOp"
             },
+            "line": 1,
+            "range": [
+              20,
+              31
+            ],
+            "raw": "3*Math.PI/2",
             "right": {
-              "type": "Int",
-              "line": 1,
               "column": 31,
-              "raw": "2",
+              "data": 2,
+              "line": 1,
               "range": [
                 30,
                 31
               ],
-              "data": 2
+              "raw": "2",
+              "type": "Int"
             },
-            "raw": "3*Math.PI/2"
+            "type": "DivideOp"
           }
         ],
         "operators": [
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 11,
               "start": 10,
-              "end": 11
+              "type": 39
             }
           },
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 19,
               "start": 18,
-              "end": 19
+              "type": 39
             }
           }
         ],
-        "raw": "Math.PI/2 < angle < 3*Math.PI/2"
+        "range": [
+          0,
+          31
+        ],
+        "raw": "Math.PI/2 < angle < 3*Math.PI/2",
+        "type": "ChainedComparisonOp"
       }
     ],
-    "raw": "Math.PI/2 < angle < 3*Math.PI/2"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    32
+  ],
+  "raw": "Math.PI/2 < angle < 3*Math.PI/2\n",
+  "type": "Program"
 }

--- a/test/examples/chained-comparison-with-unary-negate/output.json
+++ b/test/examples/chained-comparison-with-unary-negate/output.json
@@ -1,95 +1,95 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    11
-  ],
-  "raw": "-1 < 0 < 1\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       10
     ],
+    "raw": "-1 < 0 < 1",
     "statements": [
       {
-        "type": "ChainedComparisonOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          10
-        ],
+        "line": 1,
         "operands": [
           {
-            "type": "UnaryNegateOp",
-            "line": 1,
             "column": 1,
-            "range": [
-              0,
-              2
-            ],
             "expression": {
-              "type": "Int",
-              "line": 1,
               "column": 2,
+              "data": 1,
+              "line": 1,
               "range": [
                 1,
                 2
               ],
               "raw": "1",
-              "data": 1
+              "type": "Int"
             },
-            "raw": "-1"
+            "line": 1,
+            "range": [
+              0,
+              2
+            ],
+            "raw": "-1",
+            "type": "UnaryNegateOp"
           },
           {
-            "type": "Int",
-            "line": 1,
             "column": 6,
+            "data": 0,
+            "line": 1,
             "range": [
               5,
               6
             ],
             "raw": "0",
-            "data": 0
+            "type": "Int"
           },
           {
-            "type": "Int",
-            "line": 1,
             "column": 10,
+            "data": 1,
+            "line": 1,
             "range": [
               9,
               10
             ],
             "raw": "1",
-            "data": 1
+            "type": "Int"
           }
         ],
         "operators": [
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 4,
               "start": 3,
-              "end": 4
+              "type": 39
             }
           },
           {
             "operator": "<",
             "token": {
-              "type": 39,
+              "end": 8,
               "start": 7,
-              "end": 8
+              "type": 39
             }
           }
         ],
-        "raw": "-1 < 0 < 1"
+        "range": [
+          0,
+          10
+        ],
+        "raw": "-1 < 0 < 1",
+        "type": "ChainedComparisonOp"
       }
     ],
-    "raw": "-1 < 0 < 1"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    11
+  ],
+  "raw": "-1 < 0 < 1\n",
+  "type": "Program"
 }

--- a/test/examples/chained-prototype-member-access/output.json
+++ b/test/examples/chained-prototype-member-access/output.json
@@ -1,116 +1,116 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    38
-  ],
-  "raw": "Object::toString.constructor::valueOf\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       37
     ],
+    "raw": "Object::toString.constructor::valueOf",
     "statements": [
       {
-        "type": "MemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          37
-        ],
-        "raw": "Object::toString.constructor::valueOf",
         "expression": {
-          "type": "ProtoMemberAccessOp",
-          "line": 1,
           "column": 1,
-          "range": [
-            0,
-            30
-          ],
-          "raw": "Object::toString.constructor::",
           "expression": {
-            "type": "MemberAccessOp",
-            "line": 1,
             "column": 1,
-            "range": [
-              0,
-              28
-            ],
-            "raw": "Object::toString.constructor",
             "expression": {
-              "type": "MemberAccessOp",
-              "line": 1,
               "column": 1,
-              "range": [
-                0,
-                16
-              ],
-              "raw": "Object::toString",
               "expression": {
-                "type": "ProtoMemberAccessOp",
-                "line": 1,
                 "column": 1,
-                "range": [
-                  0,
-                  8
-                ],
-                "raw": "Object::",
                 "expression": {
-                  "type": "Identifier",
-                  "line": 1,
                   "column": 1,
+                  "data": "Object",
+                  "line": 1,
                   "range": [
                     0,
                     6
                   ],
                   "raw": "Object",
-                  "data": "Object"
-                }
-              },
-              "member": {
-                "type": "Identifier",
+                  "type": "Identifier"
+                },
                 "line": 1,
+                "range": [
+                  0,
+                  8
+                ],
+                "raw": "Object::",
+                "type": "ProtoMemberAccessOp"
+              },
+              "line": 1,
+              "member": {
                 "column": 9,
+                "data": "toString",
+                "line": 1,
                 "range": [
                   8,
                   16
                 ],
                 "raw": "toString",
-                "data": "toString"
-              }
+                "type": "Identifier"
+              },
+              "range": [
+                0,
+                16
+              ],
+              "raw": "Object::toString",
+              "type": "MemberAccessOp"
             },
+            "line": 1,
             "member": {
-              "type": "Identifier",
-              "line": 1,
               "column": 18,
+              "data": "constructor",
+              "line": 1,
               "range": [
                 17,
                 28
               ],
               "raw": "constructor",
-              "data": "constructor"
-            }
-          }
-        },
-        "member": {
-          "type": "Identifier",
+              "type": "Identifier"
+            },
+            "range": [
+              0,
+              28
+            ],
+            "raw": "Object::toString.constructor",
+            "type": "MemberAccessOp"
+          },
           "line": 1,
+          "range": [
+            0,
+            30
+          ],
+          "raw": "Object::toString.constructor::",
+          "type": "ProtoMemberAccessOp"
+        },
+        "line": 1,
+        "member": {
           "column": 31,
+          "data": "valueOf",
+          "line": 1,
           "range": [
             30,
             37
           ],
           "raw": "valueOf",
-          "data": "valueOf"
-        }
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          37
+        ],
+        "raw": "Object::toString.constructor::valueOf",
+        "type": "MemberAccessOp"
       }
     ],
-    "raw": "Object::toString.constructor::valueOf"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    38
+  ],
+  "raw": "Object::toString.constructor::valueOf\n",
+  "type": "Program"
 }

--- a/test/examples/class-extends/output.json
+++ b/test/examples/class-extends/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 11 ],
-  "raw": "A extends B",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 11 ],
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
     "raw": "A extends B",
     "statements": [
       {
-        "type": "ExtendsOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 11 ],
-        "raw": "A extends B",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "A",
-          "data": "A"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "A",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          11
+        ],
+        "raw": "A extends B",
+        "right": {
           "column": 11,
-          "range": [ 10, 11 ],
+          "data": "B",
+          "line": 1,
+          "range": [
+            10,
+            11
+          ],
           "raw": "B",
-          "data": "B"
-        }
+          "type": "Identifier"
+        },
+        "type": "ExtendsOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    11
+  ],
+  "raw": "A extends B",
+  "type": "Program"
 }

--- a/test/examples/class-member-with-block-comment/output.json
+++ b/test/examples/class-member-with-block-comment/output.json
@@ -1,103 +1,105 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    39
-  ],
-  "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       39
     ],
+    "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          39
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            9
-          ],
-          "raw": "Foo",
-          "data": "Foo"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            9
-          ],
-          "raw": "Foo",
-          "data": "Foo"
-        },
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
+          "inline": false,
+          "line": 2,
           "range": [
             12,
             39
           ],
+          "raw": "###\n  # foo\n  ###\n  foo: ->",
           "statements": [
             {
-              "type": "ClassProtoAssignOp",
-              "line": 5,
-              "column": 3,
-              "range": [
-                32,
-                39
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 5,
                 "column": 3,
+                "data": "foo",
+                "line": 5,
                 "range": [
                   32,
                   35
                 ],
                 "raw": "foo",
-                "data": "foo"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "Function",
-                "line": 5,
+                "body": null,
                 "column": 8,
+                "line": 5,
+                "parameters": [
+                ],
                 "range": [
                   37,
                   39
                 ],
-                "body": null,
-                "parameters": [],
-                "raw": "->"
+                "raw": "->",
+                "type": "Function"
               },
-              "raw": "foo: ->"
+              "line": 5,
+              "range": [
+                32,
+                39
+              ],
+              "raw": "foo: ->",
+              "type": "ClassProtoAssignOp"
             }
           ],
-          "inline": false,
-          "raw": "###\n  # foo\n  ###\n  foo: ->"
+          "type": "Block"
         },
-        "boundMembers": [],
-        "parent": null,
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": null,
-        "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->"
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "Foo",
+          "line": 1,
+          "range": [
+            6,
+            9
+          ],
+          "raw": "Foo",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "Foo",
+          "line": 1,
+          "range": [
+            6,
+            9
+          ],
+          "raw": "Foo",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          39
+        ],
+        "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->",
+        "type": "Class"
       }
     ],
-    "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    39
+  ],
+  "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->",
+  "type": "Program"
 }

--- a/test/examples/class-super-call/output.json
+++ b/test/examples/class-super-call/output.json
@@ -1,278 +1,282 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    76
-  ],
-  "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       76
     ],
+    "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          76
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            9
-          ],
-          "raw": "Foo",
-          "data": "Foo"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            9
-          ],
-          "raw": "Foo",
-          "data": "Foo"
-        },
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
+          "inline": false,
+          "line": 2,
           "range": [
             24,
             76
           ],
+          "raw": "constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
           "statements": [
             {
-              "type": "Constructor",
-              "line": 2,
-              "column": 3,
-              "range": [
-                24,
-                49
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 2,
                 "column": 3,
+                "data": "constructor",
+                "line": 2,
                 "range": [
                   24,
                   35
                 ],
                 "raw": "constructor",
-                "data": "constructor"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "Function",
-                "line": 2,
-                "column": 16,
-                "range": [
-                  37,
-                  49
-                ],
                 "body": {
-                  "type": "Block",
-                  "line": 3,
                   "column": 5,
+                  "inline": false,
+                  "line": 3,
                   "range": [
                     44,
                     49
                   ],
+                  "raw": "super",
                   "statements": [
                     {
-                      "type": "BareSuperFunctionApplication",
-                      "line": 3,
                       "column": 5,
+                      "line": 3,
                       "range": [
                         44,
                         49
                       ],
-                      "raw": "super"
+                      "raw": "super",
+                      "type": "BareSuperFunctionApplication"
                     }
                   ],
-                  "raw": "super",
-                  "inline": false
+                  "type": "Block"
                 },
-                "parameters": [],
-                "raw": "->\n    super"
+                "column": 16,
+                "line": 2,
+                "parameters": [
+                ],
+                "range": [
+                  37,
+                  49
+                ],
+                "raw": "->\n    super",
+                "type": "Function"
               },
-              "raw": "constructor: ->\n    super"
+              "line": 2,
+              "range": [
+                24,
+                49
+              ],
+              "raw": "constructor: ->\n    super",
+              "type": "Constructor"
             },
             {
-              "type": "ClassProtoAssignOp",
-              "line": 5,
-              "column": 3,
-              "range": [
-                53,
-                76
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 5,
                 "column": 3,
+                "data": "foo",
+                "line": 5,
                 "range": [
                   53,
                   56
                 ],
                 "raw": "foo",
-                "data": "foo"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "Function",
-                "line": 5,
-                "column": 8,
-                "range": [
-                  58,
-                  76
-                ],
                 "body": {
-                  "type": "Block",
-                  "line": 6,
                   "column": 5,
+                  "inline": false,
+                  "line": 6,
                   "range": [
                     65,
                     76
                   ],
+                  "raw": "super(1, 2)",
                   "statements": [
                     {
-                      "type": "FunctionApplication",
-                      "line": 6,
-                      "column": 5,
-                      "range": [
-                        65,
-                        76
-                      ],
-                      "function": {
-                        "type": "Super",
-                        "line": 6,
-                        "column": 5,
-                        "range": [
-                          65,
-                          70
-                        ],
-                        "raw": "super"
-                      },
                       "arguments": [
                         {
-                          "type": "Int",
-                          "line": 6,
                           "column": 11,
+                          "data": 1,
+                          "line": 6,
                           "range": [
                             71,
                             72
                           ],
                           "raw": "1",
-                          "data": 1
+                          "type": "Int"
                         },
                         {
-                          "type": "Int",
-                          "line": 6,
                           "column": 14,
+                          "data": 2,
+                          "line": 6,
                           "range": [
                             74,
                             75
                           ],
                           "raw": "2",
-                          "data": 2
+                          "type": "Int"
                         }
                       ],
-                      "raw": "super(1, 2)"
+                      "column": 5,
+                      "function": {
+                        "column": 5,
+                        "line": 6,
+                        "range": [
+                          65,
+                          70
+                        ],
+                        "raw": "super",
+                        "type": "Super"
+                      },
+                      "line": 6,
+                      "range": [
+                        65,
+                        76
+                      ],
+                      "raw": "super(1, 2)",
+                      "type": "FunctionApplication"
                     }
                   ],
-                  "raw": "super(1, 2)",
-                  "inline": false
+                  "type": "Block"
                 },
-                "parameters": [],
-                "raw": "->\n    super(1, 2)"
+                "column": 8,
+                "line": 5,
+                "parameters": [
+                ],
+                "range": [
+                  58,
+                  76
+                ],
+                "raw": "->\n    super(1, 2)",
+                "type": "Function"
               },
-              "raw": "foo: ->\n    super(1, 2)"
+              "line": 5,
+              "range": [
+                53,
+                76
+              ],
+              "raw": "foo: ->\n    super(1, 2)",
+              "type": "ClassProtoAssignOp"
             }
           ],
-          "inline": false,
-          "raw": "constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)"
+          "type": "Block"
         },
-        "boundMembers": [],
-        "parent": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 19,
-          "range": [
-            18,
-            21
-          ],
-          "raw": "Bar",
-          "data": "Bar"
-        },
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": {
-          "type": "Constructor",
-          "line": 2,
-          "column": 3,
-          "range": [
-            24,
-            49
-          ],
           "assignee": {
-            "type": "Identifier",
-            "line": 2,
             "column": 3,
+            "data": "constructor",
+            "line": 2,
             "range": [
               24,
               35
             ],
             "raw": "constructor",
-            "data": "constructor"
+            "type": "Identifier"
           },
+          "column": 3,
           "expression": {
-            "type": "Function",
-            "line": 2,
-            "column": 16,
-            "range": [
-              37,
-              49
-            ],
             "body": {
-              "type": "Block",
-              "line": 3,
               "column": 5,
+              "inline": false,
+              "line": 3,
               "range": [
                 44,
                 49
               ],
+              "raw": "super",
               "statements": [
                 {
-                  "type": "BareSuperFunctionApplication",
-                  "line": 3,
                   "column": 5,
+                  "line": 3,
                   "range": [
                     44,
                     49
                   ],
-                  "raw": "super"
+                  "raw": "super",
+                  "type": "BareSuperFunctionApplication"
                 }
               ],
-              "raw": "super",
-              "inline": false
+              "type": "Block"
             },
-            "parameters": [],
-            "raw": "->\n    super"
+            "column": 16,
+            "line": 2,
+            "parameters": [
+            ],
+            "range": [
+              37,
+              49
+            ],
+            "raw": "->\n    super",
+            "type": "Function"
           },
-          "raw": "constructor: ->\n    super"
+          "line": 2,
+          "range": [
+            24,
+            49
+          ],
+          "raw": "constructor: ->\n    super",
+          "type": "Constructor"
         },
-        "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)"
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "Foo",
+          "line": 1,
+          "range": [
+            6,
+            9
+          ],
+          "raw": "Foo",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "Foo",
+          "line": 1,
+          "range": [
+            6,
+            9
+          ],
+          "raw": "Foo",
+          "type": "Identifier"
+        },
+        "parent": {
+          "column": 19,
+          "data": "Bar",
+          "line": 1,
+          "range": [
+            18,
+            21
+          ],
+          "raw": "Bar",
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          76
+        ],
+        "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
+        "type": "Class"
       }
     ],
-    "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    76
+  ],
+  "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
+  "type": "Program"
 }

--- a/test/examples/class-with-body-statements/output.json
+++ b/test/examples/class-with-body-statements/output.json
@@ -1,134 +1,135 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    22
-  ],
-  "raw": "class A\n  a = 1\n  b: a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       22
     ],
+    "raw": "class A\n  a = 1\n  b: a",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          22
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "raw": "A",
-          "data": "A"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "raw": "A",
-          "data": "A"
-        },
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
+          "inline": false,
+          "line": 2,
           "range": [
             10,
             22
           ],
+          "raw": "a = 1\n  b: a",
           "statements": [
             {
-              "type": "AssignOp",
-              "line": 2,
-              "column": 3,
-              "range": [
-                10,
-                15
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 2,
                 "column": 3,
+                "data": "a",
+                "line": 2,
                 "range": [
                   10,
                   11
                 ],
                 "raw": "a",
-                "data": "a"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "Int",
-                "line": 2,
                 "column": 7,
+                "data": 1,
+                "line": 2,
                 "range": [
                   14,
                   15
                 ],
                 "raw": "1",
-                "data": 1
+                "type": "Int"
               },
-              "raw": "a = 1"
+              "line": 2,
+              "range": [
+                10,
+                15
+              ],
+              "raw": "a = 1",
+              "type": "AssignOp"
             },
             {
-              "type": "ClassProtoAssignOp",
-              "line": 3,
-              "column": 3,
-              "range": [
-                18,
-                22
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 3,
                 "column": 3,
+                "data": "b",
+                "line": 3,
                 "range": [
                   18,
                   19
                 ],
                 "raw": "b",
-                "data": "b"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "Identifier",
-                "line": 3,
                 "column": 6,
+                "data": "a",
+                "line": 3,
                 "range": [
                   21,
                   22
                 ],
                 "raw": "a",
-                "data": "a"
+                "type": "Identifier"
               },
-              "raw": "b: a"
+              "line": 3,
+              "range": [
+                18,
+                22
+              ],
+              "raw": "b: a",
+              "type": "ClassProtoAssignOp"
             }
           ],
-          "inline": false,
-          "raw": "a = 1\n  b: a"
+          "type": "Block"
         },
-        "boundMembers": [],
-        "parent": null,
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": null,
-        "raw": "class A\n  a = 1\n  b: a"
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          22
+        ],
+        "raw": "class A\n  a = 1\n  b: a",
+        "type": "Class"
       }
     ],
-    "raw": "class A\n  a = 1\n  b: a"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    22
+  ],
+  "raw": "class A\n  a = 1\n  b: a",
+  "type": "Program"
 }

--- a/test/examples/class-with-bound-methods/output.json
+++ b/test/examples/class-with-bound-methods/output.json
@@ -1,183 +1,185 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    17
-  ],
-  "raw": "class A\n  a: => b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       17
     ],
+    "raw": "class A\n  a: => b",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          17
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "raw": "A",
-          "data": "A"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "raw": "A",
-          "data": "A"
-        },
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
+          "inline": false,
+          "line": 2,
           "range": [
             10,
             17
           ],
+          "raw": "a: => b",
           "statements": [
             {
-              "type": "ClassProtoAssignOp",
-              "line": 2,
-              "column": 3,
-              "range": [
-                10,
-                17
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 2,
                 "column": 3,
+                "data": "a",
+                "line": 2,
                 "range": [
                   10,
                   11
                 ],
                 "raw": "a",
-                "data": "a"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "BoundFunction",
-                "line": 2,
-                "column": 6,
-                "range": [
-                  13,
-                  17
-                ],
                 "body": {
-                  "type": "Block",
-                  "line": 2,
                   "column": 9,
+                  "inline": true,
+                  "line": 2,
                   "range": [
                     16,
                     17
                   ],
+                  "raw": "b",
                   "statements": [
                     {
-                      "type": "Identifier",
-                      "line": 2,
                       "column": 9,
+                      "data": "b",
+                      "line": 2,
                       "range": [
                         16,
                         17
                       ],
                       "raw": "b",
-                      "data": "b"
+                      "type": "Identifier"
                     }
                   ],
-                  "raw": "b",
-                  "inline": true
+                  "type": "Block"
                 },
-                "parameters": [],
-                "raw": "=> b"
+                "column": 6,
+                "line": 2,
+                "parameters": [
+                ],
+                "range": [
+                  13,
+                  17
+                ],
+                "raw": "=> b",
+                "type": "BoundFunction"
               },
-              "raw": "a: => b"
+              "line": 2,
+              "range": [
+                10,
+                17
+              ],
+              "raw": "a: => b",
+              "type": "ClassProtoAssignOp"
             }
           ],
-          "inline": false,
-          "raw": "a: => b"
+          "type": "Block"
         },
         "boundMembers": [
           {
-            "type": "ClassProtoAssignOp",
-            "line": 2,
-            "column": 3,
-            "range": [
-              10,
-              17
-            ],
             "assignee": {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
+              "data": "a",
+              "line": 2,
               "range": [
                 10,
                 11
               ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             },
+            "column": 3,
             "expression": {
-              "type": "BoundFunction",
-              "line": 2,
-              "column": 6,
-              "range": [
-                13,
-                17
-              ],
               "body": {
-                "type": "Block",
-                "line": 2,
                 "column": 9,
+                "inline": true,
+                "line": 2,
                 "range": [
                   16,
                   17
                 ],
+                "raw": "b",
                 "statements": [
                   {
-                    "type": "Identifier",
-                    "line": 2,
                     "column": 9,
+                    "data": "b",
+                    "line": 2,
                     "range": [
                       16,
                       17
                     ],
                     "raw": "b",
-                    "data": "b"
+                    "type": "Identifier"
                   }
                 ],
-                "raw": "b",
-                "inline": true
+                "type": "Block"
               },
-              "parameters": [],
-              "raw": "=> b"
+              "column": 6,
+              "line": 2,
+              "parameters": [
+              ],
+              "range": [
+                13,
+                17
+              ],
+              "raw": "=> b",
+              "type": "BoundFunction"
             },
-            "raw": "a: => b"
+            "line": 2,
+            "range": [
+              10,
+              17
+            ],
+            "raw": "a: => b",
+            "type": "ClassProtoAssignOp"
           }
         ],
-        "parent": null,
+        "column": 1,
         "ctor": null,
-        "raw": "class A\n  a: => b"
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          17
+        ],
+        "raw": "class A\n  a: => b",
+        "type": "Class"
       }
     ],
-    "raw": "class A\n  a: => b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "class A\n  a: => b",
+  "type": "Program"
 }

--- a/test/examples/class-with-constructor/output.json
+++ b/test/examples/class-with-constructor/output.json
@@ -1,261 +1,262 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    39
-  ],
-  "raw": "class Point\n  constructor: (@x, @y) ->\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       38
     ],
+    "raw": "class Point\n  constructor: (@x, @y) ->",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          38
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            11
-          ],
-          "raw": "Point",
-          "data": "Point"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            11
-          ],
-          "raw": "Point",
-          "data": "Point"
-        },
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
+          "inline": false,
+          "line": 2,
           "range": [
             14,
             38
           ],
+          "raw": "constructor: (@x, @y) ->",
           "statements": [
             {
-              "type": "Constructor",
-              "line": 2,
-              "column": 3,
-              "range": [
-                14,
-                38
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 2,
                 "column": 3,
+                "data": "constructor",
+                "line": 2,
                 "range": [
                   14,
                   25
                 ],
                 "raw": "constructor",
-                "data": "constructor"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "Function",
-                "line": 2,
-                "column": 16,
-                "range": [
-                  27,
-                  38
-                ],
                 "body": null,
+                "column": 16,
+                "line": 2,
                 "parameters": [
                   {
-                    "type": "MemberAccessOp",
-                    "line": 2,
                     "column": 17,
-                    "range": [
-                      28,
-                      30
-                    ],
                     "expression": {
-                      "type": "This",
-                      "line": 2,
                       "column": 17,
+                      "line": 2,
                       "range": [
                         28,
                         29
                       ],
-                      "raw": "@"
+                      "raw": "@",
+                      "type": "This"
                     },
+                    "line": 2,
                     "member": {
-                      "type": "Identifier",
-                      "line": 2,
                       "column": 18,
+                      "data": "x",
+                      "line": 2,
                       "range": [
                         29,
                         30
                       ],
                       "raw": "x",
-                      "data": "x"
+                      "type": "Identifier"
                     },
-                    "raw": "@x"
+                    "range": [
+                      28,
+                      30
+                    ],
+                    "raw": "@x",
+                    "type": "MemberAccessOp"
                   },
                   {
-                    "type": "MemberAccessOp",
-                    "line": 2,
                     "column": 21,
-                    "range": [
-                      32,
-                      34
-                    ],
                     "expression": {
-                      "type": "This",
-                      "line": 2,
                       "column": 21,
+                      "line": 2,
                       "range": [
                         32,
                         33
                       ],
-                      "raw": "@"
+                      "raw": "@",
+                      "type": "This"
                     },
+                    "line": 2,
                     "member": {
-                      "type": "Identifier",
-                      "line": 2,
                       "column": 22,
+                      "data": "y",
+                      "line": 2,
                       "range": [
                         33,
                         34
                       ],
                       "raw": "y",
-                      "data": "y"
+                      "type": "Identifier"
                     },
-                    "raw": "@y"
+                    "range": [
+                      32,
+                      34
+                    ],
+                    "raw": "@y",
+                    "type": "MemberAccessOp"
                   }
                 ],
-                "raw": "(@x, @y) ->"
+                "range": [
+                  27,
+                  38
+                ],
+                "raw": "(@x, @y) ->",
+                "type": "Function"
               },
-              "raw": "constructor: (@x, @y) ->"
+              "line": 2,
+              "range": [
+                14,
+                38
+              ],
+              "raw": "constructor: (@x, @y) ->",
+              "type": "Constructor"
             }
           ],
-          "inline": false,
-          "raw": "constructor: (@x, @y) ->"
+          "type": "Block"
         },
-        "boundMembers": [],
-        "parent": null,
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": {
-          "type": "Constructor",
-          "line": 2,
-          "column": 3,
-          "range": [
-            14,
-            38
-          ],
           "assignee": {
-            "type": "Identifier",
-            "line": 2,
             "column": 3,
+            "data": "constructor",
+            "line": 2,
             "range": [
               14,
               25
             ],
             "raw": "constructor",
-            "data": "constructor"
+            "type": "Identifier"
           },
+          "column": 3,
           "expression": {
-            "type": "Function",
-            "line": 2,
-            "column": 16,
-            "range": [
-              27,
-              38
-            ],
             "body": null,
+            "column": 16,
+            "line": 2,
             "parameters": [
               {
-                "type": "MemberAccessOp",
-                "line": 2,
                 "column": 17,
-                "range": [
-                  28,
-                  30
-                ],
                 "expression": {
-                  "type": "This",
-                  "line": 2,
                   "column": 17,
+                  "line": 2,
                   "range": [
                     28,
                     29
                   ],
-                  "raw": "@"
+                  "raw": "@",
+                  "type": "This"
                 },
+                "line": 2,
                 "member": {
-                  "type": "Identifier",
-                  "line": 2,
                   "column": 18,
+                  "data": "x",
+                  "line": 2,
                   "range": [
                     29,
                     30
                   ],
                   "raw": "x",
-                  "data": "x"
+                  "type": "Identifier"
                 },
-                "raw": "@x"
+                "range": [
+                  28,
+                  30
+                ],
+                "raw": "@x",
+                "type": "MemberAccessOp"
               },
               {
-                "type": "MemberAccessOp",
-                "line": 2,
                 "column": 21,
-                "range": [
-                  32,
-                  34
-                ],
                 "expression": {
-                  "type": "This",
-                  "line": 2,
                   "column": 21,
+                  "line": 2,
                   "range": [
                     32,
                     33
                   ],
-                  "raw": "@"
+                  "raw": "@",
+                  "type": "This"
                 },
+                "line": 2,
                 "member": {
-                  "type": "Identifier",
-                  "line": 2,
                   "column": 22,
+                  "data": "y",
+                  "line": 2,
                   "range": [
                     33,
                     34
                   ],
                   "raw": "y",
-                  "data": "y"
+                  "type": "Identifier"
                 },
-                "raw": "@y"
+                "range": [
+                  32,
+                  34
+                ],
+                "raw": "@y",
+                "type": "MemberAccessOp"
               }
             ],
-            "raw": "(@x, @y) ->"
+            "range": [
+              27,
+              38
+            ],
+            "raw": "(@x, @y) ->",
+            "type": "Function"
           },
-          "raw": "constructor: (@x, @y) ->"
+          "line": 2,
+          "range": [
+            14,
+            38
+          ],
+          "raw": "constructor: (@x, @y) ->",
+          "type": "Constructor"
         },
-        "raw": "class Point\n  constructor: (@x, @y) ->"
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "Point",
+          "line": 1,
+          "range": [
+            6,
+            11
+          ],
+          "raw": "Point",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "Point",
+          "line": 1,
+          "range": [
+            6,
+            11
+          ],
+          "raw": "Point",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          38
+        ],
+        "raw": "class Point\n  constructor: (@x, @y) ->",
+        "type": "Class"
       }
     ],
-    "raw": "class Point\n  constructor: (@x, @y) ->"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    39
+  ],
+  "raw": "class Point\n  constructor: (@x, @y) ->\n",
+  "type": "Program"
 }

--- a/test/examples/class-with-members/output.json
+++ b/test/examples/class-with-members/output.json
@@ -1,158 +1,160 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    24
-  ],
-  "raw": "class A\n  a: 1\n  b: -> 2",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       24
     ],
+    "raw": "class A\n  a: 1\n  b: -> 2",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          24
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "raw": "A",
-          "data": "A"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "raw": "A",
-          "data": "A"
-        },
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
+          "inline": false,
+          "line": 2,
           "range": [
             10,
             24
           ],
+          "raw": "a: 1\n  b: -> 2",
           "statements": [
             {
-              "type": "ClassProtoAssignOp",
-              "line": 2,
-              "column": 3,
-              "range": [
-                10,
-                14
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 2,
                 "column": 3,
+                "data": "a",
+                "line": 2,
                 "range": [
                   10,
                   11
                 ],
                 "raw": "a",
-                "data": "a"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "Int",
-                "line": 2,
                 "column": 6,
+                "data": 1,
+                "line": 2,
                 "range": [
                   13,
                   14
                 ],
                 "raw": "1",
-                "data": 1
+                "type": "Int"
               },
-              "raw": "a: 1"
+              "line": 2,
+              "range": [
+                10,
+                14
+              ],
+              "raw": "a: 1",
+              "type": "ClassProtoAssignOp"
             },
             {
-              "type": "ClassProtoAssignOp",
-              "line": 3,
-              "column": 3,
-              "range": [
-                17,
-                24
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 3,
                 "column": 3,
+                "data": "b",
+                "line": 3,
                 "range": [
                   17,
                   18
                 ],
                 "raw": "b",
-                "data": "b"
+                "type": "Identifier"
               },
+              "column": 3,
               "expression": {
-                "type": "Function",
-                "line": 3,
-                "column": 6,
-                "range": [
-                  20,
-                  24
-                ],
                 "body": {
-                  "type": "Block",
-                  "line": 3,
                   "column": 9,
+                  "inline": true,
+                  "line": 3,
                   "range": [
                     23,
                     24
                   ],
+                  "raw": "2",
                   "statements": [
                     {
-                      "type": "Int",
-                      "line": 3,
                       "column": 9,
+                      "data": 2,
+                      "line": 3,
                       "range": [
                         23,
                         24
                       ],
                       "raw": "2",
-                      "data": 2
+                      "type": "Int"
                     }
                   ],
-                  "raw": "2",
-                  "inline": true
+                  "type": "Block"
                 },
-                "parameters": [],
-                "raw": "-> 2"
+                "column": 6,
+                "line": 3,
+                "parameters": [
+                ],
+                "range": [
+                  20,
+                  24
+                ],
+                "raw": "-> 2",
+                "type": "Function"
               },
-              "raw": "b: -> 2"
+              "line": 3,
+              "range": [
+                17,
+                24
+              ],
+              "raw": "b: -> 2",
+              "type": "ClassProtoAssignOp"
             }
           ],
-          "inline": false,
-          "raw": "a: 1\n  b: -> 2"
+          "type": "Block"
         },
-        "boundMembers": [],
-        "parent": null,
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": null,
-        "raw": "class A\n  a: 1\n  b: -> 2"
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          24
+        ],
+        "raw": "class A\n  a: 1\n  b: -> 2",
+        "type": "Class"
       }
     ],
-    "raw": "class A\n  a: 1\n  b: -> 2"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    24
+  ],
+  "raw": "class A\n  a: 1\n  b: -> 2",
+  "type": "Program"
 }

--- a/test/examples/class-with-parenthesized-value/output.json
+++ b/test/examples/class-with-parenthesized-value/output.json
@@ -1,102 +1,103 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      16
+    ],
+    "raw": "class A\n  b: (c)",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            10,
+            16
+          ],
+          "raw": "b: (c)",
+          "statements": [
+            {
+              "assignee": {
+                "column": 3,
+                "data": "b",
+                "line": 2,
+                "range": [
+                  10,
+                  11
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "column": 3,
+              "expression": {
+                "column": 7,
+                "data": "c",
+                "line": 2,
+                "range": [
+                  14,
+                  15
+                ],
+                "raw": "c",
+                "type": "Identifier"
+              },
+              "line": 2,
+              "range": [
+                10,
+                16
+              ],
+              "raw": "b: (c)",
+              "type": "ClassProtoAssignOp"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": null,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          16
+        ],
+        "raw": "class A\n  b: (c)",
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     17
   ],
   "raw": "class A\n  b: (c)\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      16
-    ],
-    "statements": [
-      {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          16
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "raw": "A",
-          "range": [
-            6,
-            7
-          ],
-          "data": "A"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "raw": "A",
-          "range": [
-            6,
-            7
-          ],
-          "data": "A"
-        },
-        "body": {
-          "type": "Block",
-          "line": 2,
-          "column": 3,
-          "range": [
-            10,
-            16
-          ],
-          "statements": [
-            {
-              "type": "ClassProtoAssignOp",
-              "line": 2,
-              "column": 3,
-              "range": [
-                10,
-                16
-              ],
-              "assignee": {
-                "type": "Identifier",
-                "line": 2,
-                "column": 3,
-                "raw": "b",
-                "range": [
-                  10,
-                  11
-                ],
-                "data": "b"
-              },
-              "expression": {
-                "type": "Identifier",
-                "line": 2,
-                "column": 7,
-                "raw": "c",
-                "range": [
-                  14,
-                  15
-                ],
-                "data": "c"
-              },
-              "raw": "b: (c)"
-            }
-          ],
-          "inline": false,
-          "raw": "b: (c)"
-        },
-        "boundMembers": [],
-        "parent": null,
-        "ctor": null,
-        "raw": "class A\n  b: (c)"
-      }
-    ],
-    "raw": "class A\n  b: (c)"
-  }
+  "type": "Program"
 }

--- a/test/examples/class-with-proto-access-name/output.json
+++ b/test/examples/class-with-proto-access-name/output.json
@@ -1,78 +1,79 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
+    "raw": "class A::",
+    "statements": [
+      {
+        "body": null,
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": null,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "expression": {
+            "column": 7,
+            "data": "A",
+            "line": 1,
+            "range": [
+              6,
+              7
+            ],
+            "raw": "A",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            6,
+            9
+          ],
+          "raw": "A::",
+          "type": "ProtoMemberAccessOp"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "expression": {
+            "column": 7,
+            "data": "A",
+            "line": 1,
+            "range": [
+              6,
+              7
+            ],
+            "raw": "A",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            6,
+            9
+          ],
+          "raw": "A::",
+          "type": "ProtoMemberAccessOp"
+        },
+        "parent": null,
+        "range": [
+          0,
+          9
+        ],
+        "raw": "class A::",
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     10
   ],
   "raw": "class A::\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      9
-    ],
-    "statements": [
-      {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          9
-        ],
-        "name": {
-          "type": "ProtoMemberAccessOp",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            9
-          ],
-          "expression": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 7,
-            "range": [
-              6,
-              7
-            ],
-            "raw": "A",
-            "data": "A"
-          },
-          "raw": "A::"
-        },
-        "nameAssignee": {
-          "type": "ProtoMemberAccessOp",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            9
-          ],
-          "expression": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 7,
-            "range": [
-              6,
-              7
-            ],
-            "raw": "A",
-            "data": "A"
-          },
-          "raw": "A::"
-        },
-        "body": null,
-        "boundMembers": [],
-        "parent": null,
-        "ctor": null,
-        "raw": "class A::"
-      }
-    ],
-    "raw": "class A::"
-  }
+  "type": "Program"
 }

--- a/test/examples/class-with-static-members/output.json
+++ b/test/examples/class-with-static-members/output.json
@@ -1,122 +1,123 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    15
-  ],
-  "raw": "class A\n  @b: c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       15
     ],
+    "raw": "class A\n  @b: c",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          15
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "raw": "A",
-          "data": "A"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "raw": "A",
-          "data": "A"
-        },
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
+          "inline": false,
+          "line": 2,
           "range": [
             10,
             15
           ],
+          "raw": "@b: c",
           "statements": [
             {
-              "type": "AssignOp",
-              "line": 2,
-              "column": 3,
-              "range": [
-                10,
-                15
-              ],
               "assignee": {
-                "type": "MemberAccessOp",
-                "line": 2,
                 "column": 3,
-                "range": [
-                  10,
-                  12
-                ],
                 "expression": {
-                  "type": "This",
-                  "line": 2,
                   "column": 3,
+                  "line": 2,
                   "range": [
                     10,
                     11
                   ],
-                  "raw": "@"
+                  "raw": "@",
+                  "type": "This"
                 },
+                "line": 2,
                 "member": {
-                  "type": "Identifier",
-                  "line": 2,
                   "column": 4,
+                  "data": "b",
+                  "line": 2,
                   "range": [
                     11,
                     12
                   ],
                   "raw": "b",
-                  "data": "b"
+                  "type": "Identifier"
                 },
-                "raw": "@b"
+                "range": [
+                  10,
+                  12
+                ],
+                "raw": "@b",
+                "type": "MemberAccessOp"
               },
+              "column": 3,
               "expression": {
-                "type": "Identifier",
-                "line": 2,
                 "column": 7,
+                "data": "c",
+                "line": 2,
                 "range": [
                   14,
                   15
                 ],
                 "raw": "c",
-                "data": "c"
+                "type": "Identifier"
               },
-              "raw": "@b: c"
+              "line": 2,
+              "range": [
+                10,
+                15
+              ],
+              "raw": "@b: c",
+              "type": "AssignOp"
             }
           ],
-          "inline": false,
-          "raw": "@b: c"
+          "type": "Block"
         },
-        "boundMembers": [],
-        "parent": null,
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": null,
-        "raw": "class A\n  @b: c"
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          15
+        ],
+        "raw": "class A\n  @b: c",
+        "type": "Class"
       }
     ],
-    "raw": "class A\n  @b: c"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    15
+  ],
+  "raw": "class A\n  @b: c",
+  "type": "Program"
 }

--- a/test/examples/comment-only-file/output.json
+++ b/test/examples/comment-only-file/output.json
@@ -1,11 +1,11 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": null,
   "column": 1,
-  "raw": "# Testing\n",
+  "line": 1,
   "range": [
     0,
     0
   ],
-  "body": null
+  "raw": "# Testing\n",
+  "type": "Program"
 }

--- a/test/examples/complex-template-literal/output.json
+++ b/test/examples/complex-template-literal/output.json
@@ -1,97 +1,15 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    22
-  ],
-  "raw": "\"#{}A#{} #{} #{}B#{}\"\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       21
     ],
+    "raw": "\"#{}A#{} #{} #{}B#{}\"",
     "statements": [
       {
-        "type": "String",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          21
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 5,
-            "raw": "A",
-            "range": [
-              4,
-              5
-            ],
-            "data": "A"
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 9,
-            "raw": " ",
-            "range": [
-              8,
-              9
-            ],
-            "data": " "
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 13,
-            "raw": " ",
-            "range": [
-              12,
-              13
-            ],
-            "data": " "
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 17,
-            "raw": "B",
-            "range": [
-              16,
-              17
-            ],
-            "data": "B"
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 21,
-            "raw": "",
-            "range": [
-              20,
-              20
-            ],
-            "data": ""
-          }
-        ],
         "expressions": [
           null,
           null,
@@ -99,9 +17,91 @@
           null,
           null
         ],
-        "raw": "\"#{}A#{} #{} #{}B#{}\""
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 5,
+            "data": "A",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
+            "raw": "A",
+            "type": "Quasi"
+          },
+          {
+            "column": 9,
+            "data": " ",
+            "line": 1,
+            "range": [
+              8,
+              9
+            ],
+            "raw": " ",
+            "type": "Quasi"
+          },
+          {
+            "column": 13,
+            "data": " ",
+            "line": 1,
+            "range": [
+              12,
+              13
+            ],
+            "raw": " ",
+            "type": "Quasi"
+          },
+          {
+            "column": 17,
+            "data": "B",
+            "line": 1,
+            "range": [
+              16,
+              17
+            ],
+            "raw": "B",
+            "type": "Quasi"
+          },
+          {
+            "column": 21,
+            "data": "",
+            "line": 1,
+            "range": [
+              20,
+              20
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          21
+        ],
+        "raw": "\"#{}A#{} #{} #{}B#{}\"",
+        "type": "String"
       }
     ],
-    "raw": "\"#{}A#{} #{} #{}B#{}\""
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    22
+  ],
+  "raw": "\"#{}A#{} #{} #{}B#{}\"\n",
+  "type": "Program"
 }

--- a/test/examples/compound-assignment-addition/output.json
+++ b/test/examples/compound-assignment-addition/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a += 1",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a += 1",
     "statements": [
       {
-        "type": "CompoundAssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a += 1",
         "assignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "expression": {
-          "type": "Int",
+          "data": "a",
           "line": 1,
-          "column": 6,
-          "range": [ 5, 6 ],
-          "raw": "1",
-          "data": 1
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
         },
-        "op": "PlusOp"
+        "column": 1,
+        "expression": {
+          "column": 6,
+          "data": 1,
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
+          "raw": "1",
+          "type": "Int"
+        },
+        "line": 1,
+        "op": "PlusOp",
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a += 1",
+        "type": "CompoundAssignOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a += 1",
+  "type": "Program"
 }

--- a/test/examples/compound-assignment-subtraction/output.json
+++ b/test/examples/compound-assignment-subtraction/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a -= b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a -= b",
     "statements": [
       {
-        "type": "CompoundAssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a -= b",
         "assignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "expression": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
-          "column": 6,
-          "range": [ 5, 6 ],
-          "raw": "b",
-          "data": "b"
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
         },
-        "op": "SubtractOp"
+        "column": 1,
+        "expression": {
+          "column": 6,
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "op": "SubtractOp",
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a -= b",
+        "type": "CompoundAssignOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a -= b",
+  "type": "Program"
 }

--- a/test/examples/conditional-empty-consequent-alternate/output.json
+++ b/test/examples/conditional-empty-consequent-alternate/output.json
@@ -1,61 +1,82 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 27 ],
-  "raw": "if false\nelse if false\nelse",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 27 ],
+    "line": 1,
+    "range": [
+      0,
+      27
+    ],
+    "raw": "if false\nelse if false\nelse",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 27 ],
-        "isUnless": false,
-        "condition": {
-          "type": "Bool",
-          "line": 1,
-          "column": 4,
-          "range": [ 3, 8 ],
-          "data": false,
-          "raw": "false"
-        },
-        "consequent": null,
         "alternate": {
-          "type": "Block",
-          "line": 2,
           "column": 6,
-          "range": [ 14, 27 ],
-          "statements": [
-            {
-              "type": "Conditional",
-              "line": 2,
-              "column": 6,
-              "range": [ 14, 27 ],
-              "isUnless": false,
-              "condition": {
-                "type": "Bool",
-                "line": 2,
-                "column": 9,
-                "range": [ 17, 22 ],
-                "data": false,
-                "raw": "false"
-              },
-              "consequent": null,
-              "alternate": null,
-              "raw": "if false\nelse"
-            }
+          "inline": true,
+          "line": 2,
+          "range": [
+            14,
+            27
           ],
           "raw": "if false\nelse",
-          "inline": true
+          "statements": [
+            {
+              "alternate": null,
+              "column": 6,
+              "condition": {
+                "column": 9,
+                "data": false,
+                "line": 2,
+                "range": [
+                  17,
+                  22
+                ],
+                "raw": "false",
+                "type": "Bool"
+              },
+              "consequent": null,
+              "isUnless": false,
+              "line": 2,
+              "range": [
+                14,
+                27
+              ],
+              "raw": "if false\nelse",
+              "type": "Conditional"
+            }
+          ],
+          "type": "Block"
         },
-        "raw": "if false\nelse if false\nelse"
+        "column": 1,
+        "condition": {
+          "column": 4,
+          "data": false,
+          "line": 1,
+          "range": [
+            3,
+            8
+          ],
+          "raw": "false",
+          "type": "Bool"
+        },
+        "consequent": null,
+        "isUnless": false,
+        "line": 1,
+        "range": [
+          0,
+          27
+        ],
+        "raw": "if false\nelse if false\nelse",
+        "type": "Conditional"
       }
     ],
-    "raw": "if false\nelse if false\nelse"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    27
+  ],
+  "raw": "if false\nelse if false\nelse",
+  "type": "Program"
 }

--- a/test/examples/conditional-on-one-line/output.json
+++ b/test/examples/conditional-on-one-line/output.json
@@ -1,68 +1,92 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 18 ],
-  "raw": "if a then b else c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 18 ],
+    "line": 1,
+    "range": [
+      0,
+      18
+    ],
     "raw": "if a then b else c",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 18 ],
-        "raw": "if a then b else c",
         "alternate": {
-          "type": "Block",
-          "line": 1,
           "column": 18,
-          "range": [ 17, 18 ],
-          "raw": "c",
           "inline": true,
+          "line": 1,
+          "range": [
+            17,
+            18
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 18,
-              "range": [ 17, 18 ],
+              "data": "c",
+              "line": 1,
+              "range": [
+                17,
+                18
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 4,
-          "range": [ 3, 4 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            3,
+            4
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
         "consequent": {
-          "type": "Block",
-          "line": 1,
           "column": 11,
-          "range": [ 10, 11 ],
-          "raw": "b",
           "inline": true,
+          "line": 1,
+          "range": [
+            10,
+            11
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 11,
-              "range": [ 10, 11 ],
+              "data": "b",
+              "line": 1,
+              "range": [
+                10,
+                11
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": false
+        "isUnless": false,
+        "line": 1,
+        "range": [
+          0,
+          18
+        ],
+        "raw": "if a then b else c",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    18
+  ],
+  "raw": "if a then b else c",
+  "type": "Program"
 }

--- a/test/examples/conditional-unless-equal-condition/output.json
+++ b/test/examples/conditional-unless-equal-condition/output.json
@@ -1,66 +1,90 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 17 ],
-  "raw": "unless a == b\n  c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
     "raw": "unless a == b\n  c",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 17 ],
-        "raw": "unless a == b\n  c",
         "alternate": null,
+        "column": 1,
         "condition": {
-          "type": "EQOp",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 13 ],
-          "raw": "a == b",
           "left": {
-            "type": "Identifier",
-            "line": 1,
             "column": 8,
-            "range": [ 7, 8 ],
-            "raw": "a",
-            "data": "a"
-          },
-          "right": {
-            "type": "Identifier",
+            "data": "a",
             "line": 1,
+            "range": [
+              7,
+              8
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            7,
+            13
+          ],
+          "raw": "a == b",
+          "right": {
             "column": 13,
-            "range": [ 12, 13 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              12,
+              13
+            ],
             "raw": "b",
-            "data": "b"
-          }
+            "type": "Identifier"
+          },
+          "type": "EQOp"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 16, 17 ],
-          "raw": "c",
           "inline": false,
+          "line": 2,
+          "range": [
+            16,
+            17
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 16, 17 ],
+              "data": "c",
+              "line": 2,
+              "range": [
+                16,
+                17
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": true
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          17
+        ],
+        "raw": "unless a == b\n  c",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "unless a == b\n  c",
+  "type": "Program"
 }

--- a/test/examples/conditional-unless-exists-op/output.json
+++ b/test/examples/conditional-unless-exists-op/output.json
@@ -1,58 +1,79 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 13 ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 13 ],
+    "line": 1,
+    "range": [
+      0,
+      13
+    ],
+    "raw": "unless a?\n  b",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
+        "alternate": null,
         "column": 1,
-        "range": [ 0, 13 ],
-        "isUnless": true,
         "condition": {
-          "type": "UnaryExistsOp",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 9 ],
           "expression": {
-            "type": "Identifier",
-            "line": 1,
             "column": 8,
-            "range": [ 7, 8 ],
             "data": "a",
-            "raw": "a"
+            "line": 1,
+            "range": [
+              7,
+              8
+            ],
+            "raw": "a",
+            "type": "Identifier"
           },
-          "raw": "a?"
+          "line": 1,
+          "range": [
+            7,
+            9
+          ],
+          "raw": "a?",
+          "type": "UnaryExistsOp"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 12, 13 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 2,
-              "column": 3,
-              "range": [ 12, 13 ],
-              "data": "b",
-              "raw": "b"
-            }
+          "inline": false,
+          "line": 2,
+          "range": [
+            12,
+            13
           ],
           "raw": "b",
-          "inline": false
+          "statements": [
+            {
+              "column": 3,
+              "data": "b",
+              "line": 2,
+              "range": [
+                12,
+                13
+              ],
+              "raw": "b",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
         },
-        "alternate": null,
-        "raw": "unless a?\n  b"
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          13
+        ],
+        "raw": "unless a?\n  b",
+        "type": "Conditional"
       }
     ],
-    "raw": "unless a?\n  b"
+    "type": "Block"
   },
-  "raw": "unless a?\n  b"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    13
+  ],
+  "raw": "unless a?\n  b",
+  "type": "Program"
 }

--- a/test/examples/conditional-unless-virtual-parens/output.json
+++ b/test/examples/conditional-unless-virtual-parens/output.json
@@ -1,66 +1,90 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 16 ],
-  "raw": "unless a + b\n  c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 16 ],
+    "line": 1,
+    "range": [
+      0,
+      16
+    ],
     "raw": "unless a + b\n  c",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 16 ],
-        "raw": "unless a + b\n  c",
         "alternate": null,
+        "column": 1,
         "condition": {
-          "type": "PlusOp",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 12 ],
-          "raw": "a + b",
           "left": {
-            "type": "Identifier",
-            "line": 1,
             "column": 8,
-            "range": [ 7, 8 ],
-            "raw": "a",
-            "data": "a"
-          },
-          "right": {
-            "type": "Identifier",
+            "data": "a",
             "line": 1,
+            "range": [
+              7,
+              8
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            7,
+            12
+          ],
+          "raw": "a + b",
+          "right": {
             "column": 12,
-            "range": [ 11, 12 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              11,
+              12
+            ],
             "raw": "b",
-            "data": "b"
-          }
+            "type": "Identifier"
+          },
+          "type": "PlusOp"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 15, 16 ],
-          "raw": "c",
           "inline": false,
+          "line": 2,
+          "range": [
+            15,
+            16
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 15, 16 ],
+              "data": "c",
+              "line": 2,
+              "range": [
+                15,
+                16
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": true
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          16
+        ],
+        "raw": "unless a + b\n  c",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    16
+  ],
+  "raw": "unless a + b\n  c",
+  "type": "Program"
 }

--- a/test/examples/conditional-using-unless/output.json
+++ b/test/examples/conditional-using-unless/output.json
@@ -1,51 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 12 ],
-  "raw": "unless a\n  b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
     "raw": "unless a\n  b",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 12 ],
-        "raw": "unless a\n  b",
         "alternate": null,
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 11, 12 ],
-          "raw": "b",
           "inline": false,
+          "line": 2,
+          "range": [
+            11,
+            12
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 11, 12 ],
+              "data": "b",
+              "line": 2,
+              "range": [
+                11,
+                12
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": true
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "unless a\n  b",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "unless a\n  b",
+  "type": "Program"
 }

--- a/test/examples/conditional-with-alternate/output.json
+++ b/test/examples/conditional-with-alternate/output.json
@@ -1,68 +1,92 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 17 ],
-  "raw": "if a\n  b\nelse\n  c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
     "raw": "if a\n  b\nelse\n  c",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 17 ],
-        "raw": "if a\n  b\nelse\n  c",
         "alternate": {
-          "type": "Block",
-          "line": 4,
           "column": 3,
-          "range": [ 16, 17 ],
-          "raw": "c",
           "inline": false,
+          "line": 4,
+          "range": [
+            16,
+            17
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 4,
               "column": 3,
-              "range": [ 16, 17 ],
+              "data": "c",
+              "line": 4,
+              "range": [
+                16,
+                17
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 4,
-          "range": [ 3, 4 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            3,
+            4
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 7, 8 ],
-          "raw": "b",
           "inline": false,
+          "line": 2,
+          "range": [
+            7,
+            8
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 7, 8 ],
+              "data": "b",
+              "line": 2,
+              "range": [
+                7,
+                8
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": false
+        "isUnless": false,
+        "line": 1,
+        "range": [
+          0,
+          17
+        ],
+        "raw": "if a\n  b\nelse\n  c",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "if a\n  b\nelse\n  c",
+  "type": "Program"
 }

--- a/test/examples/conditional-with-braces-on-one-line/output.json
+++ b/test/examples/conditional-with-braces-on-one-line/output.json
@@ -1,66 +1,90 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [0, 15 ],
-  "raw": "a if (b and c)\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [0, 14 ],
+    "line": 1,
+    "range": [
+      0,
+      14
+    ],
+    "raw": "a if (b and c)",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
+        "alternate": null,
         "column": 1,
-        "range": [0, 14 ],
-        "isUnless": false,
         "condition": {
-          "type": "LogicalAndOp",
-          "line": 1,
           "column": 7,
-          "range": [6, 13 ],
           "left": {
-            "type": "Identifier",
-            "line": 1,
             "column": 7,
-            "range": [6, 7 ],
             "data": "b",
-            "raw": "b"
-          },
-          "right": {
-            "type": "Identifier",
             "line": 1,
-            "column": 13,
-            "range": [12, 13 ],
-            "data": "c",
-            "raw": "c"
+            "range": [
+              6,
+              7
+            ],
+            "raw": "b",
+            "type": "Identifier"
           },
-          "raw": "b and c"
+          "line": 1,
+          "range": [
+            6,
+            13
+          ],
+          "raw": "b and c",
+          "right": {
+            "column": 13,
+            "data": "c",
+            "line": 1,
+            "range": [
+              12,
+              13
+            ],
+            "raw": "c",
+            "type": "Identifier"
+          },
+          "type": "LogicalAndOp"
         },
         "consequent": {
-          "type": "Block",
-          "line": 1,
           "column": 1,
-          "range": [0, 1 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 1,
-              "column": 1,
-              "range": [0, 1 ],
-              "data": "a",
-              "raw": "a"
-            }
+          "inline": true,
+          "line": 1,
+          "range": [
+            0,
+            1
           ],
           "raw": "a",
-          "inline": true
+          "statements": [
+            {
+              "column": 1,
+              "data": "a",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
+              "raw": "a",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
         },
-        "alternate": null,
-          "raw": "a if (b and c)"
+        "isUnless": false,
+        "line": 1,
+        "range": [
+          0,
+          14
+        ],
+        "raw": "a if (b and c)",
+        "type": "Conditional"
       }
     ],
-    "raw": "a if (b and c)"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    15
+  ],
+  "raw": "a if (b and c)\n",
+  "type": "Program"
 }

--- a/test/examples/conditional-with-post-if/output.json
+++ b/test/examples/conditional-with-post-if/output.json
@@ -1,51 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a if b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a if b",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a if b",
         "alternate": null,
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
+          "type": "Identifier"
         },
         "consequent": {
-          "type": "Block",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
           "inline": true,
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 1,
-              "range": [ 0, 1 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": false
+        "isUnless": false,
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a if b",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a if b",
+  "type": "Program"
 }

--- a/test/examples/conditional-with-post-unless/output.json
+++ b/test/examples/conditional-with-post-unless/output.json
@@ -1,51 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 10 ],
-  "raw": "a unless b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 10 ],
+    "line": 1,
+    "range": [
+      0,
+      10
+    ],
     "raw": "a unless b",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 10 ],
-        "raw": "a unless b",
         "alternate": null,
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 10,
-          "range": [ 9, 10 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            9,
+            10
+          ],
           "raw": "b",
-          "data": "b"
+          "type": "Identifier"
         },
         "consequent": {
-          "type": "Block",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
           "inline": true,
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 1,
-              "range": [ 0, 1 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": true
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          10
+        ],
+        "raw": "a unless b",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    10
+  ],
+  "raw": "a unless b",
+  "type": "Program"
 }

--- a/test/examples/conditional-without-alternate/output.json
+++ b/test/examples/conditional-without-alternate/output.json
@@ -1,51 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 8 ],
-  "raw": "if a\n  b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 8 ],
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
     "raw": "if a\n  b",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 8 ],
-        "raw": "if a\n  b",
         "alternate": null,
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 4,
-          "range": [ 3, 4 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            3,
+            4
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 7, 8 ],
-          "raw": "b",
           "inline": false,
+          "line": 2,
+          "range": [
+            7,
+            8
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 7, 8 ],
+              "data": "b",
+              "line": 2,
+              "range": [
+                7,
+                8
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": false
+        "isUnless": false,
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "if a\n  b",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    8
+  ],
+  "raw": "if a\n  b",
+  "type": "Program"
 }

--- a/test/examples/continue/output.json
+++ b/test/examples/continue/output.json
@@ -1,55 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      15
+    ],
+    "raw": "loop\n  continue",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            7,
+            15
+          ],
+          "raw": "continue",
+          "statements": [
+            {
+              "column": 3,
+              "line": 2,
+              "range": [
+                7,
+                15
+              ],
+              "raw": "continue",
+              "type": "Continue"
+            }
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "line": 1,
+        "range": [
+          0,
+          15
+        ],
+        "raw": "loop\n  continue",
+        "type": "Loop"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     16
   ],
   "raw": "loop\n  continue\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      15
-    ],
-    "statements": [
-      {
-        "type": "Loop",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          15
-        ],
-        "body": {
-          "type": "Block",
-          "line": 2,
-          "column": 3,
-          "range": [
-            7,
-            15
-          ],
-          "statements": [
-            {
-              "type": "Continue",
-              "line": 2,
-              "column": 3,
-              "range": [
-                7,
-                15
-              ],
-              "raw": "continue"
-            }
-          ],
-          "raw": "continue",
-          "inline": false
-        },
-        "raw": "loop\n  continue"
-      }
-    ],
-    "raw": "loop\n  continue"
-  }
+  "type": "Program"
 }

--- a/test/examples/dangling-prototype-access-of-call/output.json
+++ b/test/examples/dangling-prototype-access-of-call/output.json
@@ -1,54 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    6
-  ],
-  "raw": "a()::\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       5
     ],
+    "raw": "a()::",
     "statements": [
       {
-        "type": "ProtoMemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          5
-        ],
         "expression": {
-          "type": "FunctionApplication",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            3
+          "arguments": [
           ],
+          "column": 1,
           "function": {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
+            "data": "a",
+            "line": 1,
             "range": [
               0,
               1
             ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
-          "arguments": [],
-          "raw": "a()"
+          "line": 1,
+          "range": [
+            0,
+            3
+          ],
+          "raw": "a()",
+          "type": "FunctionApplication"
         },
-        "raw": "a()::"
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a()::",
+        "type": "ProtoMemberAccessOp"
       }
     ],
-    "raw": "a()::"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a()::\n",
+  "type": "Program"
 }

--- a/test/examples/dangling-prototype-access/output.json
+++ b/test/examples/dangling-prototype-access/output.json
@@ -1,43 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    9
-  ],
-  "raw": "Object::\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       8
     ],
+    "raw": "Object::",
     "statements": [
       {
-        "type": "ProtoMemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          8
-        ],
-        "raw": "Object::",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
+          "data": "Object",
+          "line": 1,
           "range": [
             0,
             6
           ],
           "raw": "Object",
-          "data": "Object"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "Object::",
+        "type": "ProtoMemberAccessOp"
       }
     ],
-    "raw": "Object::"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "Object::\n",
+  "type": "Program"
 }

--- a/test/examples/delete/output.json
+++ b/test/examples/delete/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 8 ],
-  "raw": "delete a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 8 ],
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
     "raw": "delete a",
     "statements": [
       {
-        "type": "DeleteOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 8 ],
-        "raw": "delete a",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "delete a",
+        "type": "DeleteOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    8
+  ],
+  "raw": "delete a",
+  "type": "Program"
 }

--- a/test/examples/division/output.json
+++ b/test/examples/division/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "3 / 4",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "3 / 4",
     "statements": [
       {
-        "type": "DivideOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "3 / 4",
         "left": {
-          "type": "Int",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "3",
-          "data": 3
-        },
-        "right": {
-          "type": "Int",
+          "data": 3,
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "3",
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "3 / 4",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": 4,
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "4",
-          "data": 4
-        }
+          "type": "Int"
+        },
+        "type": "DivideOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "3 / 4",
+  "type": "Program"
 }

--- a/test/examples/do-expression/output.json
+++ b/test/examples/do-expression/output.json
@@ -1,66 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 12 ],
-  "raw": "a(do =>\n  b)",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
     "raw": "a(do =>\n  b)",
     "statements": [
       {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 12 ],
-        "raw": "a(do =>\n  b)",
         "arguments": [
           {
-            "type": "DoOp",
-            "line": 1,
             "column": 3,
-            "range": [ 2, 11 ],
-            "raw": "do =>\n  b",
             "expression": {
-              "type": "BoundFunction",
-              "line": 1,
-              "column": 6,
-              "range": [ 5, 11 ],
-              "raw": "=>\n  b",
               "body": {
-                "type": "Block",
-                "line": 2,
                 "column": 3,
-                "range": [ 10, 11 ],
-                "raw": "b",
                 "inline": false,
+                "line": 2,
+                "range": [
+                  10,
+                  11
+                ],
+                "raw": "b",
                 "statements": [
                   {
-                    "type": "Identifier",
-                    "line": 2,
                     "column": 3,
-                    "range": [ 10, 11 ],
+                    "data": "b",
+                    "line": 2,
+                    "range": [
+                      10,
+                      11
+                    ],
                     "raw": "b",
-                    "data": "b"
+                    "type": "Identifier"
                   }
-                ]
+                ],
+                "type": "Block"
               },
-              "parameters": []
-            }
+              "column": 6,
+              "line": 1,
+              "parameters": [
+              ],
+              "range": [
+                5,
+                11
+              ],
+              "raw": "=>\n  b",
+              "type": "BoundFunction"
+            },
+            "line": 1,
+            "range": [
+              2,
+              11
+            ],
+            "raw": "do =>\n  b",
+            "type": "DoOp"
           }
         ],
+        "column": 1,
         "function": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "a(do =>\n  b)",
+        "type": "FunctionApplication"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "a(do =>\n  b)",
+  "type": "Program"
 }

--- a/test/examples/do-with-assign-and-defaults/output.json
+++ b/test/examples/do-with-assign-and-defaults/output.json
@@ -1,132 +1,132 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    25
-  ],
-  "raw": "do a = (b = c, d) ->\n  e\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       24
     ],
+    "raw": "do a = (b = c, d) ->\n  e",
     "statements": [
       {
-        "type": "DoOp",
-        "line": 1,
         "column": 1,
+        "expression": {
+          "assignee": {
+            "column": 4,
+            "data": "a",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          "column": 4,
+          "expression": {
+            "body": {
+              "column": 3,
+              "inline": false,
+              "line": 2,
+              "range": [
+                23,
+                24
+              ],
+              "raw": "e",
+              "statements": [
+                {
+                  "column": 3,
+                  "data": "e",
+                  "line": 2,
+                  "range": [
+                    23,
+                    24
+                  ],
+                  "raw": "e",
+                  "type": "Identifier"
+                }
+              ],
+              "type": "Block"
+            },
+            "column": 8,
+            "line": 1,
+            "parameters": [
+              {
+                "column": 9,
+                "default": {
+                  "column": 13,
+                  "data": "c",
+                  "line": 1,
+                  "range": [
+                    12,
+                    13
+                  ],
+                  "raw": "c",
+                  "type": "Identifier"
+                },
+                "line": 1,
+                "param": {
+                  "column": 9,
+                  "data": "b",
+                  "line": 1,
+                  "range": [
+                    8,
+                    9
+                  ],
+                  "raw": "b",
+                  "type": "Identifier"
+                },
+                "range": [
+                  8,
+                  13
+                ],
+                "raw": "b = c",
+                "type": "DefaultParam"
+              },
+              {
+                "column": 16,
+                "data": "d",
+                "line": 1,
+                "range": [
+                  15,
+                  16
+                ],
+                "raw": "d",
+                "type": "Identifier"
+              }
+            ],
+            "range": [
+              7,
+              24
+            ],
+            "raw": "(b = c, d) ->\n  e",
+            "type": "Function"
+          },
+          "line": 1,
+          "range": [
+            3,
+            24
+          ],
+          "raw": "a = (b = c, d) ->\n  e",
+          "type": "AssignOp"
+        },
+        "line": 1,
         "range": [
           0,
           24
         ],
         "raw": "do a = (b = c, d) ->\n  e",
-        "expression": {
-          "type": "AssignOp",
-          "line": 1,
-          "column": 4,
-          "range": [
-            3,
-            24
-          ],
-          "assignee": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 4,
-            "raw": "a",
-            "range": [
-              3,
-              4
-            ],
-            "data": "a"
-          },
-          "expression": {
-            "type": "Function",
-            "line": 1,
-            "column": 8,
-            "range": [
-              7,
-              24
-            ],
-            "body": {
-              "type": "Block",
-              "line": 2,
-              "column": 3,
-              "range": [
-                23,
-                24
-              ],
-              "statements": [
-                {
-                  "type": "Identifier",
-                  "line": 2,
-                  "column": 3,
-                  "raw": "e",
-                  "range": [
-                    23,
-                    24
-                  ],
-                  "data": "e"
-                }
-              ],
-              "raw": "e",
-              "inline": false
-            },
-            "parameters": [
-              {
-                "type": "DefaultParam",
-                "line": 1,
-                "column": 9,
-                "range": [
-                  8,
-                  13
-                ],
-                "param": {
-                  "type": "Identifier",
-                  "line": 1,
-                  "column": 9,
-                  "raw": "b",
-                  "range": [
-                    8,
-                    9
-                  ],
-                  "data": "b"
-                },
-                "default": {
-                  "type": "Identifier",
-                  "line": 1,
-                  "column": 13,
-                  "raw": "c",
-                  "range": [
-                    12,
-                    13
-                  ],
-                  "data": "c"
-                },
-                "raw": "b = c"
-              },
-              {
-                "type": "Identifier",
-                "line": 1,
-                "column": 16,
-                "raw": "d",
-                "range": [
-                  15,
-                  16
-                ],
-                "data": "d"
-              }
-            ],
-            "raw": "(b = c, d) ->\n  e"
-          },
-          "raw": "a = (b = c, d) ->\n  e"
-        }
+        "type": "DoOp"
       }
     ],
-    "raw": "do a = (b = c, d) ->\n  e"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    25
+  ],
+  "raw": "do a = (b = c, d) ->\n  e\n",
+  "type": "Program"
 }

--- a/test/examples/do-with-assign-expression/output.json
+++ b/test/examples/do-with-assign-expression/output.json
@@ -1,72 +1,101 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 22 ],
-  "raw": "do wait = ->\n  wait()\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 21 ],
+    "line": 1,
+    "range": [
+      0,
+      21
+    ],
     "raw": "do wait = ->\n  wait()",
     "statements": [
       {
-        "type": "DoOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 21 ],
-        "raw": "do wait = ->\n  wait()",
         "expression": {
-          "type": "AssignOp",
-          "line": 1,
-          "column": 4,
-          "range": [ 3, 21 ],
-          "raw": "wait = ->\n  wait()",
           "assignee": {
-            "type": "Identifier",
-            "line": 1,
             "column": 4,
-            "range": [ 3, 7 ],
-            "raw": "wait",
-            "data": "wait"
-          },
-          "expression": {
-            "type": "Function",
+            "data": "wait",
             "line": 1,
-            "column": 11,
-            "range": [ 10, 21 ],
-            "raw": "->\n  wait()",
+            "range": [
+              3,
+              7
+            ],
+            "raw": "wait",
+            "type": "Identifier"
+          },
+          "column": 4,
+          "expression": {
             "body": {
-              "type": "Block",
-              "line": 2,
               "column": 3,
-              "range": [ 15, 21 ],
-              "raw": "wait()",
               "inline": false,
+              "line": 2,
+              "range": [
+                15,
+                21
+              ],
+              "raw": "wait()",
               "statements": [
                 {
-                  "type": "FunctionApplication",
-                  "line": 2,
+                  "arguments": [
+                  ],
                   "column": 3,
-                  "range": [ 15, 21 ],
-                  "raw": "wait()",
-                  "arguments": [],
                   "function": {
-                    "type": "Identifier",
-                    "line": 2,
                     "column": 3,
-                    "range": [ 15, 19 ],
+                    "data": "wait",
+                    "line": 2,
+                    "range": [
+                      15,
+                      19
+                    ],
                     "raw": "wait",
-                    "data": "wait"
-                  }
+                    "type": "Identifier"
+                  },
+                  "line": 2,
+                  "range": [
+                    15,
+                    21
+                  ],
+                  "raw": "wait()",
+                  "type": "FunctionApplication"
                 }
-              ]
+              ],
+              "type": "Block"
             },
-            "parameters": []
-          }
-        }
+            "column": 11,
+            "line": 1,
+            "parameters": [
+            ],
+            "range": [
+              10,
+              21
+            ],
+            "raw": "->\n  wait()",
+            "type": "Function"
+          },
+          "line": 1,
+          "range": [
+            3,
+            21
+          ],
+          "raw": "wait = ->\n  wait()",
+          "type": "AssignOp"
+        },
+        "line": 1,
+        "range": [
+          0,
+          21
+        ],
+        "raw": "do wait = ->\n  wait()",
+        "type": "DoOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    22
+  ],
+  "raw": "do wait = ->\n  wait()\n",
+  "type": "Program"
 }

--- a/test/examples/do-with-bound-function/output.json
+++ b/test/examples/do-with-bound-function/output.json
@@ -1,49 +1,68 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "do =>\n  a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "do =>\n  a",
     "statements": [
       {
-        "type": "DoOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "do =>\n  a",
         "expression": {
-          "type": "BoundFunction",
-          "line": 1,
-          "column": 4,
-          "range": [ 3, 9 ],
-          "raw": "=>\n  a",
           "body": {
-            "type": "Block",
-            "line": 2,
             "column": 3,
-            "range": [ 8, 9 ],
-            "raw": "a",
             "inline": false,
+            "line": 2,
+            "range": [
+              8,
+              9
+            ],
+            "raw": "a",
             "statements": [
               {
-                "type": "Identifier",
-                "line": 2,
                 "column": 3,
-                "range": [ 8, 9 ],
+                "data": "a",
+                "line": 2,
+                "range": [
+                  8,
+                  9
+                ],
                 "raw": "a",
-                "data": "a"
+                "type": "Identifier"
               }
-            ]
+            ],
+            "type": "Block"
           },
-          "parameters": []
-        }
+          "column": 4,
+          "line": 1,
+          "parameters": [
+          ],
+          "range": [
+            3,
+            9
+          ],
+          "raw": "=>\n  a",
+          "type": "BoundFunction"
+        },
+        "line": 1,
+        "range": [
+          0,
+          9
+        ],
+        "raw": "do =>\n  a",
+        "type": "DoOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "do =>\n  a",
+  "type": "Program"
 }

--- a/test/examples/do-with-default-parameters/output.json
+++ b/test/examples/do-with-default-parameters/output.json
@@ -1,173 +1,173 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    25
-  ],
-  "raw": "do (a=1, b=@b) ->\n  a + b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       25
     ],
+    "raw": "do (a=1, b=@b) ->\n  a + b",
     "statements": [
       {
-        "type": "DoOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          25
-        ],
-        "raw": "do (a=1, b=@b) ->\n  a + b",
         "expression": {
-          "type": "Function",
-          "line": 1,
-          "column": 4,
-          "range": [
-            3,
-            25
-          ],
           "body": {
-            "type": "Block",
-            "line": 2,
             "column": 3,
+            "inline": false,
+            "line": 2,
             "range": [
               20,
               25
             ],
+            "raw": "a + b",
             "statements": [
               {
-                "type": "PlusOp",
-                "line": 2,
                 "column": 3,
-                "range": [
-                  20,
-                  25
-                ],
                 "left": {
-                  "type": "Identifier",
-                  "line": 2,
                   "column": 3,
+                  "data": "a",
+                  "line": 2,
                   "range": [
                     20,
                     21
                   ],
                   "raw": "a",
-                  "data": "a"
+                  "type": "Identifier"
                 },
+                "line": 2,
+                "range": [
+                  20,
+                  25
+                ],
+                "raw": "a + b",
                 "right": {
-                  "type": "Identifier",
-                  "line": 2,
                   "column": 7,
+                  "data": "b",
+                  "line": 2,
                   "range": [
                     24,
                     25
                   ],
                   "raw": "b",
-                  "data": "b"
+                  "type": "Identifier"
                 },
-                "raw": "a + b"
+                "type": "PlusOp"
               }
             ],
-            "raw": "a + b",
-            "inline": false
+            "type": "Block"
           },
+          "column": 4,
+          "line": 1,
           "parameters": [
             {
-              "type": "DefaultParam",
-              "line": 1,
               "column": 5,
-              "range": [
-                4,
-                7
-              ],
-              "param": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 5,
-                "range": [
-                  4,
-                  5
-                ],
-                "raw": "a",
-                "data": "a"
-              },
               "default": {
-                "type": "Int",
-                "line": 1,
                 "column": 7,
+                "data": 1,
+                "line": 1,
                 "range": [
                   6,
                   7
                 ],
                 "raw": "1",
-                "data": 1
+                "type": "Int"
               },
-              "raw": "a=1"
+              "line": 1,
+              "param": {
+                "column": 5,
+                "data": "a",
+                "line": 1,
+                "range": [
+                  4,
+                  5
+                ],
+                "raw": "a",
+                "type": "Identifier"
+              },
+              "range": [
+                4,
+                7
+              ],
+              "raw": "a=1",
+              "type": "DefaultParam"
             },
             {
-              "type": "DefaultParam",
-              "line": 1,
               "column": 10,
-              "range": [
-                9,
-                13
-              ],
-              "param": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 10,
-                "range": [
-                  9,
-                  10
-                ],
-                "raw": "b",
-                "data": "b"
-              },
               "default": {
-                "type": "MemberAccessOp",
-                "line": 1,
                 "column": 12,
-                "range": [
-                  11,
-                  13
-                ],
-                "raw": "@b",
                 "expression": {
-                  "type": "This",
-                  "line": 1,
                   "column": 12,
+                  "line": 1,
                   "range": [
                     11,
                     12
                   ],
-                  "raw": "@"
+                  "raw": "@",
+                  "type": "This"
                 },
+                "line": 1,
                 "member": {
-                  "type": "Identifier",
-                  "line": 1,
                   "column": 13,
+                  "data": "b",
+                  "line": 1,
                   "range": [
                     12,
                     13
                   ],
                   "raw": "b",
-                  "data": "b"
-                }
+                  "type": "Identifier"
+                },
+                "range": [
+                  11,
+                  13
+                ],
+                "raw": "@b",
+                "type": "MemberAccessOp"
               },
-              "raw": "b=@b"
+              "line": 1,
+              "param": {
+                "column": 10,
+                "data": "b",
+                "line": 1,
+                "range": [
+                  9,
+                  10
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "range": [
+                9,
+                13
+              ],
+              "raw": "b=@b",
+              "type": "DefaultParam"
             }
           ],
-          "raw": "(a=1, b=@b) ->\n  a + b"
-        }
+          "range": [
+            3,
+            25
+          ],
+          "raw": "(a=1, b=@b) ->\n  a + b",
+          "type": "Function"
+        },
+        "line": 1,
+        "range": [
+          0,
+          25
+        ],
+        "raw": "do (a=1, b=@b) ->\n  a + b",
+        "type": "DoOp"
       }
     ],
-    "raw": "do (a=1, b=@b) ->\n  a + b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    25
+  ],
+  "raw": "do (a=1, b=@b) ->\n  a + b",
+  "type": "Program"
 }

--- a/test/examples/do-with-defaults-with-same-name/output.json
+++ b/test/examples/do-with-defaults-with-same-name/output.json
@@ -1,153 +1,153 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    25
-  ],
-  "raw": "do (a=a, b=b) ->\n  a + b\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       24
     ],
+    "raw": "do (a=a, b=b) ->\n  a + b",
     "statements": [
       {
-        "type": "DoOp",
-        "line": 1,
         "column": 1,
+        "expression": {
+          "body": {
+            "column": 3,
+            "inline": false,
+            "line": 2,
+            "range": [
+              19,
+              24
+            ],
+            "raw": "a + b",
+            "statements": [
+              {
+                "column": 3,
+                "left": {
+                  "column": 3,
+                  "data": "a",
+                  "line": 2,
+                  "range": [
+                    19,
+                    20
+                  ],
+                  "raw": "a",
+                  "type": "Identifier"
+                },
+                "line": 2,
+                "range": [
+                  19,
+                  24
+                ],
+                "raw": "a + b",
+                "right": {
+                  "column": 7,
+                  "data": "b",
+                  "line": 2,
+                  "range": [
+                    23,
+                    24
+                  ],
+                  "raw": "b",
+                  "type": "Identifier"
+                },
+                "type": "PlusOp"
+              }
+            ],
+            "type": "Block"
+          },
+          "column": 4,
+          "line": 1,
+          "parameters": [
+            {
+              "column": 5,
+              "default": {
+                "column": 7,
+                "data": "a",
+                "line": 1,
+                "range": [
+                  6,
+                  7
+                ],
+                "raw": "a",
+                "type": "Identifier"
+              },
+              "line": 1,
+              "param": {
+                "column": 5,
+                "data": "a",
+                "line": 1,
+                "range": [
+                  4,
+                  5
+                ],
+                "raw": "a",
+                "type": "Identifier"
+              },
+              "range": [
+                4,
+                7
+              ],
+              "raw": "a=a",
+              "type": "DefaultParam"
+            },
+            {
+              "column": 10,
+              "default": {
+                "column": 12,
+                "data": "b",
+                "line": 1,
+                "range": [
+                  11,
+                  12
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "line": 1,
+              "param": {
+                "column": 10,
+                "data": "b",
+                "line": 1,
+                "range": [
+                  9,
+                  10
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "range": [
+                9,
+                12
+              ],
+              "raw": "b=b",
+              "type": "DefaultParam"
+            }
+          ],
+          "range": [
+            3,
+            24
+          ],
+          "raw": "(a=a, b=b) ->\n  a + b",
+          "type": "Function"
+        },
+        "line": 1,
         "range": [
           0,
           24
         ],
         "raw": "do (a=a, b=b) ->\n  a + b",
-        "expression": {
-          "type": "Function",
-          "line": 1,
-          "column": 4,
-          "range": [
-            3,
-            24
-          ],
-          "body": {
-            "type": "Block",
-            "line": 2,
-            "column": 3,
-            "range": [
-              19,
-              24
-            ],
-            "statements": [
-              {
-                "type": "PlusOp",
-                "line": 2,
-                "column": 3,
-                "range": [
-                  19,
-                  24
-                ],
-                "left": {
-                  "type": "Identifier",
-                  "line": 2,
-                  "column": 3,
-                  "range": [
-                    19,
-                    20
-                  ],
-                  "data": "a",
-                  "raw": "a"
-                },
-                "right": {
-                  "type": "Identifier",
-                  "line": 2,
-                  "column": 7,
-                  "range": [
-                    23,
-                    24
-                  ],
-                  "data": "b",
-                  "raw": "b"
-                },
-                "raw": "a + b"
-              }
-            ],
-            "raw": "a + b",
-            "inline": false
-          },
-          "parameters": [
-            {
-              "type": "DefaultParam",
-              "line": 1,
-              "column": 5,
-              "range": [
-                4,
-                7
-              ],
-              "param": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 5,
-                "range": [
-                  4,
-                  5
-                ],
-                "data": "a",
-                "raw": "a"
-              },
-              "default": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 7,
-                "range": [
-                  6,
-                  7
-                ],
-                "data": "a",
-                "raw": "a"
-              },
-              "raw": "a=a"
-            },
-            {
-              "type": "DefaultParam",
-              "line": 1,
-              "column": 10,
-              "range": [
-                9,
-                12
-              ],
-              "param": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 10,
-                "range": [
-                  9,
-                  10
-                ],
-                "data": "b",
-                "raw": "b"
-              },
-              "default": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 12,
-                "range": [
-                  11,
-                  12
-                ],
-                "data": "b",
-                "raw": "b"
-              },
-              "raw": "b=b"
-            }
-          ],
-          "raw": "(a=a, b=b) ->\n  a + b"
-        }
+        "type": "DoOp"
       }
     ],
-    "raw": "do (a=a, b=b) ->\n  a + b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    25
+  ],
+  "raw": "do (a=a, b=b) ->\n  a + b\n",
+  "type": "Program"
 }

--- a/test/examples/do-with-simple-parameters/output.json
+++ b/test/examples/do-with-simple-parameters/output.json
@@ -1,81 +1,111 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 20 ],
-  "raw": "do (a, b) ->\n  a + b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 20 ],
+    "line": 1,
+    "range": [
+      0,
+      20
+    ],
     "raw": "do (a, b) ->\n  a + b",
     "statements": [
       {
-        "type": "DoOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 20 ],
-        "raw": "do (a, b) ->\n  a + b",
         "expression": {
-          "type": "Function",
-          "line": 1,
-          "column": 4,
-          "range": [ 3, 20 ],
-          "raw": "(a, b) ->\n  a + b",
           "body": {
-            "type": "Block",
-            "line": 2,
             "column": 3,
-            "range": [ 15, 20 ],
-            "raw": "a + b",
             "inline": false,
+            "line": 2,
+            "range": [
+              15,
+              20
+            ],
+            "raw": "a + b",
             "statements": [
               {
-                "type": "PlusOp",
-                "line": 2,
                 "column": 3,
-                "range": [ 15, 20 ],
-                "raw": "a + b",
                 "left": {
-                  "type": "Identifier",
-                  "line": 2,
                   "column": 3,
-                  "range": [ 15, 16 ],
-                  "raw": "a",
-                  "data": "a"
-                },
-                "right": {
-                  "type": "Identifier",
+                  "data": "a",
                   "line": 2,
+                  "range": [
+                    15,
+                    16
+                  ],
+                  "raw": "a",
+                  "type": "Identifier"
+                },
+                "line": 2,
+                "range": [
+                  15,
+                  20
+                ],
+                "raw": "a + b",
+                "right": {
                   "column": 7,
-                  "range": [ 19, 20 ],
+                  "data": "b",
+                  "line": 2,
+                  "range": [
+                    19,
+                    20
+                  ],
                   "raw": "b",
-                  "data": "b"
-                }
+                  "type": "Identifier"
+                },
+                "type": "PlusOp"
               }
-            ]
+            ],
+            "type": "Block"
           },
+          "column": 4,
+          "line": 1,
           "parameters": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 5,
-              "range": [ 4, 5 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                4,
+                5
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             },
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 8,
-              "range": [ 7, 8 ],
+              "data": "b",
+              "line": 1,
+              "range": [
+                7,
+                8
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
-        }
+          ],
+          "range": [
+            3,
+            20
+          ],
+          "raw": "(a, b) ->\n  a + b",
+          "type": "Function"
+        },
+        "line": 1,
+        "range": [
+          0,
+          20
+        ],
+        "raw": "do (a, b) ->\n  a + b",
+        "type": "DoOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    20
+  ],
+  "raw": "do (a, b) ->\n  a + b",
+  "type": "Program"
 }

--- a/test/examples/do/output.json
+++ b/test/examples/do/output.json
@@ -1,49 +1,68 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "do ->\n  a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "do ->\n  a",
     "statements": [
       {
-        "type": "DoOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "do ->\n  a",
         "expression": {
-          "type": "Function",
-          "line": 1,
-          "column": 4,
-          "range": [ 3, 9 ],
-          "raw": "->\n  a",
           "body": {
-            "type": "Block",
-            "line": 2,
             "column": 3,
-            "range": [ 8, 9 ],
-            "raw": "a",
             "inline": false,
+            "line": 2,
+            "range": [
+              8,
+              9
+            ],
+            "raw": "a",
             "statements": [
               {
-                "type": "Identifier",
-                "line": 2,
                 "column": 3,
-                "range": [ 8, 9 ],
+                "data": "a",
+                "line": 2,
+                "range": [
+                  8,
+                  9
+                ],
                 "raw": "a",
-                "data": "a"
+                "type": "Identifier"
               }
-            ]
+            ],
+            "type": "Block"
           },
-          "parameters": []
-        }
+          "column": 4,
+          "line": 1,
+          "parameters": [
+          ],
+          "range": [
+            3,
+            9
+          ],
+          "raw": "->\n  a",
+          "type": "Function"
+        },
+        "line": 1,
+        "range": [
+          0,
+          9
+        ],
+        "raw": "do ->\n  a",
+        "type": "DoOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "do ->\n  a",
+  "type": "Program"
 }

--- a/test/examples/double-negation/output.json
+++ b/test/examples/double-negation/output.json
@@ -1,38 +1,53 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "!!a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 3 ],
+    "line": 1,
+    "range": [
+      0,
+      3
+    ],
     "raw": "!!a",
     "statements": [
       {
-        "type": "LogicalNotOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 3 ],
-        "raw": "!!a",
         "expression": {
-          "type": "LogicalNotOp",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 3 ],
-          "raw": "!a",
           "expression": {
-            "type": "Identifier",
-            "line": 1,
             "column": 3,
-            "range": [ 2, 3 ],
+            "data": "a",
+            "line": 1,
+            "range": [
+              2,
+              3
+            ],
             "raw": "a",
-            "data": "a"
-          }
-        }
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            1,
+            3
+          ],
+          "raw": "!a",
+          "type": "LogicalNotOp"
+        },
+        "line": 1,
+        "range": [
+          0,
+          3
+        ],
+        "raw": "!!a",
+        "type": "LogicalNotOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "!!a",
+  "type": "Program"
 }

--- a/test/examples/dynamic-member-expressions/output.json
+++ b/test/examples/dynamic-member-expressions/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 4 ],
-  "raw": "a[b]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 4 ],
+    "line": 1,
+    "range": [
+      0,
+      4
+    ],
     "raw": "a[b]",
     "statements": [
       {
-        "type": "DynamicMemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 4 ],
-        "raw": "a[b]",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
         "indexingExpr": {
-          "type": "Identifier",
-          "line": 1,
           "column": 3,
-          "range": [ 2, 3 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            2,
+            3
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          4
+        ],
+        "raw": "a[b]",
+        "type": "DynamicMemberAccessOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    4
+  ],
+  "raw": "a[b]",
+  "type": "Program"
 }

--- a/test/examples/empty-anonymous-class/output.json
+++ b/test/examples/empty-anonymous-class/output.json
@@ -1,29 +1,39 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "class",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "class",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "class",
         "body": null,
-        "boundMembers": [],
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": null,
+        "line": 1,
         "name": null,
         "nameAssignee": null,
-        "parent": null
+        "parent": null,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "class",
+        "type": "Class"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "class",
+  "type": "Program"
 }

--- a/test/examples/empty-array/output.json
+++ b/test/examples/empty-array/output.json
@@ -1,24 +1,34 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 2 ],
-  "raw": "[]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "[]",
     "statements": [
       {
-        "type": "ArrayInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 2 ],
+        "line": 1,
+        "members": [
+        ],
+        "range": [
+          0,
+          2
+        ],
         "raw": "[]",
-        "members": []
+        "type": "ArrayInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "[]",
+  "type": "Program"
 }

--- a/test/examples/empty-bound-function-without-body/output.json
+++ b/test/examples/empty-bound-function-without-body/output.json
@@ -1,25 +1,35 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 2 ],
-  "raw": "=>",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "=>",
     "statements": [
       {
-        "type": "BoundFunction",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 2 ],
-        "raw": "=>",
         "body": null,
-        "parameters": []
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          2
+        ],
+        "raw": "=>",
+        "type": "BoundFunction"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "=>",
+  "type": "Program"
 }

--- a/test/examples/empty-class-with-superclass/output.json
+++ b/test/examples/empty-class-with-superclass/output.json
@@ -1,50 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 17 ],
-  "raw": "class A extends B",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
     "raw": "class A extends B",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 17 ],
-        "raw": "class A extends B",
         "body": null,
-        "boundMembers": [],
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": null,
+        "line": 1,
         "name": {
-          "type": "Identifier",
-          "line": 1,
           "column": 7,
-          "range": [ 6, 7 ],
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
           "raw": "A",
-          "data": "A"
+          "type": "Identifier"
         },
         "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 7,
-          "range": [ 6, 7 ],
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
           "raw": "A",
-          "data": "A"
+          "type": "Identifier"
         },
         "parent": {
-          "type": "Identifier",
-          "line": 1,
           "column": 17,
-          "range": [ 16, 17 ],
+          "data": "B",
+          "line": 1,
+          "range": [
+            16,
+            17
+          ],
           "raw": "B",
-          "data": "B"
-        }
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          17
+        ],
+        "raw": "class A extends B",
+        "type": "Class"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "class A extends B",
+  "type": "Program"
 }

--- a/test/examples/empty-class/output.json
+++ b/test/examples/empty-class/output.json
@@ -1,43 +1,59 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "class A",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 7 ],
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
     "raw": "class A",
     "statements": [
       {
-        "type": "Class",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 7 ],
-        "raw": "class A",
         "body": null,
-        "boundMembers": [],
+        "boundMembers": [
+        ],
+        "column": 1,
         "ctor": null,
+        "line": 1,
         "name": {
-          "type": "Identifier",
-          "line": 1,
           "column": 7,
-          "range": [ 6, 7 ],
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
           "raw": "A",
-          "data": "A"
+          "type": "Identifier"
         },
         "nameAssignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 7,
-          "range": [ 6, 7 ],
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
           "raw": "A",
-          "data": "A"
+          "type": "Identifier"
         },
-        "parent": null
+        "parent": null,
+        "range": [
+          0,
+          7
+        ],
+        "raw": "class A",
+        "type": "Class"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "class A",
+  "type": "Program"
 }

--- a/test/examples/empty-function-without-parameters/output.json
+++ b/test/examples/empty-function-without-parameters/output.json
@@ -1,25 +1,35 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "->\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "->",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 2 ],
-        "raw": "->",
         "body": null,
-        "parameters": []
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          2
+        ],
+        "raw": "->",
+        "type": "Function"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "->\n",
+  "type": "Program"
 }

--- a/test/examples/empty-heregex-interpolation/output.json
+++ b/test/examples/empty-heregex-interpolation/output.json
@@ -1,69 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
+    "raw": "///a#{}b///",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          null
+        ],
+        "flags": {
+          "g": false,
+          "global": false,
+          "i": false,
+          "ignoreCase": false,
+          "m": false,
+          "multiline": false,
+          "sticky": false,
+          "y": false
+        },
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "a",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "a",
+            "type": "Quasi"
+          },
+          {
+            "column": 8,
+            "data": "b",
+            "line": 1,
+            "range": [
+              7,
+              8
+            ],
+            "raw": "b",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          11
+        ],
+        "raw": "///a#{}b///",
+        "type": "Heregex"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     12
   ],
   "raw": "///a#{}b///\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      11
-    ],
-    "statements": [
-      {
-        "type": "Heregex",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          11
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "a",
-            "range": [
-              3,
-              4
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 8,
-            "raw": "b",
-            "range": [
-              7,
-              8
-            ],
-            "data": "b"
-          }
-        ],
-        "expressions": [
-          null
-        ],
-        "flags": {
-          "global": false,
-          "ignoreCase": false,
-          "multiline": false,
-          "sticky": false,
-          "g": false,
-          "i": false,
-          "m": false,
-          "y": false
-        },
-        "raw": "///a#{}b///"
-      }
-    ],
-    "raw": "///a#{}b///"
-  }
+  "type": "Program"
 }

--- a/test/examples/empty-object/output.json
+++ b/test/examples/empty-object/output.json
@@ -1,24 +1,34 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 2 ],
-  "raw": "{}",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "{}",
     "statements": [
       {
-        "type": "ObjectInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 2 ],
+        "line": 1,
+        "members": [
+        ],
+        "range": [
+          0,
+          2
+        ],
         "raw": "{}",
-        "members": []
+        "type": "ObjectInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "{}",
+  "type": "Program"
 }

--- a/test/examples/empty-program/output.json
+++ b/test/examples/empty-program/output.json
@@ -1,8 +1,11 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": null,
   "column": 1,
-  "range": [ 0, 0 ],
+  "line": 1,
+  "range": [
+    0,
+    0
+  ],
   "raw": "",
-  "body": null
+  "type": "Program"
 }

--- a/test/examples/empty-string-interpolation/output.json
+++ b/test/examples/empty-string-interpolation/output.json
@@ -1,59 +1,59 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
+    "raw": "\"a#{}b\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          null
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "a",
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
+            "raw": "a",
+            "type": "Quasi"
+          },
+          {
+            "column": 6,
+            "data": "b",
+            "line": 1,
+            "range": [
+              5,
+              6
+            ],
+            "raw": "b",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          7
+        ],
+        "raw": "\"a#{}b\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     8
   ],
   "raw": "\"a#{}b\"\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      7
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          7
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "a",
-            "range": [
-              1,
-              2
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 6,
-            "raw": "b",
-            "range": [
-              5,
-              6
-            ],
-            "data": "b"
-          }
-        ],
-        "expressions": [
-          null
-        ],
-        "raw": "\"a#{}b\""
-      }
-    ],
-    "raw": "\"a#{}b\""
-  }
+  "type": "Program"
 }

--- a/test/examples/equality-longhand/output.json
+++ b/test/examples/equality-longhand/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a is b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a is b",
     "statements": [
       {
-        "type": "EQOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a is b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a is b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "EQOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a is b",
+  "type": "Program"
 }

--- a/test/examples/equality/output.json
+++ b/test/examples/equality/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a == b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a == b",
     "statements": [
       {
-        "type": "EQOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a == b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a == b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "EQOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a == b",
+  "type": "Program"
 }

--- a/test/examples/existential-binary/output.json
+++ b/test/examples/existential-binary/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "a ? b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "a ? b",
     "statements": [
       {
-        "type": "ExistsOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "a ? b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a ? b",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "ExistsOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a ? b",
+  "type": "Program"
 }

--- a/test/examples/existential-unary/output.json
+++ b/test/examples/existential-unary/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 2 ],
-  "raw": "a?",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "a?",
     "statements": [
       {
-        "type": "UnaryExistsOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 2 ],
-        "raw": "a?",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          2
+        ],
+        "raw": "a?",
+        "type": "UnaryExistsOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "a?",
+  "type": "Program"
 }

--- a/test/examples/expansion/output.json
+++ b/test/examples/expansion/output.json
@@ -1,63 +1,87 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 15 ],
-  "raw": "[a, ..., b] = c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 15 ],
+    "line": 1,
+    "range": [
+      0,
+      15
+    ],
     "raw": "[a, ..., b] = c",
     "statements": [
       {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 15 ],
-        "raw": "[a, ..., b] = c",
         "assignee": {
-          "type": "ArrayInitialiser",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 11 ],
-          "raw": "[a, ..., b]",
+          "line": 1,
           "members": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 2,
-              "range": [ 1, 2 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                1,
+                2
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             },
             {
-              "type": "Expansion",
-              "line": 1,
               "column": 5,
-              "range": [ 4, 7 ],
-              "raw": "..."
+              "line": 1,
+              "range": [
+                4,
+                7
+              ],
+              "raw": "...",
+              "type": "Expansion"
             },
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 10,
-              "range": [ 9, 10 ],
+              "data": "b",
+              "line": 1,
+              "range": [
+                9,
+                10
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "range": [
+            0,
+            11
+          ],
+          "raw": "[a, ..., b]",
+          "type": "ArrayInitialiser"
         },
+        "column": 1,
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 15,
-          "range": [ 14, 15 ],
+          "data": "c",
+          "line": 1,
+          "range": [
+            14,
+            15
+          ],
           "raw": "c",
-          "data": "c"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          15
+        ],
+        "raw": "[a, ..., b] = c",
+        "type": "AssignOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    15
+  ],
+  "raw": "[a, ..., b] = c",
+  "type": "Program"
 }

--- a/test/examples/external-constructor/output.json
+++ b/test/examples/external-constructor/output.json
@@ -1,166 +1,168 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      31
+    ],
+    "raw": "f = ->\nclass A\n  constructor: f",
+    "statements": [
+      {
+        "assignee": {
+          "column": 1,
+          "data": "f",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "f",
+          "type": "Identifier"
+        },
+        "column": 1,
+        "expression": {
+          "body": null,
+          "column": 5,
+          "line": 1,
+          "parameters": [
+          ],
+          "range": [
+            4,
+            6
+          ],
+          "raw": "->",
+          "type": "Function"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "f = ->",
+        "type": "AssignOp"
+      },
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 3,
+          "range": [
+            17,
+            31
+          ],
+          "raw": "constructor: f",
+          "statements": [
+            {
+              "assignee": {
+                "column": 3,
+                "data": "constructor",
+                "line": 3,
+                "range": [
+                  17,
+                  28
+                ],
+                "raw": "constructor",
+                "type": "Identifier"
+              },
+              "column": 3,
+              "expression": {
+                "column": 16,
+                "data": "f",
+                "line": 3,
+                "range": [
+                  30,
+                  31
+                ],
+                "raw": "f",
+                "type": "Identifier"
+              },
+              "line": 3,
+              "range": [
+                17,
+                31
+              ],
+              "raw": "constructor: f",
+              "type": "Constructor"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": {
+          "assignee": {
+            "column": 3,
+            "data": "constructor",
+            "line": 3,
+            "range": [
+              17,
+              28
+            ],
+            "raw": "constructor",
+            "type": "Identifier"
+          },
+          "column": 3,
+          "expression": {
+            "column": 16,
+            "data": "f",
+            "line": 3,
+            "range": [
+              30,
+              31
+            ],
+            "raw": "f",
+            "type": "Identifier"
+          },
+          "line": 3,
+          "range": [
+            17,
+            31
+          ],
+          "raw": "constructor: f",
+          "type": "Constructor"
+        },
+        "line": 2,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 2,
+          "range": [
+            13,
+            14
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 2,
+          "range": [
+            13,
+            14
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          7,
+          31
+        ],
+        "raw": "class A\n  constructor: f",
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     32
   ],
   "raw": "f = ->\nclass A\n  constructor: f\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      31
-    ],
-    "statements": [
-      {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          6
-        ],
-        "assignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 1,
-          "raw": "f",
-          "range": [
-            0,
-            1
-          ],
-          "data": "f"
-        },
-        "expression": {
-          "type": "Function",
-          "line": 1,
-          "column": 5,
-          "range": [
-            4,
-            6
-          ],
-          "body": null,
-          "parameters": [],
-          "raw": "->"
-        },
-        "raw": "f = ->"
-      },
-      {
-        "type": "Class",
-        "line": 2,
-        "column": 1,
-        "range": [
-          7,
-          31
-        ],
-        "name": {
-          "type": "Identifier",
-          "line": 2,
-          "column": 7,
-          "raw": "A",
-          "range": [
-            13,
-            14
-          ],
-          "data": "A"
-        },
-        "nameAssignee": {
-          "type": "Identifier",
-          "line": 2,
-          "column": 7,
-          "raw": "A",
-          "range": [
-            13,
-            14
-          ],
-          "data": "A"
-        },
-        "body": {
-          "type": "Block",
-          "line": 3,
-          "column": 3,
-          "range": [
-            17,
-            31
-          ],
-          "statements": [
-            {
-              "type": "Constructor",
-              "line": 3,
-              "column": 3,
-              "range": [
-                17,
-                31
-              ],
-              "assignee": {
-                "type": "Identifier",
-                "line": 3,
-                "column": 3,
-                "raw": "constructor",
-                "range": [
-                  17,
-                  28
-                ],
-                "data": "constructor"
-              },
-              "expression": {
-                "type": "Identifier",
-                "line": 3,
-                "column": 16,
-                "raw": "f",
-                "range": [
-                  30,
-                  31
-                ],
-                "data": "f"
-              },
-              "raw": "constructor: f"
-            }
-          ],
-          "inline": false,
-          "raw": "constructor: f"
-        },
-        "boundMembers": [],
-        "parent": null,
-        "ctor": {
-          "type": "Constructor",
-          "line": 3,
-          "column": 3,
-          "range": [
-            17,
-            31
-          ],
-          "assignee": {
-            "type": "Identifier",
-            "line": 3,
-            "column": 3,
-            "raw": "constructor",
-            "range": [
-              17,
-              28
-            ],
-            "data": "constructor"
-          },
-          "expression": {
-            "type": "Identifier",
-            "line": 3,
-            "column": 16,
-            "raw": "f",
-            "range": [
-              30,
-              31
-            ],
-            "data": "f"
-          },
-          "raw": "constructor: f"
-        },
-        "raw": "class A\n  constructor: f"
-      }
-    ],
-    "raw": "f = ->\nclass A\n  constructor: f"
-  }
+  "type": "Program"
 }

--- a/test/examples/false/output.json
+++ b/test/examples/false/output.json
@@ -1,24 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "false",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "false",
     "statements": [
       {
-        "type": "Bool",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
+        "data": false,
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
         "raw": "false",
-        "data": false
+        "type": "Bool"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "false",
+  "type": "Program"
 }

--- a/test/examples/float-int-value/output.json
+++ b/test/examples/float-int-value/output.json
@@ -1,33 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    3
-  ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       3
     ],
+    "raw": "1.0",
     "statements": [
       {
-        "type": "Float",
-        "line": 1,
         "column": 1,
+        "data": 1,
+        "line": 1,
         "range": [
           0,
           3
         ],
-        "data": 1,
-        "raw": "1.0"
+        "raw": "1.0",
+        "type": "Float"
       }
     ],
-    "raw": "1.0"
+    "type": "Block"
   },
-  "raw": "1.0"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "1.0",
+  "type": "Program"
 }

--- a/test/examples/float-leading-period/output.json
+++ b/test/examples/float-leading-period/output.json
@@ -1,33 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    4
-  ],
-  "raw": ".25\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       3
     ],
+    "raw": ".25",
     "statements": [
       {
-        "type": "Float",
-        "line": 1,
         "column": 1,
+        "data": 0.25,
+        "line": 1,
         "range": [
           0,
           3
         ],
         "raw": ".25",
-        "data": 0.25
+        "type": "Float"
       }
     ],
-    "raw": ".25"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    4
+  ],
+  "raw": ".25\n",
+  "type": "Program"
 }

--- a/test/examples/float/output.json
+++ b/test/examples/float/output.json
@@ -1,24 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "1.2",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 3 ],
+    "line": 1,
+    "range": [
+      0,
+      3
+    ],
     "raw": "1.2",
     "statements": [
       {
-        "type": "Float",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 3 ],
+        "data": 1.2,
+        "line": 1,
+        "range": [
+          0,
+          3
+        ],
         "raw": "1.2",
-        "data": 1.2
+        "type": "Float"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "1.2",
+  "type": "Program"
 }

--- a/test/examples/floor-division/output.json
+++ b/test/examples/floor-division/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "7 // 3",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "7 // 3",
     "statements": [
       {
-        "type": "FloorDivideOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "7 // 3",
         "left": {
-          "type": "Int",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "7",
-          "data": 7
-        },
-        "right": {
-          "type": "Int",
+          "data": 7,
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "7",
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "7 // 3",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": 3,
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "3",
-          "data": 3
-        }
+          "type": "Int"
+        },
+        "type": "FloorDivideOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "7 // 3",
+  "type": "Program"
 }

--- a/test/examples/for-comprehension/output.json
+++ b/test/examples/for-comprehension/output.json
@@ -1,60 +1,81 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 12 ],
-  "raw": "a for b in c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
     "raw": "a for b in c",
     "statements": [
       {
-        "type": "ForIn",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 12 ],
-        "raw": "a for b in c",
         "body": {
-          "type": "Block",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
           "inline": true,
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 1,
-              "range": [ 0, 1 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": null,
         "keyAssignee": null,
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "a for b in c",
         "step": null,
         "target": {
-          "type": "Identifier",
-          "line": 1,
           "column": 12,
-          "range": [ 11, 12 ],
-          "raw": "c",
-          "data": "c"
-        },
-        "valAssignee": {
-          "type": "Identifier",
+          "data": "c",
           "line": 1,
+          "range": [
+            11,
+            12
+          ],
+          "raw": "c",
+          "type": "Identifier"
+        },
+        "type": "ForIn",
+        "valAssignee": {
           "column": 7,
-          "range": [ 6, 7 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
           "raw": "b",
-          "data": "b"
+          "type": "Identifier"
         }
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "a for b in c",
+  "type": "Program"
 }

--- a/test/examples/for-in-by/output.json
+++ b/test/examples/for-in-by/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 19 ],
-  "raw": "for a in b by c\n  d",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 19 ],
+    "line": 1,
+    "range": [
+      0,
+      19
+    ],
     "raw": "for a in b by c\n  d",
     "statements": [
       {
-        "type": "ForIn",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 19 ],
-        "raw": "for a in b by c\n  d",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 18, 19 ],
-          "raw": "d",
           "inline": false,
+          "line": 2,
+          "range": [
+            18,
+            19
+          ],
+          "raw": "d",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 18, 19 ],
+              "data": "d",
+              "line": 2,
+              "range": [
+                18,
+                19
+              ],
               "raw": "d",
-              "data": "d"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": null,
         "keyAssignee": null,
+        "line": 1,
+        "range": [
+          0,
+          19
+        ],
+        "raw": "for a in b by c\n  d",
         "step": {
-          "type": "Identifier",
-          "line": 1,
           "column": 15,
-          "range": [ 14, 15 ],
+          "data": "c",
+          "line": 1,
+          "range": [
+            14,
+            15
+          ],
           "raw": "c",
-          "data": "c"
+          "type": "Identifier"
         },
         "target": {
-          "type": "Identifier",
-          "line": 1,
           "column": 10,
-          "range": [ 9, 10 ],
-          "raw": "b",
-          "data": "b"
-        },
-        "valAssignee": {
-          "type": "Identifier",
+          "data": "b",
           "line": 1,
+          "range": [
+            9,
+            10
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "ForIn",
+        "valAssignee": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         }
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    19
+  ],
+  "raw": "for a in b by c\n  d",
+  "type": "Program"
 }

--- a/test/examples/for-in-when/output.json
+++ b/test/examples/for-in-when/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 21 ],
-  "raw": "for a in b when c\n  d",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 21 ],
+    "line": 1,
+    "range": [
+      0,
+      21
+    ],
     "raw": "for a in b when c\n  d",
     "statements": [
       {
-        "type": "ForIn",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 21 ],
-        "raw": "for a in b when c\n  d",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 20, 21 ],
-          "raw": "d",
           "inline": false,
+          "line": 2,
+          "range": [
+            20,
+            21
+          ],
+          "raw": "d",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 20, 21 ],
+              "data": "d",
+              "line": 2,
+              "range": [
+                20,
+                21
+              ],
               "raw": "d",
-              "data": "d"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": {
-          "type": "Identifier",
-          "line": 1,
           "column": 17,
-          "range": [ 16, 17 ],
+          "data": "c",
+          "line": 1,
+          "range": [
+            16,
+            17
+          ],
           "raw": "c",
-          "data": "c"
+          "type": "Identifier"
         },
         "keyAssignee": null,
+        "line": 1,
+        "range": [
+          0,
+          21
+        ],
+        "raw": "for a in b when c\n  d",
         "step": null,
         "target": {
-          "type": "Identifier",
-          "line": 1,
           "column": 10,
-          "range": [ 9, 10 ],
-          "raw": "b",
-          "data": "b"
-        },
-        "valAssignee": {
-          "type": "Identifier",
+          "data": "b",
           "line": 1,
+          "range": [
+            9,
+            10
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "ForIn",
+        "valAssignee": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         }
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    21
+  ],
+  "raw": "for a in b when c\n  d",
+  "type": "Program"
 }

--- a/test/examples/for-in-with-key-and-value-assignees/output.json
+++ b/test/examples/for-in-with-key-and-value-assignees/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 17 ],
-  "raw": "for a, i in b\n  c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
     "raw": "for a, i in b\n  c",
     "statements": [
       {
-        "type": "ForIn",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 17 ],
-        "raw": "for a, i in b\n  c",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 16, 17 ],
-          "raw": "c",
           "inline": false,
+          "line": 2,
+          "range": [
+            16,
+            17
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 16, 17 ],
+              "data": "c",
+              "line": 2,
+              "range": [
+                16,
+                17
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": null,
         "keyAssignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "i",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "i",
-          "data": "i"
+          "type": "Identifier"
         },
+        "line": 1,
+        "range": [
+          0,
+          17
+        ],
+        "raw": "for a, i in b\n  c",
         "step": null,
         "target": {
-          "type": "Identifier",
-          "line": 1,
           "column": 13,
-          "range": [ 12, 13 ],
-          "raw": "b",
-          "data": "b"
-        },
-        "valAssignee": {
-          "type": "Identifier",
+          "data": "b",
           "line": 1,
+          "range": [
+            12,
+            13
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "ForIn",
+        "valAssignee": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         }
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "for a, i in b\n  c",
+  "type": "Program"
 }

--- a/test/examples/for-in/output.json
+++ b/test/examples/for-in/output.json
@@ -1,60 +1,81 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 14 ],
-  "raw": "for a in b\n  c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 14 ],
+    "line": 1,
+    "range": [
+      0,
+      14
+    ],
     "raw": "for a in b\n  c",
     "statements": [
       {
-        "type": "ForIn",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 14 ],
-        "raw": "for a in b\n  c",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 13, 14 ],
-          "raw": "c",
           "inline": false,
+          "line": 2,
+          "range": [
+            13,
+            14
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 13, 14 ],
+              "data": "c",
+              "line": 2,
+              "range": [
+                13,
+                14
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": null,
         "keyAssignee": null,
+        "line": 1,
+        "range": [
+          0,
+          14
+        ],
+        "raw": "for a in b\n  c",
         "step": null,
         "target": {
-          "type": "Identifier",
-          "line": 1,
           "column": 10,
-          "range": [ 9, 10 ],
-          "raw": "b",
-          "data": "b"
-        },
-        "valAssignee": {
-          "type": "Identifier",
+          "data": "b",
           "line": 1,
+          "range": [
+            9,
+            10
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "ForIn",
+        "valAssignee": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         }
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    14
+  ],
+  "raw": "for a in b\n  c",
+  "type": "Program"
 }

--- a/test/examples/for-of-expression/output.json
+++ b/test/examples/for-of-expression/output.json
@@ -1,77 +1,104 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 18 ],
-  "raw": "a(for b of c\n  b)\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
     "raw": "a(for b of c\n  b)",
     "statements": [
       {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 17 ],
-        "raw": "a(for b of c\n  b)",
         "arguments": [
           {
-            "type": "ForOf",
-            "line": 1,
-            "column": 3,
-            "range": [ 2, 16 ],
-            "raw": "for b of c\n  b",
             "body": {
-              "type": "Block",
-              "line": 2,
               "column": 3,
-              "range": [ 15, 16 ],
-              "raw": "b",
               "inline": false,
+              "line": 2,
+              "range": [
+                15,
+                16
+              ],
+              "raw": "b",
               "statements": [
                 {
-                  "type": "Identifier",
-                  "line": 2,
                   "column": 3,
-                  "range": [ 15, 16 ],
+                  "data": "b",
+                  "line": 2,
+                  "range": [
+                    15,
+                    16
+                  ],
                   "raw": "b",
-                  "data": "b"
+                  "type": "Identifier"
                 }
-              ]
+              ],
+              "type": "Block"
             },
+            "column": 3,
             "filter": null,
             "isOwn": false,
             "keyAssignee": {
-              "type": "Identifier",
-              "line": 1,
               "column": 7,
-              "range": [ 6, 7 ],
-              "raw": "b",
-              "data": "b"
-            },
-            "target": {
-              "type": "Identifier",
+              "data": "b",
               "line": 1,
-              "column": 12,
-              "range": [ 11, 12 ],
-              "raw": "c",
-              "data": "c"
+              "range": [
+                6,
+                7
+              ],
+              "raw": "b",
+              "type": "Identifier"
             },
+            "line": 1,
+            "range": [
+              2,
+              16
+            ],
+            "raw": "for b of c\n  b",
+            "target": {
+              "column": 12,
+              "data": "c",
+              "line": 1,
+              "range": [
+                11,
+                12
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            },
+            "type": "ForOf",
             "valAssignee": null
           }
         ],
+        "column": 1,
         "function": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          17
+        ],
+        "raw": "a(for b of c\n  b)",
+        "type": "FunctionApplication"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    18
+  ],
+  "raw": "a(for b of c\n  b)\n",
+  "type": "Program"
 }

--- a/test/examples/for-of-when/output.json
+++ b/test/examples/for-of-when/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 21 ],
-  "raw": "for a of b when c\n  d",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 21 ],
+    "line": 1,
+    "range": [
+      0,
+      21
+    ],
     "raw": "for a of b when c\n  d",
     "statements": [
       {
-        "type": "ForOf",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 21 ],
-        "raw": "for a of b when c\n  d",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 20, 21 ],
-          "raw": "d",
           "inline": false,
+          "line": 2,
+          "range": [
+            20,
+            21
+          ],
+          "raw": "d",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 20, 21 ],
+              "data": "d",
+              "line": 2,
+              "range": [
+                20,
+                21
+              ],
               "raw": "d",
-              "data": "d"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": {
-          "type": "Identifier",
-          "line": 1,
           "column": 17,
-          "range": [ 16, 17 ],
+          "data": "c",
+          "line": 1,
+          "range": [
+            16,
+            17
+          ],
           "raw": "c",
-          "data": "c"
+          "type": "Identifier"
         },
         "isOwn": false,
         "keyAssignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 5 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "target": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
-          "column": 10,
-          "range": [ 9, 10 ],
-          "raw": "b",
-          "data": "b"
+          "range": [
+            4,
+            5
+          ],
+          "raw": "a",
+          "type": "Identifier"
         },
+        "line": 1,
+        "range": [
+          0,
+          21
+        ],
+        "raw": "for a of b when c\n  d",
+        "target": {
+          "column": 10,
+          "data": "b",
+          "line": 1,
+          "range": [
+            9,
+            10
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "ForOf",
         "valAssignee": null
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    21
+  ],
+  "raw": "for a of b when c\n  d",
+  "type": "Program"
 }

--- a/test/examples/for-of-with-key-and-value-assignees/output.json
+++ b/test/examples/for-of-with-key-and-value-assignees/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 17 ],
-  "raw": "for k, v of a\n  b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
     "raw": "for k, v of a\n  b",
     "statements": [
       {
-        "type": "ForOf",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 17 ],
-        "raw": "for k, v of a\n  b",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 16, 17 ],
-          "raw": "b",
           "inline": false,
+          "line": 2,
+          "range": [
+            16,
+            17
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 16, 17 ],
+              "data": "b",
+              "line": 2,
+              "range": [
+                16,
+                17
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": null,
         "isOwn": false,
         "keyAssignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "k",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "k",
-          "data": "k"
+          "type": "Identifier"
         },
+        "line": 1,
+        "range": [
+          0,
+          17
+        ],
+        "raw": "for k, v of a\n  b",
         "target": {
-          "type": "Identifier",
-          "line": 1,
           "column": 13,
-          "range": [ 12, 13 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "valAssignee": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            12,
+            13
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "type": "ForOf",
+        "valAssignee": {
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "v",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "v",
-          "data": "v"
+          "type": "Identifier"
         }
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "for k, v of a\n  b",
+  "type": "Program"
 }

--- a/test/examples/for-of/output.json
+++ b/test/examples/for-of/output.json
@@ -1,60 +1,81 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 14 ],
-  "raw": "for a of b\n  c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 14 ],
+    "line": 1,
+    "range": [
+      0,
+      14
+    ],
     "raw": "for a of b\n  c",
     "statements": [
       {
-        "type": "ForOf",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 14 ],
-        "raw": "for a of b\n  c",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 13, 14 ],
-          "raw": "c",
           "inline": false,
+          "line": 2,
+          "range": [
+            13,
+            14
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 13, 14 ],
+              "data": "c",
+              "line": 2,
+              "range": [
+                13,
+                14
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": null,
         "isOwn": false,
         "keyAssignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 5 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "target": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
-          "column": 10,
-          "range": [ 9, 10 ],
-          "raw": "b",
-          "data": "b"
+          "range": [
+            4,
+            5
+          ],
+          "raw": "a",
+          "type": "Identifier"
         },
+        "line": 1,
+        "range": [
+          0,
+          14
+        ],
+        "raw": "for a of b\n  c",
+        "target": {
+          "column": 10,
+          "data": "b",
+          "line": 1,
+          "range": [
+            9,
+            10
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "ForOf",
         "valAssignee": null
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    14
+  ],
+  "raw": "for a of b\n  c",
+  "type": "Program"
 }

--- a/test/examples/for-own-of/output.json
+++ b/test/examples/for-own-of/output.json
@@ -1,60 +1,81 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 18 ],
-  "raw": "for own a of b\n  c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 18 ],
+    "line": 1,
+    "range": [
+      0,
+      18
+    ],
     "raw": "for own a of b\n  c",
     "statements": [
       {
-        "type": "ForOf",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 18 ],
-        "raw": "for own a of b\n  c",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 17, 18 ],
-          "raw": "c",
           "inline": false,
+          "line": 2,
+          "range": [
+            17,
+            18
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 17, 18 ],
+              "data": "c",
+              "line": 2,
+              "range": [
+                17,
+                18
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": null,
         "isOwn": true,
         "keyAssignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 9,
-          "range": [ 8, 9 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "target": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
-          "column": 14,
-          "range": [ 13, 14 ],
-          "raw": "b",
-          "data": "b"
+          "range": [
+            8,
+            9
+          ],
+          "raw": "a",
+          "type": "Identifier"
         },
+        "line": 1,
+        "range": [
+          0,
+          18
+        ],
+        "raw": "for own a of b\n  c",
+        "target": {
+          "column": 14,
+          "data": "b",
+          "line": 1,
+          "range": [
+            13,
+            14
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "ForOf",
         "valAssignee": null
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    18
+  ],
+  "raw": "for own a of b\n  c",
+  "type": "Program"
 }

--- a/test/examples/for-repeater/output.json
+++ b/test/examples/for-repeater/output.json
@@ -1,69 +1,93 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 15 ],
-  "raw": "for [0..1]\n  2\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 14 ],
+    "line": 1,
+    "range": [
+      0,
+      14
+    ],
     "raw": "for [0..1]\n  2",
     "statements": [
       {
-        "type": "ForIn",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 14 ],
-        "raw": "for [0..1]\n  2",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 13, 14 ],
-          "raw": "2",
           "inline": false,
+          "line": 2,
+          "range": [
+            13,
+            14
+          ],
+          "raw": "2",
           "statements": [
             {
-              "type": "Int",
-              "line": 2,
               "column": 3,
-              "range": [ 13, 14 ],
+              "data": 2,
+              "line": 2,
+              "range": [
+                13,
+                14
+              ],
               "raw": "2",
-              "data": 2
+              "type": "Int"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "filter": null,
         "keyAssignee": null,
+        "line": 1,
+        "range": [
+          0,
+          14
+        ],
+        "raw": "for [0..1]\n  2",
         "step": null,
         "target": {
-          "type": "Range",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 10 ],
-          "raw": "[0..1]",
           "isInclusive": true,
           "left": {
-            "type": "Int",
-            "line": 1,
             "column": 6,
-            "range": [ 5, 6 ],
-            "raw": "0",
-            "data": 0
-          },
-          "right": {
-            "type": "Int",
+            "data": 0,
             "line": 1,
+            "range": [
+              5,
+              6
+            ],
+            "raw": "0",
+            "type": "Int"
+          },
+          "line": 1,
+          "range": [
+            4,
+            10
+          ],
+          "raw": "[0..1]",
+          "right": {
             "column": 9,
-            "range": [ 8, 9 ],
+            "data": 1,
+            "line": 1,
+            "range": [
+              8,
+              9
+            ],
             "raw": "1",
-            "data": 1
-          }
+            "type": "Int"
+          },
+          "type": "Range"
         },
+        "type": "ForIn",
         "valAssignee": null
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    15
+  ],
+  "raw": "for [0..1]\n  2\n",
+  "type": "Program"
 }

--- a/test/examples/function-ending-in-block-comment/output.json
+++ b/test/examples/function-ending-in-block-comment/output.json
@@ -1,80 +1,81 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      20
+    ],
+    "raw": "a ->\n  b\n  ### c ###",
+    "statements": [
+      {
+        "arguments": [
+          {
+            "body": {
+              "column": 3,
+              "inline": false,
+              "line": 2,
+              "range": [
+                7,
+                20
+              ],
+              "raw": "b\n  ### c ###",
+              "statements": [
+                {
+                  "column": 3,
+                  "data": "b",
+                  "line": 2,
+                  "range": [
+                    7,
+                    8
+                  ],
+                  "raw": "b",
+                  "type": "Identifier"
+                }
+              ],
+              "type": "Block"
+            },
+            "column": 3,
+            "line": 1,
+            "parameters": [
+            ],
+            "range": [
+              2,
+              20
+            ],
+            "raw": "->\n  b\n  ### c ###",
+            "type": "Function"
+          }
+        ],
+        "column": 1,
+        "function": {
+          "column": 1,
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          20
+        ],
+        "raw": "a ->\n  b\n  ### c ###",
+        "type": "FunctionApplication"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     21
   ],
   "raw": "a ->\n  b\n  ### c ###\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      20
-    ],
-    "statements": [
-      {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          20
-        ],
-        "function": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 1,
-          "raw": "a",
-          "range": [
-            0,
-            1
-          ],
-          "data": "a"
-        },
-        "arguments": [
-          {
-            "type": "Function",
-            "line": 1,
-            "column": 3,
-            "range": [
-              2,
-              20
-            ],
-            "body": {
-              "type": "Block",
-              "line": 2,
-              "column": 3,
-              "range": [
-                7,
-                20
-              ],
-              "statements": [
-                {
-                  "type": "Identifier",
-                  "line": 2,
-                  "column": 3,
-                  "raw": "b",
-                  "range": [
-                    7,
-                    8
-                  ],
-                  "data": "b"
-                }
-              ],
-              "raw": "b\n  ### c ###",
-              "inline": false
-            },
-            "parameters": [],
-            "raw": "->\n  b\n  ### c ###"
-          }
-        ],
-        "raw": "a ->\n  b\n  ### c ###"
-      }
-    ],
-    "raw": "a ->\n  b\n  ### c ###"
-  }
+  "type": "Program"
 }

--- a/test/examples/function-followed-by-block-comment/output.json
+++ b/test/examples/function-followed-by-block-comment/output.json
@@ -1,80 +1,81 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      18
+    ],
+    "raw": "a ->\n  b\n### c ###",
+    "statements": [
+      {
+        "arguments": [
+          {
+            "body": {
+              "column": 3,
+              "inline": false,
+              "line": 2,
+              "range": [
+                7,
+                8
+              ],
+              "raw": "b",
+              "statements": [
+                {
+                  "column": 3,
+                  "data": "b",
+                  "line": 2,
+                  "range": [
+                    7,
+                    8
+                  ],
+                  "raw": "b",
+                  "type": "Identifier"
+                }
+              ],
+              "type": "Block"
+            },
+            "column": 3,
+            "line": 1,
+            "parameters": [
+            ],
+            "range": [
+              2,
+              8
+            ],
+            "raw": "->\n  b",
+            "type": "Function"
+          }
+        ],
+        "column": 1,
+        "function": {
+          "column": 1,
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "a ->\n  b",
+        "type": "FunctionApplication"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     19
   ],
   "raw": "a ->\n  b\n### c ###\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      18
-    ],
-    "statements": [
-      {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          8
-        ],
-        "function": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 1,
-          "raw": "a",
-          "range": [
-            0,
-            1
-          ],
-          "data": "a"
-        },
-        "arguments": [
-          {
-            "type": "Function",
-            "line": 1,
-            "column": 3,
-            "range": [
-              2,
-              8
-            ],
-            "body": {
-              "type": "Block",
-              "line": 2,
-              "column": 3,
-              "range": [
-                7,
-                8
-              ],
-              "statements": [
-                {
-                  "type": "Identifier",
-                  "line": 2,
-                  "column": 3,
-                  "raw": "b",
-                  "range": [
-                    7,
-                    8
-                  ],
-                  "data": "b"
-                }
-              ],
-              "raw": "b",
-              "inline": false
-            },
-            "parameters": [],
-            "raw": "->\n  b"
-          }
-        ],
-        "raw": "a ->\n  b"
-      }
-    ],
-    "raw": "a ->\n  b\n### c ###"
-  }
+  "type": "Program"
 }

--- a/test/examples/function-trailing-spaces/output.json
+++ b/test/examples/function-trailing-spaces/output.json
@@ -1,73 +1,101 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 26 ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 26 ],
+    "line": 1,
+    "range": [
+      0,
+      26
+    ],
+    "raw": "main = ->\n  foo\n  bar\n\nbaz",
     "statements": [
       {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 21 ],
         "assignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 4 ],
           "data": "main",
-          "raw": "main"
-        },
-        "expression": {
-          "type": "Function",
           "line": 1,
-          "column": 8,
-          "range": [ 7, 21 ],
+          "range": [
+            0,
+            4
+          ],
+          "raw": "main",
+          "type": "Identifier"
+        },
+        "column": 1,
+        "expression": {
           "body": {
-            "type": "Block",
-            "line": 2,
             "column": 3,
-            "range": [ 12, 21 ],
-            "statements": [
-              {
-                "type": "Identifier",
-                "line": 2,
-                "column": 3,
-                "range": [ 12, 15 ],
-                "data": "foo",
-                "raw": "foo"
-              },
-              {
-                "type": "Identifier",
-                "line": 3,
-                "column": 3,
-                "range": [ 18, 21 ],
-                "data": "bar",
-                "raw": "bar"
-              }
+            "inline": false,
+            "line": 2,
+            "range": [
+              12,
+              21
             ],
             "raw": "foo\n  bar",
-            "inline": false
+            "statements": [
+              {
+                "column": 3,
+                "data": "foo",
+                "line": 2,
+                "range": [
+                  12,
+                  15
+                ],
+                "raw": "foo",
+                "type": "Identifier"
+              },
+              {
+                "column": 3,
+                "data": "bar",
+                "line": 3,
+                "range": [
+                  18,
+                  21
+                ],
+                "raw": "bar",
+                "type": "Identifier"
+              }
+            ],
+            "type": "Block"
           },
-          "parameters": [],
-          "raw": "->\n  foo\n  bar"
+          "column": 8,
+          "line": 1,
+          "parameters": [
+          ],
+          "range": [
+            7,
+            21
+          ],
+          "raw": "->\n  foo\n  bar",
+          "type": "Function"
         },
-        "raw": "main = ->\n  foo\n  bar"
+        "line": 1,
+        "range": [
+          0,
+          21
+        ],
+        "raw": "main = ->\n  foo\n  bar",
+        "type": "AssignOp"
       },
       {
-        "type": "Identifier",
-        "line": 5,
         "column": 1,
-        "range": [ 23, 26 ],
         "data": "baz",
-        "raw": "baz"
+        "line": 5,
+        "range": [
+          23,
+          26
+        ],
+        "raw": "baz",
+        "type": "Identifier"
       }
     ],
-    "raw": "main = ->\n  foo\n  bar\n\nbaz"
+    "type": "Block"
   },
-  "raw": "main = ->\n  foo\n  bar\n\nbaz"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    26
+  ],
+  "raw": "main = ->\n  foo\n  bar\n\nbaz",
+  "type": "Program"
 }

--- a/test/examples/function-with-body/output.json
+++ b/test/examples/function-with-body/output.json
@@ -1,42 +1,58 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "->\n  a\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "->\n  a",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "->\n  a",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 5, 6 ],
-          "raw": "a",
           "inline": false,
+          "line": 2,
+          "range": [
+            5,
+            6
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 5, 6 ],
+              "data": "a",
+              "line": 2,
+              "range": [
+                5,
+                6
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "parameters": []
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          6
+        ],
+        "raw": "->\n  a",
+        "type": "Function"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "->\n  a\n",
+  "type": "Program"
 }

--- a/test/examples/function-with-default-parameter/output.json
+++ b/test/examples/function-with-default-parameter/output.json
@@ -1,49 +1,67 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "(a=1) ->\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 8 ],
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
     "raw": "(a=1) ->",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 8 ],
-        "raw": "(a=1) ->",
         "body": null,
+        "column": 1,
+        "line": 1,
         "parameters": [
           {
-            "type": "DefaultParam",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 4 ],
-            "raw": "a=1",
             "default": {
-              "type": "Int",
-              "line": 1,
               "column": 4,
-              "range": [ 3, 4 ],
-              "raw": "1",
-              "data": 1
-            },
-            "param": {
-              "type": "Identifier",
+              "data": 1,
               "line": 1,
+              "range": [
+                3,
+                4
+              ],
+              "raw": "1",
+              "type": "Int"
+            },
+            "line": 1,
+            "param": {
               "column": 2,
-              "range": [ 1, 2 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                1,
+                2
+              ],
               "raw": "a",
-              "data": "a"
-            }
+              "type": "Identifier"
+            },
+            "range": [
+              1,
+              4
+            ],
+            "raw": "a=1",
+            "type": "DefaultParam"
           }
-        ]
+        ],
+        "range": [
+          0,
+          8
+        ],
+        "raw": "(a=1) ->",
+        "type": "Function"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "(a=1) ->\n",
+  "type": "Program"
 }

--- a/test/examples/function-with-parameters/output.json
+++ b/test/examples/function-with-parameters/output.json
@@ -1,42 +1,57 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "(a, b) ->",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "(a, b) ->",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "(a, b) ->",
         "body": null,
+        "column": 1,
+        "line": 1,
         "parameters": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 2 ],
+            "data": "a",
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 5,
-            "range": [ 4, 5 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           }
-        ]
+        ],
+        "range": [
+          0,
+          9
+        ],
+        "raw": "(a, b) ->",
+        "type": "Function"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "(a, b) ->",
+  "type": "Program"
 }

--- a/test/examples/function-with-statement-after-block-and-comments/output.json
+++ b/test/examples/function-with-statement-after-block-and-comments/output.json
@@ -1,50 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 27 ],
-  "raw": "->\n  a\n\n# hey\n## foo ###\nb\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 26 ],
+    "line": 1,
+    "range": [
+      0,
+      26
+    ],
+    "raw": "->\n  a\n\n# hey\n## foo ###\nb",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 6 ],
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 5, 6 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 2,
-              "column": 3,
-              "range": [ 5, 6 ],
-              "data": "a",
-              "raw": "a"
-            }
+          "inline": false,
+          "line": 2,
+          "range": [
+            5,
+            6
           ],
           "raw": "a",
-          "inline": false
+          "statements": [
+            {
+              "column": 3,
+              "data": "a",
+              "line": 2,
+              "range": [
+                5,
+                6
+              ],
+              "raw": "a",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
         },
-        "parameters": [],
-        "raw": "->\n  a"
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          6
+        ],
+        "raw": "->\n  a",
+        "type": "Function"
       },
       {
-        "type": "Identifier",
-        "line": 6,
         "column": 1,
-        "range": [ 25, 26 ],
         "data": "b",
-        "raw": "b"
+        "line": 6,
+        "range": [
+          25,
+          26
+        ],
+        "raw": "b",
+        "type": "Identifier"
       }
     ],
-    "raw": "->\n  a\n\n# hey\n## foo ###\nb"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    27
+  ],
+  "raw": "->\n  a\n\n# hey\n## foo ###\nb\n",
+  "type": "Program"
 }

--- a/test/examples/greater-than-equal/output.json
+++ b/test/examples/greater-than-equal/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a >= b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a >= b",
     "statements": [
       {
-        "type": "GTEOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a >= b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a >= b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "GTEOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a >= b",
+  "type": "Program"
 }

--- a/test/examples/greater-than/output.json
+++ b/test/examples/greater-than/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "a > b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "a > b",
     "statements": [
       {
-        "type": "GTOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "a > b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a > b",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "GTOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a > b",
+  "type": "Program"
 }

--- a/test/examples/heregex-in-method-call/output.json
+++ b/test/examples/heregex-in-method-call/output.json
@@ -1,113 +1,115 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      19
+    ],
+    "raw": "///foo///.test('a')",
+    "statements": [
+      {
+        "arguments": [
+          {
+            "column": 16,
+            "expressions": [
+            ],
+            "line": 1,
+            "quasis": [
+              {
+                "column": 17,
+                "data": "a",
+                "line": 1,
+                "range": [
+                  16,
+                  17
+                ],
+                "raw": "a",
+                "type": "Quasi"
+              }
+            ],
+            "range": [
+              15,
+              18
+            ],
+            "raw": "'a'",
+            "type": "String"
+          }
+        ],
+        "column": 1,
+        "function": {
+          "column": 1,
+          "expression": {
+            "column": 1,
+            "expressions": [
+            ],
+            "flags": {
+              "g": false,
+              "global": false,
+              "i": false,
+              "ignoreCase": false,
+              "m": false,
+              "multiline": false,
+              "sticky": false,
+              "y": false
+            },
+            "line": 1,
+            "quasis": [
+              {
+                "column": 4,
+                "data": "/foo/",
+                "line": 1,
+                "range": [
+                  3,
+                  6
+                ],
+                "raw": "foo",
+                "type": "Quasi"
+              }
+            ],
+            "range": [
+              0,
+              9
+            ],
+            "raw": "///foo///",
+            "type": "Heregex"
+          },
+          "line": 1,
+          "member": {
+            "column": 11,
+            "data": "test",
+            "line": 1,
+            "range": [
+              10,
+              14
+            ],
+            "raw": "test",
+            "type": "Identifier"
+          },
+          "range": [
+            0,
+            14
+          ],
+          "raw": "///foo///.test",
+          "type": "MemberAccessOp"
+        },
+        "line": 1,
+        "range": [
+          0,
+          19
+        ],
+        "raw": "///foo///.test('a')",
+        "type": "FunctionApplication"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     20
   ],
   "raw": "///foo///.test('a')\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      19
-    ],
-    "statements": [
-      {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          19
-        ],
-        "function": {
-          "type": "MemberAccessOp",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            14
-          ],
-          "expression": {
-            "type": "Heregex",
-            "line": 1,
-            "column": 1,
-            "raw": "///foo///",
-            "range": [
-              0,
-              9
-            ],
-            "quasis": [
-              {
-                "type": "Quasi",
-                "line": 1,
-                "column": 4,
-                "raw": "foo",
-                "range": [
-                  3,
-                  6
-                ],
-                "data": "/foo/"
-              }
-            ],
-            "expressions": [],
-            "flags": {
-              "global": false,
-              "ignoreCase": false,
-              "multiline": false,
-              "sticky": false,
-              "g": false,
-              "i": false,
-              "m": false,
-              "y": false
-            }
-          },
-          "member": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 11,
-            "raw": "test",
-            "range": [
-              10,
-              14
-            ],
-            "data": "test"
-          },
-          "raw": "///foo///.test"
-        },
-        "arguments": [
-          {
-            "type": "String",
-            "line": 1,
-            "column": 16,
-            "raw": "'a'",
-            "range": [
-              15,
-              18
-            ],
-            "quasis": [
-              {
-                "type": "Quasi",
-                "line": 1,
-                "column": 17,
-                "raw": "a",
-                "range": [
-                  16,
-                  17
-                ],
-                "data": "a"
-              }
-            ],
-            "expressions": []
-          }
-        ],
-        "raw": "///foo///.test('a')"
-      }
-    ],
-    "raw": "///foo///.test('a')"
-  }
+  "type": "Program"
 }

--- a/test/examples/heregex-with-flags/output.json
+++ b/test/examples/heregex-with-flags/output.json
@@ -1,56 +1,57 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      15
+    ],
+    "raw": "///a/b/c///gimy",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "flags": {
+          "g": true,
+          "global": true,
+          "i": true,
+          "ignoreCase": true,
+          "m": true,
+          "multiline": true,
+          "sticky": true,
+          "y": true
+        },
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "/a\\/b\\/c/gimy",
+            "line": 1,
+            "range": [
+              3,
+              8
+            ],
+            "raw": "a/b/c",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          15
+        ],
+        "raw": "///a/b/c///gimy",
+        "type": "Heregex"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     15
   ],
   "raw": "///a/b/c///gimy",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      15
-    ],
-    "statements": [
-      {
-        "type": "Heregex",
-        "line": 1,
-        "column": 1,
-        "raw": "///a/b/c///gimy",
-        "range": [
-          0,
-          15
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "a/b/c",
-            "range": [
-              3,
-              8
-            ],
-            "data": "/a\\/b\\/c/gimy"
-          }
-        ],
-        "expressions": [],
-        "flags": {
-          "global": true,
-          "ignoreCase": true,
-          "multiline": true,
-          "sticky": true,
-          "g": true,
-          "i": true,
-          "m": true,
-          "y": true
-        }
-      }
-    ],
-    "raw": "///a/b/c///gimy"
-  }
+  "type": "Program"
 }

--- a/test/examples/heregex-with-interpolations-and-flags/output.json
+++ b/test/examples/heregex-with-interpolations-and-flags/output.json
@@ -1,79 +1,79 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      30
+    ],
+    "raw": "///\n  abc # def #{ghi} j\n///gi",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 15,
+            "data": "ghi",
+            "line": 2,
+            "range": [
+              18,
+              21
+            ],
+            "raw": "ghi",
+            "type": "Identifier"
+          }
+        ],
+        "flags": {
+          "g": true,
+          "global": true,
+          "i": true,
+          "ignoreCase": true,
+          "m": false,
+          "multiline": false,
+          "sticky": false,
+          "y": false
+        },
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "abc",
+            "line": 1,
+            "range": [
+              3,
+              16
+            ],
+            "raw": "\n  abc # def ",
+            "type": "Quasi"
+          },
+          {
+            "column": 19,
+            "data": "j",
+            "line": 2,
+            "range": [
+              22,
+              25
+            ],
+            "raw": " j\n",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          30
+        ],
+        "raw": "///\n  abc # def #{ghi} j\n///gi",
+        "type": "Heregex"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     31
   ],
   "raw": "///\n  abc # def #{ghi} j\n///gi\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      30
-    ],
-    "statements": [
-      {
-        "type": "Heregex",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          30
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "\n  abc # def ",
-            "range": [
-              3,
-              16
-            ],
-            "data": "abc"
-          },
-          {
-            "type": "Quasi",
-            "line": 2,
-            "column": 19,
-            "raw": " j\n",
-            "range": [
-              22,
-              25
-            ],
-            "data": "j"
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 2,
-            "column": 15,
-            "raw": "ghi",
-            "range": [
-              18,
-              21
-            ],
-            "data": "ghi"
-          }
-        ],
-        "flags": {
-          "global": true,
-          "ignoreCase": true,
-          "multiline": false,
-          "sticky": false,
-          "g": true,
-          "i": true,
-          "m": false,
-          "y": false
-        },
-        "raw": "///\n  abc # def #{ghi} j\n///gi"
-      }
-    ],
-    "raw": "///\n  abc # def #{ghi} j\n///gi"
-  }
+  "type": "Program"
 }

--- a/test/examples/heregex-with-interpolations/output.json
+++ b/test/examples/heregex-with-interpolations/output.json
@@ -1,79 +1,79 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      29
+    ],
+    "raw": "///\n  foo\n  #{bar}  # baz\n///",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 5,
+            "data": "bar",
+            "line": 3,
+            "range": [
+              14,
+              17
+            ],
+            "raw": "bar",
+            "type": "Identifier"
+          }
+        ],
+        "flags": {
+          "g": false,
+          "global": false,
+          "i": false,
+          "ignoreCase": false,
+          "m": false,
+          "multiline": false,
+          "sticky": false,
+          "y": false
+        },
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "foo",
+            "line": 1,
+            "range": [
+              3,
+              12
+            ],
+            "raw": "\n  foo\n  ",
+            "type": "Quasi"
+          },
+          {
+            "column": 9,
+            "data": "",
+            "line": 3,
+            "range": [
+              18,
+              26
+            ],
+            "raw": "  # baz\n",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          29
+        ],
+        "raw": "///\n  foo\n  #{bar}  # baz\n///",
+        "type": "Heregex"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     30
   ],
   "raw": "///\n  foo\n  #{bar}  # baz\n///\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      29
-    ],
-    "statements": [
-      {
-        "type": "Heregex",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          29
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "\n  foo\n  ",
-            "range": [
-              3,
-              12
-            ],
-            "data": "foo"
-          },
-          {
-            "type": "Quasi",
-            "line": 3,
-            "column": 9,
-            "raw": "  # baz\n",
-            "range": [
-              18,
-              26
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 3,
-            "column": 5,
-            "raw": "bar",
-            "range": [
-              14,
-              17
-            ],
-            "data": "bar"
-          }
-        ],
-        "flags": {
-          "global": false,
-          "ignoreCase": false,
-          "multiline": false,
-          "sticky": false,
-          "g": false,
-          "i": false,
-          "m": false,
-          "y": false
-        },
-        "raw": "///\n  foo\n  #{bar}  # baz\n///"
-      }
-    ],
-    "raw": "///\n  foo\n  #{bar}  # baz\n///"
-  }
+  "type": "Program"
 }

--- a/test/examples/heregex-with-spaces-and-comments/output.json
+++ b/test/examples/heregex-with-spaces-and-comments/output.json
@@ -1,77 +1,78 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      305
+    ],
+    "raw": "OPERATOR = /// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///",
+    "statements": [
+      {
+        "assignee": {
+          "column": 1,
+          "data": "OPERATOR",
+          "line": 1,
+          "range": [
+            0,
+            8
+          ],
+          "raw": "OPERATOR",
+          "type": "Identifier"
+        },
+        "column": 1,
+        "expression": {
+          "column": 12,
+          "expressions": [
+          ],
+          "flags": {
+            "g": false,
+            "global": false,
+            "i": false,
+            "ignoreCase": false,
+            "m": false,
+            "multiline": false,
+            "sticky": false,
+            "y": false
+          },
+          "line": 1,
+          "quasis": [
+            {
+              "column": 15,
+              "data": "/^(?:[-=]>|[-+*\\/%<>&|^!?=]=|>>>=?|([-+:])\\1|([&|<>])\\2=?|\\?\\.|\\.{2,3})/",
+              "line": 1,
+              "range": [
+                14,
+                302
+              ],
+              "raw": " ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ",
+              "type": "Quasi"
+            }
+          ],
+          "range": [
+            11,
+            305
+          ],
+          "raw": "/// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///",
+          "type": "Heregex"
+        },
+        "line": 1,
+        "range": [
+          0,
+          305
+        ],
+        "raw": "OPERATOR = /// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///",
+        "type": "AssignOp"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     306
   ],
   "raw": "OPERATOR = /// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      305
-    ],
-    "statements": [
-      {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          305
-        ],
-        "assignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 1,
-          "raw": "OPERATOR",
-          "range": [
-            0,
-            8
-          ],
-          "data": "OPERATOR"
-        },
-        "expression": {
-          "type": "Heregex",
-          "line": 1,
-          "column": 12,
-          "raw": "/// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///",
-          "range": [
-            11,
-            305
-          ],
-          "quasis": [
-            {
-              "type": "Quasi",
-              "line": 1,
-              "column": 15,
-              "raw": " ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ",
-              "range": [
-                14,
-                302
-              ],
-              "data": "/^(?:[-=]>|[-+*\\/%<>&|^!?=]=|>>>=?|([-+:])\\1|([&|<>])\\2=?|\\?\\.|\\.{2,3})/"
-            }
-          ],
-          "expressions": [],
-          "flags": {
-            "global": false,
-            "ignoreCase": false,
-            "multiline": false,
-            "sticky": false,
-            "g": false,
-            "i": false,
-            "m": false,
-            "y": false
-          }
-        },
-        "raw": "OPERATOR = /// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///"
-      }
-    ],
-    "raw": "OPERATOR = /// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///"
-  }
+  "type": "Program"
 }

--- a/test/examples/heregex-with-strange-whitespace/output.json
+++ b/test/examples/heregex-with-strange-whitespace/output.json
@@ -1,56 +1,57 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 2,
+    "range": [
+      37,
+      44
+    ],
+    "raw": "/// ///",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "flags": {
+          "g": false,
+          "global": false,
+          "i": false,
+          "ignoreCase": false,
+          "m": false,
+          "multiline": false,
+          "sticky": false,
+          "y": false
+        },
+        "line": 2,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "/(?:)/",
+            "line": 2,
+            "range": [
+              40,
+              41
+            ],
+            "raw": " ",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          37,
+          44
+        ],
+        "raw": "/// ///",
+        "type": "Heregex"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     45
   ],
   "raw": "# This has a \\u2028 character in it.\n/// ///\n",
-  "body": {
-    "type": "Block",
-    "line": 2,
-    "column": 1,
-    "range": [
-      37,
-      44
-    ],
-    "statements": [
-      {
-        "type": "Heregex",
-        "line": 2,
-        "column": 1,
-        "raw": "/// ///",
-        "range": [
-          37,
-          44
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 2,
-            "column": 4,
-            "raw": " ",
-            "range": [
-              40,
-              41
-            ],
-            "data": "/(?:)/"
-          }
-        ],
-        "expressions": [],
-        "flags": {
-          "global": false,
-          "ignoreCase": false,
-          "multiline": false,
-          "sticky": false,
-          "g": false,
-          "i": false,
-          "m": false,
-          "y": false
-        }
-      }
-    ],
-    "raw": "/// ///"
-  }
+  "type": "Program"
 }

--- a/test/examples/heregex/output.json
+++ b/test/examples/heregex/output.json
@@ -1,56 +1,57 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
+    "raw": "///a/b/c///",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "flags": {
+          "g": false,
+          "global": false,
+          "i": false,
+          "ignoreCase": false,
+          "m": false,
+          "multiline": false,
+          "sticky": false,
+          "y": false
+        },
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "/a\\/b\\/c/",
+            "line": 1,
+            "range": [
+              3,
+              8
+            ],
+            "raw": "a/b/c",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          11
+        ],
+        "raw": "///a/b/c///",
+        "type": "Heregex"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     11
   ],
   "raw": "///a/b/c///",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      11
-    ],
-    "statements": [
-      {
-        "type": "Heregex",
-        "line": 1,
-        "column": 1,
-        "raw": "///a/b/c///",
-        "range": [
-          0,
-          11
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "a/b/c",
-            "range": [
-              3,
-              8
-            ],
-            "data": "/a\\/b\\/c/"
-          }
-        ],
-        "expressions": [],
-        "flags": {
-          "global": false,
-          "ignoreCase": false,
-          "multiline": false,
-          "sticky": false,
-          "g": false,
-          "i": false,
-          "m": false,
-          "y": false
-        }
-      }
-    ],
-    "raw": "///a/b/c///"
-  }
+  "type": "Program"
 }

--- a/test/examples/hexidecimal-number/output.json
+++ b/test/examples/hexidecimal-number/output.json
@@ -1,24 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "0x1B000",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 7 ],
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
     "raw": "0x1B000",
     "statements": [
       {
-        "type": "Int",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 7 ],
+        "data": 110592,
+        "line": 1,
+        "range": [
+          0,
+          7
+        ],
         "raw": "0x1B000",
-        "data": 110592
+        "type": "Int"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "0x1B000",
+  "type": "Program"
 }

--- a/test/examples/iife-in-function-call/output.json
+++ b/test/examples/iife-in-function-call/output.json
@@ -1,67 +1,93 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 13 ],
-  "raw": "a((=>\n  0)())",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 13 ],
+    "line": 1,
+    "range": [
+      0,
+      13
+    ],
     "raw": "a((=>\n  0)())",
     "statements": [
       {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 13 ],
-        "raw": "a((=>\n  0)())",
         "arguments": [
           {
-            "type": "FunctionApplication",
-            "line": 1,
+            "arguments": [
+            ],
             "column": 3,
-            "range": [ 2, 12 ],
-            "raw": "(=>\n  0)()",
-            "arguments": [],
             "function": {
-              "type": "BoundFunction",
-              "line": 1,
-              "column": 4,
-              "range": [ 3, 9 ],
-              "raw": "=>\n  0",
               "body": {
-                "type": "Block",
-                "line": 2,
                 "column": 3,
-                "range": [ 8, 9 ],
-                "raw": "0",
                 "inline": false,
+                "line": 2,
+                "range": [
+                  8,
+                  9
+                ],
+                "raw": "0",
                 "statements": [
                   {
-                    "type": "Int",
-                    "line": 2,
                     "column": 3,
-                    "range": [ 8, 9 ],
+                    "data": 0,
+                    "line": 2,
+                    "range": [
+                      8,
+                      9
+                    ],
                     "raw": "0",
-                    "data": 0
+                    "type": "Int"
                   }
-                ]
+                ],
+                "type": "Block"
               },
-              "parameters": []
-            }
+              "column": 4,
+              "line": 1,
+              "parameters": [
+              ],
+              "range": [
+                3,
+                9
+              ],
+              "raw": "=>\n  0",
+              "type": "BoundFunction"
+            },
+            "line": 1,
+            "range": [
+              2,
+              12
+            ],
+            "raw": "(=>\n  0)()",
+            "type": "FunctionApplication"
           }
         ],
+        "column": 1,
         "function": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          13
+        ],
+        "raw": "a((=>\n  0)())",
+        "type": "FunctionApplication"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    13
+  ],
+  "raw": "a((=>\n  0)())",
+  "type": "Program"
 }

--- a/test/examples/in-not/output.json
+++ b/test/examples/in-not/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 10 ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 10 ],
+    "line": 1,
+    "range": [
+      0,
+      10
+    ],
+    "raw": "a not in b",
     "statements": [
       {
-        "type": "InOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 10 ],
         "isNot": true,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
           "data": "a",
-          "raw": "a"
-        },
-        "right": {
-          "type": "Identifier",
           "line": 1,
-          "column": 10,
-          "range": [ 9, 10 ],
-          "data": "b",
-          "raw": "b"
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
         },
-        "raw": "a not in b"
+        "line": 1,
+        "range": [
+          0,
+          10
+        ],
+        "raw": "a not in b",
+        "right": {
+          "column": 10,
+          "data": "b",
+          "line": 1,
+          "range": [
+            9,
+            10
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "InOp"
       }
     ],
-    "raw": "a not in b"
+    "type": "Block"
   },
-  "raw": "a not in b"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    10
+  ],
+  "raw": "a not in b",
+  "type": "Program"
 }

--- a/test/examples/in/output.json
+++ b/test/examples/in/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a in b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a in b",
     "statements": [
       {
-        "type": "InOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a in b",
         "isNot": false,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a in b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "InOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a in b",
+  "type": "Program"
 }

--- a/test/examples/instanceof-not/output.json
+++ b/test/examples/instanceof-not/output.json
@@ -1,55 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    18
-  ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       18
     ],
+    "raw": "a not instanceof b",
     "statements": [
       {
-        "type": "InstanceofOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          18
-        ],
+        "isNot": true,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
+          "data": "a",
+          "line": 1,
           "range": [
             0,
             1
           ],
-          "data": "a",
-          "raw": "a"
+          "raw": "a",
+          "type": "Identifier"
         },
+        "line": 1,
+        "range": [
+          0,
+          18
+        ],
+        "raw": "a not instanceof b",
         "right": {
-          "type": "Identifier",
-          "line": 1,
           "column": 18,
+          "data": "b",
+          "line": 1,
           "range": [
             17,
             18
           ],
-          "data": "b",
-          "raw": "b"
+          "raw": "b",
+          "type": "Identifier"
         },
-        "raw": "a not instanceof b",
-        "isNot": true
+        "type": "InstanceofOp"
       }
     ],
-    "raw": "a not instanceof b"
+    "type": "Block"
   },
-  "raw": "a not instanceof b"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    18
+  ],
+  "raw": "a not instanceof b",
+  "type": "Program"
 }

--- a/test/examples/instanceof/output.json
+++ b/test/examples/instanceof/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 14 ],
-  "raw": "a instanceof b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 14 ],
+    "line": 1,
+    "range": [
+      0,
+      14
+    ],
     "raw": "a instanceof b",
     "statements": [
       {
-        "type": "InstanceofOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 14 ],
-        "raw": "a instanceof b",
         "isNot": false,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          14
+        ],
+        "raw": "a instanceof b",
+        "right": {
           "column": 14,
-          "range": [ 13, 14 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            13,
+            14
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "InstanceofOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    14
+  ],
+  "raw": "a instanceof b",
+  "type": "Program"
 }

--- a/test/examples/integer/output.json
+++ b/test/examples/integer/output.json
@@ -1,24 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 1 ],
-  "raw": "1",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 1 ],
+    "line": 1,
+    "range": [
+      0,
+      1
+    ],
     "raw": "1",
     "statements": [
       {
-        "type": "Int",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 1 ],
+        "data": 1,
+        "line": 1,
+        "range": [
+          0,
+          1
+        ],
         "raw": "1",
-        "data": 1
+        "type": "Int"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    1
+  ],
+  "raw": "1",
+  "type": "Program"
 }

--- a/test/examples/js/output.json
+++ b/test/examples/js/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 12 ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
+    "raw": "a = `void 0`",
     "statements": [
       {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 12 ],
         "assignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
           "data": "a",
-          "raw": "a"
-        },
-        "expression": {
-          "type": "JavaScript",
           "line": 1,
-          "column": 5,
-          "range": [ 4, 12 ],
-          "data": "void 0",
-          "raw": "`void 0`"
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
         },
-        "raw": "a = `void 0`"
+        "column": 1,
+        "expression": {
+          "column": 5,
+          "data": "void 0",
+          "line": 1,
+          "range": [
+            4,
+            12
+          ],
+          "raw": "`void 0`",
+          "type": "JavaScript"
+        },
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "a = `void 0`",
+        "type": "AssignOp"
       }
     ],
-    "raw": "a = `void 0`"
+    "type": "Block"
   },
-  "raw": "a = `void 0`"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "a = `void 0`",
+  "type": "Program"
 }

--- a/test/examples/keyword-member-access/output.json
+++ b/test/examples/keyword-member-access/output.json
@@ -1,54 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    8
-  ],
-  "raw": "a.break\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       7
     ],
+    "raw": "a.break",
     "statements": [
       {
-        "type": "MemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          7
-        ],
-        "raw": "a.break",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
+          "data": "a",
+          "line": 1,
           "range": [
             0,
             1
           ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
+        "line": 1,
         "member": {
-          "type": "Identifier",
-          "line": 1,
           "column": 3,
+          "data": "break",
+          "line": 1,
           "range": [
             2,
             7
           ],
           "raw": "break",
-          "data": "break"
-        }
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          7
+        ],
+        "raw": "a.break",
+        "type": "MemberAccessOp"
       }
     ],
-    "raw": "a.break"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    8
+  ],
+  "raw": "a.break\n",
+  "type": "Program"
 }

--- a/test/examples/less-than-equal/output.json
+++ b/test/examples/less-than-equal/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a <= b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a <= b",
     "statements": [
       {
-        "type": "LTEOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a <= b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a <= b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "LTEOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a <= b",
+  "type": "Program"
 }

--- a/test/examples/less-than/output.json
+++ b/test/examples/less-than/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "a < b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "a < b",
     "statements": [
       {
-        "type": "LTOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "a < b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a < b",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "LTOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a < b",
+  "type": "Program"
 }

--- a/test/examples/logical-and-longform/output.json
+++ b/test/examples/logical-and-longform/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "a and b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 7 ],
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
     "raw": "a and b",
     "statements": [
       {
-        "type": "LogicalAndOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 7 ],
-        "raw": "a and b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          7
+        ],
+        "raw": "a and b",
+        "right": {
           "column": 7,
-          "range": [ 6, 7 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "LogicalAndOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "a and b",
+  "type": "Program"
 }

--- a/test/examples/logical-and/output.json
+++ b/test/examples/logical-and/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a && b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a && b",
     "statements": [
       {
-        "type": "LogicalAndOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a && b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a && b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "LogicalAndOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a && b",
+  "type": "Program"
 }

--- a/test/examples/logical-or-longform/output.json
+++ b/test/examples/logical-or-longform/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a or b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a or b",
     "statements": [
       {
-        "type": "LogicalOrOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a or b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a or b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "LogicalOrOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a or b",
+  "type": "Program"
 }

--- a/test/examples/logical-or/output.json
+++ b/test/examples/logical-or/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a || b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a || b",
     "statements": [
       {
-        "type": "LogicalOrOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a || b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a || b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "LogicalOrOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a || b",
+  "type": "Program"
 }

--- a/test/examples/loop/output.json
+++ b/test/examples/loop/output.json
@@ -1,56 +1,56 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    8
-  ],
-  "raw": "loop\n  a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       8
     ],
+    "raw": "loop\n  a",
     "statements": [
       {
-        "type": "Loop",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          8
-        ],
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
+          "inline": false,
+          "line": 2,
           "range": [
             7,
             8
           ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
+              "data": "a",
+              "line": 2,
               "range": [
                 7,
                 8
               ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
           ],
-          "raw": "a",
-          "inline": false
+          "type": "Block"
         },
-        "raw": "loop\n  a"
+        "column": 1,
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "loop\n  a",
+        "type": "Loop"
       }
     ],
-    "raw": "loop\n  a"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    8
+  ],
+  "raw": "loop\n  a",
+  "type": "Program"
 }

--- a/test/examples/many-expressions-in-parens/output.json
+++ b/test/examples/many-expressions-in-parens/output.json
@@ -1,99 +1,138 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 19 ],
-  "raw": "(a; b; c; d; e) + f",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 19 ],
+    "line": 1,
+    "range": [
+      0,
+      19
+    ],
     "raw": "(a; b; c; d; e) + f",
     "statements": [
       {
-        "type": "PlusOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 19 ],
-        "raw": "(a; b; c; d; e) + f",
         "left": {
-          "type": "SeqOp",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 14 ],
-          "raw": "a; b; c; d; e",
           "left": {
-            "type": "Identifier",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 2 ],
-            "raw": "a",
-            "data": "a"
-          },
-          "right": {
-            "type": "SeqOp",
+            "data": "a",
             "line": 1,
-            "column": 5,
-            "range": [ 4, 14 ],
-            "raw": "b; c; d; e",
-            "left": {
-              "type": "Identifier",
-              "line": 1,
-              "column": 5,
-              "range": [ 4, 5 ],
-              "raw": "b",
-              "data": "b"
-            },
-            "right": {
-              "type": "SeqOp",
-              "line": 1,
-              "column": 8,
-              "range": [ 7, 14 ],
-              "raw": "c; d; e",
-              "left": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 8,
-                "range": [ 7, 8 ],
-                "raw": "c",
-                "data": "c"
-              },
-              "right": {
-                "type": "SeqOp",
-                "line": 1,
-                "column": 11,
-                "range": [ 10, 14 ],
-                "raw": "d; e",
-                "left": {
-                  "type": "Identifier",
-                  "line": 1,
-                  "column": 11,
-                  "range": [ 10, 11 ],
-                  "raw": "d",
-                  "data": "d"
-                },
-                "right": {
-                  "type": "Identifier",
-                  "line": 1,
-                  "column": 14,
-                  "range": [ 13, 14 ],
-                  "raw": "e",
-                  "data": "e"
-                }
-              }
-            }
-          }
-        },
-        "right": {
-          "type": "Identifier",
+            "range": [
+              1,
+              2
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
           "line": 1,
+          "range": [
+            1,
+            14
+          ],
+          "raw": "a; b; c; d; e",
+          "right": {
+            "column": 5,
+            "left": {
+              "column": 5,
+              "data": "b",
+              "line": 1,
+              "range": [
+                4,
+                5
+              ],
+              "raw": "b",
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              4,
+              14
+            ],
+            "raw": "b; c; d; e",
+            "right": {
+              "column": 8,
+              "left": {
+                "column": 8,
+                "data": "c",
+                "line": 1,
+                "range": [
+                  7,
+                  8
+                ],
+                "raw": "c",
+                "type": "Identifier"
+              },
+              "line": 1,
+              "range": [
+                7,
+                14
+              ],
+              "raw": "c; d; e",
+              "right": {
+                "column": 11,
+                "left": {
+                  "column": 11,
+                  "data": "d",
+                  "line": 1,
+                  "range": [
+                    10,
+                    11
+                  ],
+                  "raw": "d",
+                  "type": "Identifier"
+                },
+                "line": 1,
+                "range": [
+                  10,
+                  14
+                ],
+                "raw": "d; e",
+                "right": {
+                  "column": 14,
+                  "data": "e",
+                  "line": 1,
+                  "range": [
+                    13,
+                    14
+                  ],
+                  "raw": "e",
+                  "type": "Identifier"
+                },
+                "type": "SeqOp"
+              },
+              "type": "SeqOp"
+            },
+            "type": "SeqOp"
+          },
+          "type": "SeqOp"
+        },
+        "line": 1,
+        "range": [
+          0,
+          19
+        ],
+        "raw": "(a; b; c; d; e) + f",
+        "right": {
           "column": 19,
-          "range": [ 18, 19 ],
+          "data": "f",
+          "line": 1,
+          "range": [
+            18,
+            19
+          ],
           "raw": "f",
-          "data": "f"
-        }
+          "type": "Identifier"
+        },
+        "type": "PlusOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    19
+  ],
+  "raw": "(a; b; c; d; e) + f",
+  "type": "Program"
 }

--- a/test/examples/modulo/output.json
+++ b/test/examples/modulo/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "a %% b\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a %% b",
     "statements": [
       {
-        "type": "ModuloOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a %% b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a %% b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "ModuloOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "a %% b\n",
+  "type": "Program"
 }

--- a/test/examples/multiline-interpolated-string-with-escaped-newline/output.json
+++ b/test/examples/multiline-interpolated-string-with-escaped-newline/output.json
@@ -1,91 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      13
+    ],
+    "raw": "\"#{a}\\\n #{b}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 4,
+            "data": "a",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          {
+            "column": 4,
+            "data": "b",
+            "line": 2,
+            "range": [
+              10,
+              11
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 6,
+            "data": "",
+            "line": 1,
+            "range": [
+              5,
+              8
+            ],
+            "raw": "\\\n ",
+            "type": "Quasi"
+          },
+          {
+            "column": 6,
+            "data": "",
+            "line": 2,
+            "range": [
+              12,
+              12
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          13
+        ],
+        "raw": "\"#{a}\\\n #{b}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     14
   ],
   "raw": "\"#{a}\\\n #{b}\"\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      13
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          13
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 6,
-            "raw": "\\\n ",
-            "range": [
-              5,
-              8
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 2,
-            "column": 6,
-            "raw": "",
-            "range": [
-              12,
-              12
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 4,
-            "raw": "a",
-            "range": [
-              3,
-              4
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Identifier",
-            "line": 2,
-            "column": 4,
-            "raw": "b",
-            "range": [
-              10,
-              11
-            ],
-            "data": "b"
-          }
-        ],
-        "raw": "\"#{a}\\\n #{b}\""
-      }
-    ],
-    "raw": "\"#{a}\\\n #{b}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/multiline-string-with-interpolations-and-quotes/output.json
+++ b/test/examples/multiline-string-with-interpolations-and-quotes/output.json
@@ -1,91 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      39
+    ],
+    "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 9,
+            "data": "c",
+            "line": 3,
+            "range": [
+              16,
+              17
+            ],
+            "raw": "c",
+            "type": "Identifier"
+          },
+          {
+            "column": 9,
+            "data": "e",
+            "line": 4,
+            "range": [
+              28,
+              29
+            ],
+            "raw": "e",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "a\n  b\"",
+            "line": 1,
+            "range": [
+              3,
+              14
+            ],
+            "raw": "\n  a\n    b\"",
+            "type": "Quasi"
+          },
+          {
+            "column": 11,
+            "data": "\"\n  d\"",
+            "line": 3,
+            "range": [
+              18,
+              26
+            ],
+            "raw": "\"\n    d\"",
+            "type": "Quasi"
+          },
+          {
+            "column": 11,
+            "data": "\"\nf",
+            "line": 4,
+            "range": [
+              30,
+              36
+            ],
+            "raw": "\"\n  f\n",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          39
+        ],
+        "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     40
   ],
   "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\"\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      39
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          39
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "\n  a\n    b\"",
-            "range": [
-              3,
-              14
-            ],
-            "data": "a\n  b\""
-          },
-          {
-            "type": "Quasi",
-            "line": 3,
-            "column": 11,
-            "raw": "\"\n    d\"",
-            "range": [
-              18,
-              26
-            ],
-            "data": "\"\n  d\""
-          },
-          {
-            "type": "Quasi",
-            "line": 4,
-            "column": 11,
-            "raw": "\"\n  f\n",
-            "range": [
-              30,
-              36
-            ],
-            "data": "\"\nf"
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 3,
-            "column": 9,
-            "raw": "c",
-            "range": [
-              16,
-              17
-            ],
-            "data": "c"
-          },
-          {
-            "type": "Identifier",
-            "line": 4,
-            "column": 9,
-            "raw": "e",
-            "range": [
-              28,
-              29
-            ],
-            "data": "e"
-          }
-        ],
-        "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\""
-      }
-    ],
-    "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\""
-  }
+  "type": "Program"
 }

--- a/test/examples/multiline-string-with-quoted-interpolations-and-non-interpolations/output.json
+++ b/test/examples/multiline-string-with-quoted-interpolations-and-non-interpolations/output.json
@@ -1,91 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      48
+    ],
+    "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 9,
+            "data": "c",
+            "line": 3,
+            "range": [
+              16,
+              17
+            ],
+            "raw": "c",
+            "type": "Identifier"
+          },
+          {
+            "column": 9,
+            "data": "g",
+            "line": 5,
+            "range": [
+              37,
+              38
+            ],
+            "raw": "g",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "a\n  b\"",
+            "line": 1,
+            "range": [
+              3,
+              14
+            ],
+            "raw": "\n  a\n    b\"",
+            "type": "Quasi"
+          },
+          {
+            "column": 11,
+            "data": "\"\n  d\"e\"\n  f\"",
+            "line": 3,
+            "range": [
+              18,
+              35
+            ],
+            "raw": "\"\n    d\"e\"\n    f\"",
+            "type": "Quasi"
+          },
+          {
+            "column": 11,
+            "data": "\"\nh",
+            "line": 5,
+            "range": [
+              39,
+              45
+            ],
+            "raw": "\"\n  h\n",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          48
+        ],
+        "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     49
   ],
   "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\"\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      48
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          48
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "\n  a\n    b\"",
-            "range": [
-              3,
-              14
-            ],
-            "data": "a\n  b\""
-          },
-          {
-            "type": "Quasi",
-            "line": 3,
-            "column": 11,
-            "raw": "\"\n    d\"e\"\n    f\"",
-            "range": [
-              18,
-              35
-            ],
-            "data": "\"\n  d\"e\"\n  f\""
-          },
-          {
-            "type": "Quasi",
-            "line": 5,
-            "column": 11,
-            "raw": "\"\n  h\n",
-            "range": [
-              39,
-              45
-            ],
-            "data": "\"\nh"
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 3,
-            "column": 9,
-            "raw": "c",
-            "range": [
-              16,
-              17
-            ],
-            "data": "c"
-          },
-          {
-            "type": "Identifier",
-            "line": 5,
-            "column": 9,
-            "raw": "g",
-            "range": [
-              37,
-              38
-            ],
-            "data": "g"
-          }
-        ],
-        "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\""
-      }
-    ],
-    "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\""
-  }
+  "type": "Program"
 }

--- a/test/examples/multiple-expressions-in-parens/output.json
+++ b/test/examples/multiple-expressions-in-parens/output.json
@@ -1,54 +1,75 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 10 ],
-  "raw": "a + (b; c)",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 10 ],
+    "line": 1,
+    "range": [
+      0,
+      10
+    ],
     "raw": "a + (b; c)",
     "statements": [
       {
-        "type": "PlusOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 10 ],
-        "raw": "a + (b; c)",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "SeqOp",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          10
+        ],
+        "raw": "a + (b; c)",
+        "right": {
           "column": 6,
-          "range": [ 5, 9 ],
-          "raw": "b; c",
           "left": {
-            "type": "Identifier",
-            "line": 1,
             "column": 6,
-            "range": [ 5, 6 ],
-            "raw": "b",
-            "data": "b"
-          },
-          "right": {
-            "type": "Identifier",
+            "data": "b",
             "line": 1,
+            "range": [
+              5,
+              6
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            5,
+            9
+          ],
+          "raw": "b; c",
+          "right": {
             "column": 9,
-            "range": [ 8, 9 ],
+            "data": "c",
+            "line": 1,
+            "range": [
+              8,
+              9
+            ],
             "raw": "c",
-            "data": "c"
-          }
-        }
+            "type": "Identifier"
+          },
+          "type": "SeqOp"
+        },
+        "type": "PlusOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    10
+  ],
+  "raw": "a + (b; c)",
+  "type": "Program"
 }

--- a/test/examples/multiplication/output.json
+++ b/test/examples/multiplication/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "3 * 4",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "3 * 4",
     "statements": [
       {
-        "type": "MultiplyOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "3 * 4",
         "left": {
-          "type": "Int",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "3",
-          "data": 3
-        },
-        "right": {
-          "type": "Int",
+          "data": 3,
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "3",
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "3 * 4",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": 4,
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "4",
-          "data": 4
-        }
+          "type": "Int"
+        },
+        "type": "MultiplyOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "3 * 4",
+  "type": "Program"
 }

--- a/test/examples/negated-equality-longhand/output.json
+++ b/test/examples/negated-equality-longhand/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 8 ],
-  "raw": "a isnt b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 8 ],
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
     "raw": "a isnt b",
     "statements": [
       {
-        "type": "NEQOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 8 ],
-        "raw": "a isnt b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "a isnt b",
+        "right": {
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "NEQOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    8
+  ],
+  "raw": "a isnt b",
+  "type": "Program"
 }

--- a/test/examples/negated-equality/output.json
+++ b/test/examples/negated-equality/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a != b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a != b",
     "statements": [
       {
-        "type": "NEQOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a != b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a != b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "NEQOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a != b",
+  "type": "Program"
 }

--- a/test/examples/negation-with-not/output.json
+++ b/test/examples/negation-with-not/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "not a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "not a",
     "statements": [
       {
-        "type": "LogicalNotOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "not a",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "not a",
+        "type": "LogicalNotOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "not a",
+  "type": "Program"
 }

--- a/test/examples/negation/output.json
+++ b/test/examples/negation/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 2 ],
-  "raw": "!a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "!a",
     "statements": [
       {
-        "type": "LogicalNotOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 2 ],
-        "raw": "!a",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 2 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            1,
+            2
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          2
+        ],
+        "raw": "!a",
+        "type": "LogicalNotOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "!a",
+  "type": "Program"
 }

--- a/test/examples/nested-code-with-outdent/output.json
+++ b/test/examples/nested-code-with-outdent/output.json
@@ -1,204 +1,205 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      52
+    ],
+    "raw": "a {\n  b: ->\n    return c d,\n      if e\n        f\n}\ng",
+    "statements": [
+      {
+        "arguments": [
+          {
+            "column": 3,
+            "line": 1,
+            "members": [
+              {
+                "column": 3,
+                "expression": {
+                  "body": {
+                    "column": 5,
+                    "inline": false,
+                    "line": 3,
+                    "range": [
+                      16,
+                      48
+                    ],
+                    "raw": "return c d,\n      if e\n        f",
+                    "statements": [
+                      {
+                        "column": 5,
+                        "expression": {
+                          "arguments": [
+                            {
+                              "column": 14,
+                              "data": "d",
+                              "line": 3,
+                              "range": [
+                                25,
+                                26
+                              ],
+                              "raw": "d",
+                              "type": "Identifier"
+                            },
+                            {
+                              "alternate": null,
+                              "column": 7,
+                              "condition": {
+                                "column": 10,
+                                "data": "e",
+                                "line": 4,
+                                "range": [
+                                  37,
+                                  38
+                                ],
+                                "raw": "e",
+                                "type": "Identifier"
+                              },
+                              "consequent": {
+                                "column": 9,
+                                "inline": false,
+                                "line": 5,
+                                "range": [
+                                  47,
+                                  48
+                                ],
+                                "raw": "f",
+                                "statements": [
+                                  {
+                                    "column": 9,
+                                    "data": "f",
+                                    "line": 5,
+                                    "range": [
+                                      47,
+                                      48
+                                    ],
+                                    "raw": "f",
+                                    "type": "Identifier"
+                                  }
+                                ],
+                                "type": "Block"
+                              },
+                              "isUnless": false,
+                              "line": 4,
+                              "range": [
+                                34,
+                                48
+                              ],
+                              "raw": "if e\n        f",
+                              "type": "Conditional"
+                            }
+                          ],
+                          "column": 12,
+                          "function": {
+                            "column": 12,
+                            "data": "c",
+                            "line": 3,
+                            "range": [
+                              23,
+                              24
+                            ],
+                            "raw": "c",
+                            "type": "Identifier"
+                          },
+                          "line": 3,
+                          "range": [
+                            23,
+                            48
+                          ],
+                          "raw": "c d,\n      if e\n        f",
+                          "type": "FunctionApplication"
+                        },
+                        "line": 3,
+                        "range": [
+                          16,
+                          48
+                        ],
+                        "raw": "return c d,\n      if e\n        f",
+                        "type": "Return"
+                      }
+                    ],
+                    "type": "Block"
+                  },
+                  "column": 6,
+                  "line": 2,
+                  "parameters": [
+                  ],
+                  "range": [
+                    9,
+                    48
+                  ],
+                  "raw": "->\n    return c d,\n      if e\n        f",
+                  "type": "Function"
+                },
+                "key": {
+                  "column": 3,
+                  "data": "b",
+                  "line": 2,
+                  "range": [
+                    6,
+                    7
+                  ],
+                  "raw": "b",
+                  "type": "Identifier"
+                },
+                "line": 2,
+                "range": [
+                  6,
+                  48
+                ],
+                "raw": "b: ->\n    return c d,\n      if e\n        f",
+                "type": "ObjectInitialiserMember"
+              }
+            ],
+            "range": [
+              2,
+              50
+            ],
+            "raw": "{\n  b: ->\n    return c d,\n      if e\n        f\n}",
+            "type": "ObjectInitialiser"
+          }
+        ],
+        "column": 1,
+        "function": {
+          "column": 1,
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          50
+        ],
+        "raw": "a {\n  b: ->\n    return c d,\n      if e\n        f\n}",
+        "type": "FunctionApplication"
+      },
+      {
+        "column": 1,
+        "data": "g",
+        "line": 7,
+        "range": [
+          51,
+          52
+        ],
+        "raw": "g",
+        "type": "Identifier"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     53
   ],
   "raw": "a {\n  b: ->\n    return c d,\n      if e\n        f\n}\ng\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      52
-    ],
-    "statements": [
-      {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          50
-        ],
-        "function": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            1
-          ],
-          "data": "a",
-          "raw": "a"
-        },
-        "arguments": [
-          {
-            "type": "ObjectInitialiser",
-            "line": 1,
-            "column": 3,
-            "range": [
-              2,
-              50
-            ],
-            "members": [
-              {
-                "type": "ObjectInitialiserMember",
-                "line": 2,
-                "column": 3,
-                "range": [
-                  6,
-                  48
-                ],
-                "key": {
-                  "type": "Identifier",
-                  "line": 2,
-                  "column": 3,
-                  "range": [
-                    6,
-                    7
-                  ],
-                  "data": "b",
-                  "raw": "b"
-                },
-                "expression": {
-                  "type": "Function",
-                  "line": 2,
-                  "column": 6,
-                  "range": [
-                    9,
-                    48
-                  ],
-                  "body": {
-                    "type": "Block",
-                    "line": 3,
-                    "column": 5,
-                    "range": [
-                      16,
-                      48
-                    ],
-                    "statements": [
-                      {
-                        "type": "Return",
-                        "line": 3,
-                        "column": 5,
-                        "range": [
-                          16,
-                          48
-                        ],
-                        "expression": {
-                          "type": "FunctionApplication",
-                          "line": 3,
-                          "column": 12,
-                          "range": [
-                            23,
-                            48
-                          ],
-                          "function": {
-                            "type": "Identifier",
-                            "line": 3,
-                            "column": 12,
-                            "range": [
-                              23,
-                              24
-                            ],
-                            "data": "c",
-                            "raw": "c"
-                          },
-                          "arguments": [
-                            {
-                              "type": "Identifier",
-                              "line": 3,
-                              "column": 14,
-                              "range": [
-                                25,
-                                26
-                              ],
-                              "data": "d",
-                              "raw": "d"
-                            },
-                            {
-                              "type": "Conditional",
-                              "line": 4,
-                              "column": 7,
-                              "range": [
-                                34,
-                                48
-                              ],
-                              "isUnless": false,
-                              "condition": {
-                                "type": "Identifier",
-                                "line": 4,
-                                "column": 10,
-                                "range": [
-                                  37,
-                                  38
-                                ],
-                                "data": "e",
-                                "raw": "e"
-                              },
-                              "consequent": {
-                                "type": "Block",
-                                "line": 5,
-                                "column": 9,
-                                "range": [
-                                  47,
-                                  48
-                                ],
-                                "statements": [
-                                  {
-                                    "type": "Identifier",
-                                    "line": 5,
-                                    "column": 9,
-                                    "range": [
-                                      47,
-                                      48
-                                    ],
-                                    "data": "f",
-                                    "raw": "f"
-                                  }
-                                ],
-                                "raw": "f",
-                                "inline": false
-                              },
-                              "alternate": null,
-                              "raw": "if e\n        f"
-                            }
-                          ],
-                          "raw": "c d,\n      if e\n        f"
-                        },
-                        "raw": "return c d,\n      if e\n        f"
-                      }
-                    ],
-                    "raw": "return c d,\n      if e\n        f",
-                    "inline": false
-                  },
-                  "parameters": [],
-                  "raw": "->\n    return c d,\n      if e\n        f"
-                },
-                "raw": "b: ->\n    return c d,\n      if e\n        f"
-              }
-            ],
-            "raw": "{\n  b: ->\n    return c d,\n      if e\n        f\n}"
-          }
-        ],
-        "raw": "a {\n  b: ->\n    return c d,\n      if e\n        f\n}"
-      },
-      {
-        "type": "Identifier",
-        "line": 7,
-        "column": 1,
-        "range": [
-          51,
-          52
-        ],
-        "data": "g",
-        "raw": "g"
-      }
-    ],
-    "raw": "a {\n  b: ->\n    return c d,\n      if e\n        f\n}\ng"
-  }
+  "type": "Program"
 }

--- a/test/examples/nested-conditionals/output.json
+++ b/test/examples/nested-conditionals/output.json
@@ -1,112 +1,151 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 31 ],
-  "raw": "if a\n  b\nelse if c\n  d\nelse\n  e",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 31 ],
+    "line": 1,
+    "range": [
+      0,
+      31
+    ],
     "raw": "if a\n  b\nelse if c\n  d\nelse\n  e",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 31 ],
-        "raw": "if a\n  b\nelse if c\n  d\nelse\n  e",
         "alternate": {
-          "type": "Block",
-          "line": 3,
           "column": 6,
-          "range": [ 14, 31 ],
-          "raw": "if c\n  d\nelse\n  e",
           "inline": true,
+          "line": 3,
+          "range": [
+            14,
+            31
+          ],
+          "raw": "if c\n  d\nelse\n  e",
           "statements": [
             {
-              "type": "Conditional",
-              "line": 3,
-              "column": 6,
-              "range": [ 14, 31 ],
-              "raw": "if c\n  d\nelse\n  e",
               "alternate": {
-                "type": "Block",
-                "line": 6,
                 "column": 3,
-                "range": [ 30, 31 ],
-                "raw": "e",
                 "inline": false,
+                "line": 6,
+                "range": [
+                  30,
+                  31
+                ],
+                "raw": "e",
                 "statements": [
                   {
-                    "type": "Identifier",
-                    "line": 6,
                     "column": 3,
-                    "range": [ 30, 31 ],
+                    "data": "e",
+                    "line": 6,
+                    "range": [
+                      30,
+                      31
+                    ],
                     "raw": "e",
-                    "data": "e"
+                    "type": "Identifier"
                   }
-                ]
+                ],
+                "type": "Block"
               },
+              "column": 6,
               "condition": {
-                "type": "Identifier",
-                "line": 3,
                 "column": 9,
-                "range": [ 17, 18 ],
+                "data": "c",
+                "line": 3,
+                "range": [
+                  17,
+                  18
+                ],
                 "raw": "c",
-                "data": "c"
+                "type": "Identifier"
               },
               "consequent": {
-                "type": "Block",
-                "line": 4,
                 "column": 3,
-                "range": [ 21, 22 ],
-                "raw": "d",
                 "inline": false,
+                "line": 4,
+                "range": [
+                  21,
+                  22
+                ],
+                "raw": "d",
                 "statements": [
                   {
-                    "type": "Identifier",
-                    "line": 4,
                     "column": 3,
-                    "range": [ 21, 22 ],
+                    "data": "d",
+                    "line": 4,
+                    "range": [
+                      21,
+                      22
+                    ],
                     "raw": "d",
-                    "data": "d"
+                    "type": "Identifier"
                   }
-                ]
+                ],
+                "type": "Block"
               },
-              "isUnless": false
+              "isUnless": false,
+              "line": 3,
+              "range": [
+                14,
+                31
+              ],
+              "raw": "if c\n  d\nelse\n  e",
+              "type": "Conditional"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 4,
-          "range": [ 3, 4 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            3,
+            4
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 7, 8 ],
-          "raw": "b",
           "inline": false,
+          "line": 2,
+          "range": [
+            7,
+            8
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 7, 8 ],
+              "data": "b",
+              "line": 2,
+              "range": [
+                7,
+                8
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "isUnless": false
+        "isUnless": false,
+        "line": 1,
+        "range": [
+          0,
+          31
+        ],
+        "raw": "if a\n  b\nelse if c\n  d\nelse\n  e",
+        "type": "Conditional"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    31
+  ],
+  "raw": "if a\n  b\nelse if c\n  d\nelse\n  e",
+  "type": "Program"
 }

--- a/test/examples/nested-member-expressions/output.json
+++ b/test/examples/nested-member-expressions/output.json
@@ -1,75 +1,75 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    5
-  ],
-  "raw": "a.b.c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       5
     ],
+    "raw": "a.b.c",
     "statements": [
       {
-        "type": "MemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          5
-        ],
-        "raw": "a.b.c",
         "expression": {
-          "type": "MemberAccessOp",
-          "line": 1,
           "column": 1,
-          "range": [
-            0,
-            3
-          ],
-          "raw": "a.b",
           "expression": {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
+            "data": "a",
+            "line": 1,
             "range": [
               0,
               1
             ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
+          "line": 1,
           "member": {
-            "type": "Identifier",
-            "line": 1,
             "column": 3,
+            "data": "b",
+            "line": 1,
             "range": [
               2,
               3
             ],
             "raw": "b",
-            "data": "b"
-          }
+            "type": "Identifier"
+          },
+          "range": [
+            0,
+            3
+          ],
+          "raw": "a.b",
+          "type": "MemberAccessOp"
         },
+        "line": 1,
         "member": {
-          "type": "Identifier",
-          "line": 1,
           "column": 5,
+          "data": "c",
+          "line": 1,
           "range": [
             4,
             5
           ],
           "raw": "c",
-          "data": "c"
-        }
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a.b.c",
+        "type": "MemberAccessOp"
       }
     ],
-    "raw": "a.b.c"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a.b.c",
+  "type": "Program"
 }

--- a/test/examples/nested-object-literals/output.json
+++ b/test/examples/nested-object-literals/output.json
@@ -1,72 +1,99 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "a:\n  b: c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "a:\n  b: c",
     "statements": [
       {
-        "type": "ObjectInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "a:\n  b: c",
+        "line": 1,
         "members": [
           {
-            "type": "ObjectInitialiserMember",
-            "line": 1,
             "column": 1,
-            "range": [ 0, 9 ],
-            "raw": "a:\n  b: c",
             "expression": {
-              "type": "ObjectInitialiser",
-              "line": 2,
               "column": 3,
-              "range": [ 5, 9 ],
-              "raw": "b: c",
+              "line": 2,
               "members": [
                 {
-                  "type": "ObjectInitialiserMember",
-                  "line": 2,
                   "column": 3,
-                  "range": [ 5, 9 ],
-                  "raw": "b: c",
                   "expression": {
-                    "type": "Identifier",
-                    "line": 2,
                     "column": 6,
-                    "range": [ 8, 9 ],
+                    "data": "c",
+                    "line": 2,
+                    "range": [
+                      8,
+                      9
+                    ],
                     "raw": "c",
-                    "data": "c"
+                    "type": "Identifier"
                   },
                   "key": {
-                    "type": "Identifier",
-                    "line": 2,
                     "column": 3,
-                    "range": [ 5, 6 ],
+                    "data": "b",
+                    "line": 2,
+                    "range": [
+                      5,
+                      6
+                    ],
                     "raw": "b",
-                    "data": "b"
-                  }
+                    "type": "Identifier"
+                  },
+                  "line": 2,
+                  "range": [
+                    5,
+                    9
+                  ],
+                  "raw": "b: c",
+                  "type": "ObjectInitialiserMember"
                 }
-              ]
+              ],
+              "range": [
+                5,
+                9
+              ],
+              "raw": "b: c",
+              "type": "ObjectInitialiser"
             },
             "key": {
-              "type": "Identifier",
-              "line": 1,
               "column": 1,
-              "range": [ 0, 1 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
               "raw": "a",
-              "data": "a"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              0,
+              9
+            ],
+            "raw": "a:\n  b: c",
+            "type": "ObjectInitialiserMember"
           }
-        ]
+        ],
+        "range": [
+          0,
+          9
+        ],
+        "raw": "a:\n  b: c",
+        "type": "ObjectInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "a:\n  b: c",
+  "type": "Program"
 }

--- a/test/examples/nested-string-interpolation/output.json
+++ b/test/examples/nested-string-interpolation/output.json
@@ -1,105 +1,105 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      13
+    ],
+    "raw": "\"a#{\"b#{c}\"}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 5,
+            "expressions": [
+              {
+                "column": 9,
+                "data": "c",
+                "line": 1,
+                "range": [
+                  8,
+                  9
+                ],
+                "raw": "c",
+                "type": "Identifier"
+              }
+            ],
+            "line": 1,
+            "quasis": [
+              {
+                "column": 6,
+                "data": "b",
+                "line": 1,
+                "range": [
+                  5,
+                  6
+                ],
+                "raw": "b",
+                "type": "Quasi"
+              },
+              {
+                "column": 11,
+                "data": "",
+                "line": 1,
+                "range": [
+                  10,
+                  10
+                ],
+                "raw": "",
+                "type": "Quasi"
+              }
+            ],
+            "range": [
+              4,
+              11
+            ],
+            "raw": "\"b#{c}\"",
+            "type": "String"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "a",
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
+            "raw": "a",
+            "type": "Quasi"
+          },
+          {
+            "column": 13,
+            "data": "",
+            "line": 1,
+            "range": [
+              12,
+              12
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          13
+        ],
+        "raw": "\"a#{\"b#{c}\"}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     13
   ],
   "raw": "\"a#{\"b#{c}\"}\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      13
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          13
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "a",
-            "range": [
-              1,
-              2
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 13,
-            "raw": "",
-            "range": [
-              12,
-              12
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "String",
-            "line": 1,
-            "column": 5,
-            "range": [
-              4,
-              11
-            ],
-            "quasis": [
-              {
-                "type": "Quasi",
-                "line": 1,
-                "column": 6,
-                "raw": "b",
-                "range": [
-                  5,
-                  6
-                ],
-                "data": "b"
-              },
-              {
-                "type": "Quasi",
-                "line": 1,
-                "column": 11,
-                "raw": "",
-                "range": [
-                  10,
-                  10
-                ],
-                "data": ""
-              }
-            ],
-            "expressions": [
-              {
-                "type": "Identifier",
-                "line": 1,
-                "column": 9,
-                "raw": "c",
-                "range": [
-                  8,
-                  9
-                ],
-                "data": "c"
-              }
-            ],
-            "raw": "\"b#{c}\""
-          }
-        ],
-        "raw": "\"a#{\"b#{c}\"}\""
-      }
-    ],
-    "raw": "\"a#{\"b#{c}\"}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/new-with-method-call/output.json
+++ b/test/examples/new-with-method-call/output.json
@@ -1,112 +1,114 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    16
-  ],
-  "raw": "-> new A().b(c)\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       15
     ],
+    "raw": "-> new A().b(c)",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          15
-        ],
         "body": {
-          "type": "Block",
-          "line": 1,
           "column": 4,
+          "inline": true,
+          "line": 1,
           "range": [
             3,
             15
           ],
+          "raw": "new A().b(c)",
           "statements": [
             {
-              "type": "FunctionApplication",
-              "line": 1,
-              "column": 4,
-              "range": [
-                3,
-                15
-              ],
-              "function": {
-                "type": "MemberAccessOp",
-                "line": 1,
-                "column": 4,
-                "range": [
-                  3,
-                  12
-                ],
-                "expression": {
-                  "type": "NewOp",
-                  "line": 1,
-                  "column": 4,
-                  "range": [
-                    3,
-                    10
-                  ],
-                  "ctor": {
-                    "type": "Identifier",
-                    "line": 1,
-                    "column": 8,
-                    "range": [
-                      7,
-                      8
-                    ],
-                    "raw": "A",
-                    "data": "A"
-                  },
-                  "arguments": [],
-                  "raw": "new A()"
-                },
-                "member": {
-                  "type": "Identifier",
-                  "line": 1,
-                  "column": 12,
-                  "range": [
-                    11,
-                    12
-                  ],
-                  "raw": "b",
-                  "data": "b"
-                },
-                "raw": "new A().b"
-              },
               "arguments": [
                 {
-                  "type": "Identifier",
-                  "line": 1,
                   "column": 14,
+                  "data": "c",
+                  "line": 1,
                   "range": [
                     13,
                     14
                   ],
                   "raw": "c",
-                  "data": "c"
+                  "type": "Identifier"
                 }
               ],
-              "raw": "new A().b(c)"
+              "column": 4,
+              "function": {
+                "column": 4,
+                "expression": {
+                  "arguments": [
+                  ],
+                  "column": 4,
+                  "ctor": {
+                    "column": 8,
+                    "data": "A",
+                    "line": 1,
+                    "range": [
+                      7,
+                      8
+                    ],
+                    "raw": "A",
+                    "type": "Identifier"
+                  },
+                  "line": 1,
+                  "range": [
+                    3,
+                    10
+                  ],
+                  "raw": "new A()",
+                  "type": "NewOp"
+                },
+                "line": 1,
+                "member": {
+                  "column": 12,
+                  "data": "b",
+                  "line": 1,
+                  "range": [
+                    11,
+                    12
+                  ],
+                  "raw": "b",
+                  "type": "Identifier"
+                },
+                "range": [
+                  3,
+                  12
+                ],
+                "raw": "new A().b",
+                "type": "MemberAccessOp"
+              },
+              "line": 1,
+              "range": [
+                3,
+                15
+              ],
+              "raw": "new A().b(c)",
+              "type": "FunctionApplication"
             }
           ],
-          "raw": "new A().b(c)",
-          "inline": true
+          "type": "Block"
         },
-        "parameters": [],
-        "raw": "-> new A().b(c)"
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          15
+        ],
+        "raw": "-> new A().b(c)",
+        "type": "Function"
       }
     ],
-    "raw": "-> new A().b(c)"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    16
+  ],
+  "raw": "-> new A().b(c)\n",
+  "type": "Program"
 }

--- a/test/examples/new-without-parens/output.json
+++ b/test/examples/new-without-parens/output.json
@@ -1,32 +1,45 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "new A",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "new A",
     "statements": [
       {
-        "type": "NewOp",
-        "line": 1,
+        "arguments": [
+        ],
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "new A",
-        "arguments": [],
         "ctor": {
-          "type": "Identifier",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "A",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "A",
-          "data": "A"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "new A",
+        "type": "NewOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "new A",
+  "type": "Program"
 }

--- a/test/examples/new/output.json
+++ b/test/examples/new/output.json
@@ -1,65 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    9
-  ],
-  "raw": "new a.B()",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       9
     ],
+    "raw": "new a.B()",
     "statements": [
       {
-        "type": "NewOp",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          9
+        "arguments": [
         ],
+        "column": 1,
         "ctor": {
-          "type": "MemberAccessOp",
-          "line": 1,
           "column": 5,
-          "range": [
-            4,
-            7
-          ],
-          "raw": "a.B",
           "expression": {
-            "type": "Identifier",
-            "line": 1,
             "column": 5,
+            "data": "a",
+            "line": 1,
             "range": [
               4,
               5
             ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
+          "line": 1,
           "member": {
-            "type": "Identifier",
-            "line": 1,
             "column": 7,
+            "data": "B",
+            "line": 1,
             "range": [
               6,
               7
             ],
             "raw": "B",
-            "data": "B"
-          }
+            "type": "Identifier"
+          },
+          "range": [
+            4,
+            7
+          ],
+          "raw": "a.B",
+          "type": "MemberAccessOp"
         },
-        "arguments": [],
-        "raw": "new a.B()"
+        "line": 1,
+        "range": [
+          0,
+          9
+        ],
+        "raw": "new a.B()",
+        "type": "NewOp"
       }
     ],
-    "raw": "new a.B()"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "new a.B()",
+  "type": "Program"
 }

--- a/test/examples/null/output.json
+++ b/test/examples/null/output.json
@@ -1,23 +1,32 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 4 ],
-  "raw": "null",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 4 ],
+    "line": 1,
+    "range": [
+      0,
+      4
+    ],
     "raw": "null",
     "statements": [
       {
-        "type": "Null",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 4 ],
-        "raw": "null"
+        "line": 1,
+        "range": [
+          0,
+          4
+        ],
+        "raw": "null",
+        "type": "Null"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    4
+  ],
+  "raw": "null",
+  "type": "Program"
 }

--- a/test/examples/object-destructure-with-default/output.json
+++ b/test/examples/object-destructure-with-default/output.json
@@ -1,87 +1,87 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    12
-  ],
-  "raw": "{a = 1} = b\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       11
     ],
+    "raw": "{a = 1} = b",
     "statements": [
       {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          11
-        ],
         "assignee": {
-          "type": "ObjectInitialiser",
-          "line": 1,
           "column": 1,
-          "range": [
-            0,
-            7
-          ],
+          "line": 1,
           "members": [
             {
-              "type": "AssignOp",
-              "line": 1,
-              "column": 2,
-              "range": [
-                1,
-                6
-              ],
               "assignee": {
-                "type": "Identifier",
-                "line": 1,
                 "column": 2,
+                "data": "a",
+                "line": 1,
                 "range": [
                   1,
                   2
                 ],
                 "raw": "a",
-                "data": "a"
+                "type": "Identifier"
               },
+              "column": 2,
               "expression": {
-                "type": "Int",
-                "line": 1,
                 "column": 6,
+                "data": 1,
+                "line": 1,
                 "range": [
                   5,
                   6
                 ],
                 "raw": "1",
-                "data": 1
+                "type": "Int"
               },
-              "raw": "a = 1"
+              "line": 1,
+              "range": [
+                1,
+                6
+              ],
+              "raw": "a = 1",
+              "type": "AssignOp"
             }
           ],
-          "raw": "{a = 1}"
+          "range": [
+            0,
+            7
+          ],
+          "raw": "{a = 1}",
+          "type": "ObjectInitialiser"
         },
+        "column": 1,
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 11,
+          "data": "b",
+          "line": 1,
           "range": [
             10,
             11
           ],
           "raw": "b",
-          "data": "b"
+          "type": "Identifier"
         },
-        "raw": "{a = 1} = b"
+        "line": 1,
+        "range": [
+          0,
+          11
+        ],
+        "raw": "{a = 1} = b",
+        "type": "AssignOp"
       }
     ],
-    "raw": "{a = 1} = b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "{a = 1} = b\n",
+  "type": "Program"
 }

--- a/test/examples/object-with-block-comments/output.json
+++ b/test/examples/object-with-block-comments/output.json
@@ -1,63 +1,87 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 47 ],
-  "raw": "obj =\n  ###\n  # @returns {boolean}\n  ###\n  a: 1",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 47 ],
+    "line": 1,
+    "range": [
+      0,
+      47
+    ],
     "raw": "obj =\n  ###\n  # @returns {boolean}\n  ###\n  a: 1",
     "statements": [
       {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 47 ],
-        "raw": "obj =\n  ###\n  # @returns {boolean}\n  ###\n  a: 1",
         "assignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 3 ],
+          "data": "obj",
+          "line": 1,
+          "range": [
+            0,
+            3
+          ],
           "raw": "obj",
-          "data": "obj"
+          "type": "Identifier"
         },
+        "column": 1,
         "expression": {
-          "type": "ObjectInitialiser",
-          "line": 2,
           "column": 3,
-          "range": [ 8, 47 ],
-          "raw": "###\n  # @returns {boolean}\n  ###\n  a: 1",
+          "line": 2,
           "members": [
             {
-              "type": "ObjectInitialiserMember",
-              "line": 5,
               "column": 3,
-              "range": [ 43, 47 ],
-              "raw": "a: 1",
               "expression": {
-                "type": "Int",
-                "line": 5,
                 "column": 6,
-                "range": [ 46, 47 ],
+                "data": 1,
+                "line": 5,
+                "range": [
+                  46,
+                  47
+                ],
                 "raw": "1",
-                "data": 1
+                "type": "Int"
               },
               "key": {
-                "type": "Identifier",
-                "line": 5,
                 "column": 3,
-                "range": [ 43, 44 ],
+                "data": "a",
+                "line": 5,
+                "range": [
+                  43,
+                  44
+                ],
                 "raw": "a",
-                "data": "a"
-              }
+                "type": "Identifier"
+              },
+              "line": 5,
+              "range": [
+                43,
+                47
+              ],
+              "raw": "a: 1",
+              "type": "ObjectInitialiserMember"
             }
-          ]
-        }
+          ],
+          "range": [
+            8,
+            47
+          ],
+          "raw": "###\n  # @returns {boolean}\n  ###\n  a: 1",
+          "type": "ObjectInitialiser"
+        },
+        "line": 1,
+        "range": [
+          0,
+          47
+        ],
+        "raw": "obj =\n  ###\n  # @returns {boolean}\n  ###\n  a: 1",
+        "type": "AssignOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    47
+  ],
+  "raw": "obj =\n  ###\n  # @returns {boolean}\n  ###\n  a: 1",
+  "type": "Program"
 }

--- a/test/examples/object-with-braces/output.json
+++ b/test/examples/object-with-braces/output.json
@@ -1,48 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "{a: 1}",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "{a: 1}",
     "statements": [
       {
-        "type": "ObjectInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "{a: 1}",
+        "line": 1,
         "members": [
           {
-            "type": "ObjectInitialiserMember",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 5 ],
-            "raw": "a: 1",
             "expression": {
-              "type": "Int",
-              "line": 1,
               "column": 5,
-              "range": [ 4, 5 ],
+              "data": 1,
+              "line": 1,
+              "range": [
+                4,
+                5
+              ],
               "raw": "1",
-              "data": 1
+              "type": "Int"
             },
             "key": {
-              "type": "Identifier",
-              "line": 1,
               "column": 2,
-              "range": [ 1, 2 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                1,
+                2
+              ],
               "raw": "a",
-              "data": "a"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              1,
+              5
+            ],
+            "raw": "a: 1",
+            "type": "ObjectInitialiserMember"
           }
-        ]
+        ],
+        "range": [
+          0,
+          6
+        ],
+        "raw": "{a: 1}",
+        "type": "ObjectInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "{a: 1}",
+  "type": "Program"
 }

--- a/test/examples/object-with-combined-key-value/output.json
+++ b/test/examples/object-with-combined-key-value/output.json
@@ -1,71 +1,98 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 11 ],
-  "raw": "{ a, b: 1 }",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 11 ],
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
     "raw": "{ a, b: 1 }",
     "statements": [
       {
-        "type": "ObjectInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 11 ],
-        "raw": "{ a, b: 1 }",
+        "line": 1,
         "members": [
           {
-            "type": "ObjectInitialiserMember",
-            "line": 1,
             "column": 3,
-            "range": [ 2, 3 ],
-            "raw": "a",
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 3,
-              "range": [ 2, 3 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                2,
+                3
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             },
             "key": {
-              "type": "Identifier",
-              "line": 1,
               "column": 3,
-              "range": [ 2, 3 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                2,
+                3
+              ],
               "raw": "a",
-              "data": "a"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              2,
+              3
+            ],
+            "raw": "a",
+            "type": "ObjectInitialiserMember"
           },
           {
-            "type": "ObjectInitialiserMember",
-            "line": 1,
             "column": 6,
-            "range": [ 5, 9 ],
-            "raw": "b: 1",
             "expression": {
-              "type": "Int",
-              "line": 1,
               "column": 9,
-              "range": [ 8, 9 ],
+              "data": 1,
+              "line": 1,
+              "range": [
+                8,
+                9
+              ],
               "raw": "1",
-              "data": 1
+              "type": "Int"
             },
             "key": {
-              "type": "Identifier",
-              "line": 1,
               "column": 6,
-              "range": [ 5, 6 ],
+              "data": "b",
+              "line": 1,
+              "range": [
+                5,
+                6
+              ],
               "raw": "b",
-              "data": "b"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              5,
+              9
+            ],
+            "raw": "b: 1",
+            "type": "ObjectInitialiserMember"
           }
-        ]
+        ],
+        "range": [
+          0,
+          11
+        ],
+        "raw": "{ a, b: 1 }",
+        "type": "ObjectInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    11
+  ],
+  "raw": "{ a, b: 1 }",
+  "type": "Program"
 }

--- a/test/examples/object-with-multiple-properties/output.json
+++ b/test/examples/object-with-multiple-properties/output.json
@@ -1,71 +1,98 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 18 ],
-  "raw": "{\n  a: 1,\n  b: 2\n}",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 18 ],
+    "line": 1,
+    "range": [
+      0,
+      18
+    ],
     "raw": "{\n  a: 1,\n  b: 2\n}",
     "statements": [
       {
-        "type": "ObjectInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 18 ],
-        "raw": "{\n  a: 1,\n  b: 2\n}",
+        "line": 1,
         "members": [
           {
-            "type": "ObjectInitialiserMember",
-            "line": 2,
             "column": 3,
-            "range": [ 4, 8 ],
-            "raw": "a: 1",
             "expression": {
-              "type": "Int",
-              "line": 2,
               "column": 6,
-              "range": [ 7, 8 ],
+              "data": 1,
+              "line": 2,
+              "range": [
+                7,
+                8
+              ],
               "raw": "1",
-              "data": 1
+              "type": "Int"
             },
             "key": {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 4, 5 ],
+              "data": "a",
+              "line": 2,
+              "range": [
+                4,
+                5
+              ],
               "raw": "a",
-              "data": "a"
-            }
+              "type": "Identifier"
+            },
+            "line": 2,
+            "range": [
+              4,
+              8
+            ],
+            "raw": "a: 1",
+            "type": "ObjectInitialiserMember"
           },
           {
-            "type": "ObjectInitialiserMember",
-            "line": 3,
             "column": 3,
-            "range": [ 12, 16 ],
-            "raw": "b: 2",
             "expression": {
-              "type": "Int",
-              "line": 3,
               "column": 6,
-              "range": [ 15, 16 ],
+              "data": 2,
+              "line": 3,
+              "range": [
+                15,
+                16
+              ],
               "raw": "2",
-              "data": 2
+              "type": "Int"
             },
             "key": {
-              "type": "Identifier",
-              "line": 3,
               "column": 3,
-              "range": [ 12, 13 ],
+              "data": "b",
+              "line": 3,
+              "range": [
+                12,
+                13
+              ],
               "raw": "b",
-              "data": "b"
-            }
+              "type": "Identifier"
+            },
+            "line": 3,
+            "range": [
+              12,
+              16
+            ],
+            "raw": "b: 2",
+            "type": "ObjectInitialiserMember"
           }
-        ]
+        ],
+        "range": [
+          0,
+          18
+        ],
+        "raw": "{\n  a: 1,\n  b: 2\n}",
+        "type": "ObjectInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    18
+  ],
+  "raw": "{\n  a: 1,\n  b: 2\n}",
+  "type": "Program"
 }

--- a/test/examples/object-with-parenthesized-value/output.json
+++ b/test/examples/object-with-parenthesized-value/output.json
@@ -1,98 +1,98 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    12
-  ],
-  "raw": "{a: (b), c}\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       11
     ],
+    "raw": "{a: (b), c}",
     "statements": [
       {
-        "type": "ObjectInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          11
-        ],
+        "line": 1,
         "members": [
           {
-            "type": "ObjectInitialiserMember",
-            "line": 1,
             "column": 2,
-            "range": [
-              1,
-              7
-            ],
-            "key": {
-              "type": "Identifier",
-              "line": 1,
-              "column": 2,
-              "range": [
-                1,
-                2
-              ],
-              "raw": "a",
-              "data": "a"
-            },
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 6,
+              "data": "b",
+              "line": 1,
               "range": [
                 5,
                 6
               ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             },
-            "raw": "a: (b)"
+            "key": {
+              "column": 2,
+              "data": "a",
+              "line": 1,
+              "range": [
+                1,
+                2
+              ],
+              "raw": "a",
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              1,
+              7
+            ],
+            "raw": "a: (b)",
+            "type": "ObjectInitialiserMember"
           },
           {
-            "type": "ObjectInitialiserMember",
-            "line": 1,
             "column": 10,
+            "expression": {
+              "column": 10,
+              "data": "c",
+              "line": 1,
+              "range": [
+                9,
+                10
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            },
+            "key": {
+              "column": 10,
+              "data": "c",
+              "line": 1,
+              "range": [
+                9,
+                10
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            },
+            "line": 1,
             "range": [
               9,
               10
             ],
-            "key": {
-              "type": "Identifier",
-              "line": 1,
-              "column": 10,
-              "range": [
-                9,
-                10
-              ],
-              "raw": "c",
-              "data": "c"
-            },
-            "expression": {
-              "type": "Identifier",
-              "line": 1,
-              "column": 10,
-              "range": [
-                9,
-                10
-              ],
-              "raw": "c",
-              "data": "c"
-            },
-            "raw": "c"
+            "raw": "c",
+            "type": "ObjectInitialiserMember"
           }
         ],
-        "raw": "{a: (b), c}"
+        "range": [
+          0,
+          11
+        ],
+        "raw": "{a: (b), c}",
+        "type": "ObjectInitialiser"
       }
     ],
-    "raw": "{a: (b), c}"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "{a: (b), c}\n",
+  "type": "Program"
 }

--- a/test/examples/object-without-braces/output.json
+++ b/test/examples/object-without-braces/output.json
@@ -1,48 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 4 ],
-  "raw": "a: 1",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 4 ],
+    "line": 1,
+    "range": [
+      0,
+      4
+    ],
     "raw": "a: 1",
     "statements": [
       {
-        "type": "ObjectInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 4 ],
-        "raw": "a: 1",
+        "line": 1,
         "members": [
           {
-            "type": "ObjectInitialiserMember",
-            "line": 1,
             "column": 1,
-            "range": [ 0, 4 ],
-            "raw": "a: 1",
             "expression": {
-              "type": "Int",
-              "line": 1,
               "column": 4,
-              "range": [ 3, 4 ],
+              "data": 1,
+              "line": 1,
+              "range": [
+                3,
+                4
+              ],
               "raw": "1",
-              "data": 1
+              "type": "Int"
             },
             "key": {
-              "type": "Identifier",
-              "line": 1,
               "column": 1,
-              "range": [ 0, 1 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
               "raw": "a",
-              "data": "a"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              0,
+              4
+            ],
+            "raw": "a: 1",
+            "type": "ObjectInitialiserMember"
           }
-        ]
+        ],
+        "range": [
+          0,
+          4
+        ],
+        "raw": "a: 1",
+        "type": "ObjectInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    4
+  ],
+  "raw": "a: 1",
+  "type": "Program"
 }

--- a/test/examples/octal-number/output.json
+++ b/test/examples/octal-number/output.json
@@ -1,24 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "0o1234",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "0o1234",
     "statements": [
       {
-        "type": "Int",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
+        "data": 668,
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
         "raw": "0o1234",
-        "data": 668
+        "type": "Int"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "0o1234",
+  "type": "Program"
 }

--- a/test/examples/of-not/output.json
+++ b/test/examples/of-not/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 10 ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 10 ],
+    "line": 1,
+    "range": [
+      0,
+      10
+    ],
+    "raw": "a not of b",
     "statements": [
       {
-        "type": "OfOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 10 ],
         "isNot": true,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
           "data": "a",
-          "raw": "a"
-        },
-        "right": {
-          "type": "Identifier",
           "line": 1,
-          "column": 10,
-          "range": [ 9, 10 ],
-          "data": "b",
-          "raw": "b"
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
         },
-        "raw": "a not of b"
+        "line": 1,
+        "range": [
+          0,
+          10
+        ],
+        "raw": "a not of b",
+        "right": {
+          "column": 10,
+          "data": "b",
+          "line": 1,
+          "range": [
+            9,
+            10
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "OfOp"
       }
     ],
-    "raw": "a not of b"
+    "type": "Block"
   },
-  "raw": "a not of b"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    10
+  ],
+  "raw": "a not of b",
+  "type": "Program"
 }

--- a/test/examples/of/output.json
+++ b/test/examples/of/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a of b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a of b",
     "statements": [
       {
-        "type": "OfOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a of b",
         "isNot": false,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a of b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "OfOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a of b",
+  "type": "Program"
 }

--- a/test/examples/only-empty-string-interpolation/output.json
+++ b/test/examples/only-empty-string-interpolation/output.json
@@ -1,59 +1,59 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
+    "raw": "\"#{}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          null
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 5,
+            "data": "",
+            "line": 1,
+            "range": [
+              4,
+              4
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          5
+        ],
+        "raw": "\"#{}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     6
   ],
   "raw": "\"#{}\"\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      5
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "raw": "\"#{}\"",
-        "range": [
-          0,
-          5
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 5,
-            "raw": "",
-            "range": [
-              4,
-              4
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          null
-        ]
-      }
-    ],
-    "raw": "\"#{}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/parentheses/output.json
+++ b/test/examples/parentheses/output.json
@@ -1,54 +1,75 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 11 ],
-  "raw": "(a + b) * c",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 11 ],
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
     "raw": "(a + b) * c",
     "statements": [
       {
-        "type": "MultiplyOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 11 ],
-        "raw": "(a + b) * c",
         "left": {
-          "type": "PlusOp",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 6 ],
-          "raw": "a + b",
           "left": {
-            "type": "Identifier",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 2 ],
-            "raw": "a",
-            "data": "a"
-          },
-          "right": {
-            "type": "Identifier",
+            "data": "a",
             "line": 1,
-            "column": 6,
-            "range": [ 5, 6 ],
-            "raw": "b",
-            "data": "b"
-          }
-        },
-        "right": {
-          "type": "Identifier",
+            "range": [
+              1,
+              2
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
           "line": 1,
+          "range": [
+            1,
+            6
+          ],
+          "raw": "a + b",
+          "right": {
+            "column": 6,
+            "data": "b",
+            "line": 1,
+            "range": [
+              5,
+              6
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          },
+          "type": "PlusOp"
+        },
+        "line": 1,
+        "range": [
+          0,
+          11
+        ],
+        "raw": "(a + b) * c",
+        "right": {
           "column": 11,
-          "range": [ 10, 11 ],
+          "data": "c",
+          "line": 1,
+          "range": [
+            10,
+            11
+          ],
           "raw": "c",
-          "data": "c"
-        }
+          "type": "Identifier"
+        },
+        "type": "MultiplyOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    11
+  ],
+  "raw": "(a + b) * c",
+  "type": "Program"
 }

--- a/test/examples/parenthesized-member-access/output.json
+++ b/test/examples/parenthesized-member-access/output.json
@@ -1,54 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
+    "raw": "(a).b",
+    "statements": [
+      {
+        "column": 1,
+        "expression": {
+          "column": 2,
+          "data": "a",
+          "line": 1,
+          "range": [
+            1,
+            2
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "member": {
+          "column": 5,
+          "data": "b",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          5
+        ],
+        "raw": "(a).b",
+        "type": "MemberAccessOp"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     6
   ],
   "raw": "(a).b\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      5
-    ],
-    "statements": [
-      {
-        "type": "MemberAccessOp",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          5
-        ],
-        "expression": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 2,
-          "raw": "a",
-          "range": [
-            1,
-            2
-          ],
-          "data": "a"
-        },
-        "member": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 5,
-          "raw": "b",
-          "range": [
-            4,
-            5
-          ],
-          "data": "b"
-        },
-        "raw": "(a).b"
-      }
-    ],
-    "raw": "(a).b"
-  }
+  "type": "Program"
 }

--- a/test/examples/post-decrement/output.json
+++ b/test/examples/post-decrement/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "a--",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 3 ],
+    "line": 1,
+    "range": [
+      0,
+      3
+    ],
     "raw": "a--",
     "statements": [
       {
-        "type": "PostDecrementOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 3 ],
-        "raw": "a--",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          3
+        ],
+        "raw": "a--",
+        "type": "PostDecrementOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "a--",
+  "type": "Program"
 }

--- a/test/examples/post-for/output.json
+++ b/test/examples/post-for/output.json
@@ -1,81 +1,81 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
+    "raw": "a for a in b",
+    "statements": [
+      {
+        "body": {
+          "column": 1,
+          "inline": true,
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "statements": [
+            {
+              "column": 1,
+              "data": "a",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
+              "raw": "a",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "filter": null,
+        "keyAssignee": null,
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "a for a in b",
+        "step": null,
+        "target": {
+          "column": 12,
+          "data": "b",
+          "line": 1,
+          "range": [
+            11,
+            12
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "type": "ForIn",
+        "valAssignee": {
+          "column": 7,
+          "data": "a",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        }
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     13
   ],
   "raw": "a for a in b\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      12
-    ],
-    "statements": [
-      {
-        "type": "ForIn",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          12
-        ],
-        "keyAssignee": null,
-        "valAssignee": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [
-            6,
-            7
-          ],
-          "data": "a",
-          "raw": "a"
-        },
-        "body": {
-          "type": "Block",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            1
-          ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 1,
-              "column": 1,
-              "range": [
-                0,
-                1
-              ],
-              "data": "a",
-              "raw": "a"
-            }
-          ],
-          "raw": "a",
-          "inline": true
-        },
-        "target": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 12,
-          "range": [
-            11,
-            12
-          ],
-          "data": "b",
-          "raw": "b"
-        },
-        "filter": null,
-        "step": null,
-        "raw": "a for a in b"
-      }
-    ],
-    "raw": "a for a in b"
-  }
+  "type": "Program"
 }

--- a/test/examples/post-increment/output.json
+++ b/test/examples/post-increment/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "a++",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 3 ],
+    "line": 1,
+    "range": [
+      0,
+      3
+    ],
     "raw": "a++",
     "statements": [
       {
-        "type": "PostIncrementOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 3 ],
-        "raw": "a++",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          3
+        ],
+        "raw": "a++",
+        "type": "PostIncrementOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "a++",
+  "type": "Program"
 }

--- a/test/examples/post-unless-not-if/output.json
+++ b/test/examples/post-unless-not-if/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 20 ],
-  "raw": "c unless a not in b\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 19 ],
+    "line": 1,
+    "range": [
+      0,
+      19
+    ],
+    "raw": "c unless a not in b",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
+        "alternate": null,
         "column": 1,
-        "range": [ 0, 19 ],
-        "isUnless": true,
         "condition": {
-          "type": "InOp",
-          "line": 1,
           "column": 10,
-          "range": [ 9, 19 ],
-          "left": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 10,
-            "range": [ 9, 10 ],
-            "data": "a",
-            "raw": "a"
-          },
-          "right": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 19,
-            "range": [ 18, 19 ],
-            "data": "b",
-            "raw": "b"
-          },
           "isNot": true,
-          "raw": "a not in b"
+          "left": {
+            "column": 10,
+            "data": "a",
+            "line": 1,
+            "range": [
+              9,
+              10
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            9,
+            19
+          ],
+          "raw": "a not in b",
+          "right": {
+            "column": 19,
+            "data": "b",
+            "line": 1,
+            "range": [
+              18,
+              19
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          },
+          "type": "InOp"
         },
         "consequent": {
-          "type": "Block",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 1,
-              "column": 1,
-              "range": [ 0, 1 ],
-              "data": "c",
-              "raw": "c"
-            }
+          "inline": true,
+          "line": 1,
+          "range": [
+            0,
+            1
           ],
           "raw": "c",
-          "inline": true
+          "statements": [
+            {
+              "column": 1,
+              "data": "c",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
         },
-        "alternate": null,
-        "raw": "c unless a not in b"
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          19
+        ],
+        "raw": "c unless a not in b",
+        "type": "Conditional"
       }
     ],
-    "raw": "c unless a not in b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    20
+  ],
+  "raw": "c unless a not in b\n",
+  "type": "Program"
 }

--- a/test/examples/post-while-with-loop/output.json
+++ b/test/examples/post-while-with-loop/output.json
@@ -1,62 +1,29 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    15
-  ],
-  "raw": "loop a while b\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       14
     ],
+    "raw": "loop a while b",
     "statements": [
       {
-        "type": "Loop",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          14
-        ],
         "body": {
-          "type": "Block",
-          "line": 1,
           "column": 6,
+          "inline": true,
+          "line": 1,
           "range": [
             5,
             14
           ],
+          "raw": "a while b",
           "statements": [
             {
-              "type": "While",
-              "line": 1,
-              "column": 6,
-              "range": [
-                5,
-                14
-              ],
-              "condition": {
-                "type": "Identifier",
-                "line": 1,
-                "column": 14,
-                "range": [
-                  13,
-                  14
-                ],
-                "raw": "b",
-                "data": "b"
-              },
-              "guard": null,
               "body": {
-                "type": "Block",
-                "line": 1,
                 "column": 6,
+                "inline": true,
+                "line": 1,
                 "range": [
                   5,
                   6
@@ -64,29 +31,62 @@
                 "raw": "a",
                 "statements": [
                   {
-                    "type": "Identifier",
-                    "line": 1,
                     "column": 6,
+                    "data": "a",
+                    "line": 1,
                     "range": [
                       5,
                       6
                     ],
                     "raw": "a",
-                    "data": "a"
+                    "type": "Identifier"
                   }
                 ],
-                "inline": true
+                "type": "Block"
               },
+              "column": 6,
+              "condition": {
+                "column": 14,
+                "data": "b",
+                "line": 1,
+                "range": [
+                  13,
+                  14
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "guard": null,
               "isUntil": false,
-              "raw": "a while b"
+              "line": 1,
+              "range": [
+                5,
+                14
+              ],
+              "raw": "a while b",
+              "type": "While"
             }
           ],
-          "raw": "a while b",
-          "inline": true
+          "type": "Block"
         },
-        "raw": "loop a while b"
+        "column": 1,
+        "line": 1,
+        "range": [
+          0,
+          14
+        ],
+        "raw": "loop a while b",
+        "type": "Loop"
       }
     ],
-    "raw": "loop a while b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    15
+  ],
+  "raw": "loop a while b\n",
+  "type": "Program"
 }

--- a/test/examples/pow/output.json
+++ b/test/examples/pow/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "a ** b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "a ** b",
     "statements": [
       {
-        "type": "ExpOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "a ** b",
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a ** b",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "ExpOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a ** b",
+  "type": "Program"
 }

--- a/test/examples/pre-decrement/output.json
+++ b/test/examples/pre-decrement/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "--a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 3 ],
+    "line": 1,
+    "range": [
+      0,
+      3
+    ],
     "raw": "--a",
     "statements": [
       {
-        "type": "PreDecrementOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 3 ],
-        "raw": "--a",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 3,
-          "range": [ 2, 3 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            2,
+            3
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          3
+        ],
+        "raw": "--a",
+        "type": "PreDecrementOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "--a",
+  "type": "Program"
 }

--- a/test/examples/pre-increment/output.json
+++ b/test/examples/pre-increment/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "++a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 3 ],
+    "line": 1,
+    "range": [
+      0,
+      3
+    ],
     "raw": "++a",
     "statements": [
       {
-        "type": "PreIncrementOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 3 ],
-        "raw": "++a",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 3,
-          "range": [ 2, 3 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            2,
+            3
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          3
+        ],
+        "raw": "++a",
+        "type": "PreIncrementOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "++a",
+  "type": "Program"
 }

--- a/test/examples/prototype-member-access/output.json
+++ b/test/examples/prototype-member-access/output.json
@@ -1,64 +1,64 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    16
-  ],
-  "raw": "Object::toString",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       16
     ],
+    "raw": "Object::toString",
     "statements": [
       {
-        "type": "MemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          16
-        ],
-        "raw": "Object::toString",
         "expression": {
-          "type": "ProtoMemberAccessOp",
-          "line": 1,
           "column": 1,
-          "range": [
-            0,
-            8
-          ],
-          "raw": "Object::",
           "expression": {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
+            "data": "Object",
+            "line": 1,
             "range": [
               0,
               6
             ],
             "raw": "Object",
-            "data": "Object"
-          }
-        },
-        "member": {
-          "type": "Identifier",
+            "type": "Identifier"
+          },
           "line": 1,
+          "range": [
+            0,
+            8
+          ],
+          "raw": "Object::",
+          "type": "ProtoMemberAccessOp"
+        },
+        "line": 1,
+        "member": {
           "column": 9,
+          "data": "toString",
+          "line": 1,
           "range": [
             8,
             16
           ],
           "raw": "toString",
-          "data": "toString"
-        }
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          16
+        ],
+        "raw": "Object::toString",
+        "type": "MemberAccessOp"
       }
     ],
-    "raw": "Object::toString"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    16
+  ],
+  "raw": "Object::toString",
+  "type": "Program"
 }

--- a/test/examples/range-exclusive/output.json
+++ b/test/examples/range-exclusive/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "[a...b]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 7 ],
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
     "raw": "[a...b]",
     "statements": [
       {
-        "type": "Range",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 7 ],
-        "raw": "[a...b]",
         "isInclusive": false,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 2 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            1,
+            2
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          7
+        ],
+        "raw": "[a...b]",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "Range"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "[a...b]",
+  "type": "Program"
 }

--- a/test/examples/range-inclusive/output.json
+++ b/test/examples/range-inclusive/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "[a..b]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "[a..b]",
     "statements": [
       {
-        "type": "Range",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "[a..b]",
         "isInclusive": true,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 2 ],
-          "raw": "a",
-          "data": "a"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "a",
           "line": 1,
+          "range": [
+            1,
+            2
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "[a..b]",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "type": "Range"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "[a..b]",
+  "type": "Program"
 }

--- a/test/examples/regexp/output.json
+++ b/test/examples/regexp/output.json
@@ -1,43 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    4
-  ],
-  "raw": "/a/\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       3
     ],
+    "raw": "/a/",
     "statements": [
       {
-        "type": "Regex",
-        "line": 1,
         "column": 1,
+        "flags": {
+          "g": false,
+          "global": false,
+          "i": false,
+          "ignoreCase": false,
+          "m": false,
+          "multiline": false,
+          "sticky": false,
+          "y": false
+        },
+        "line": 1,
+        "pattern": "a",
         "range": [
           0,
           3
         ],
         "raw": "/a/",
-        "pattern": "a",
-        "flags": {
-          "global": false,
-          "ignoreCase": false,
-          "multiline": false,
-          "sticky": false,
-          "g": false,
-          "i": false,
-          "m": false,
-          "y": false
-        }
+        "type": "Regex"
       }
     ],
-    "raw": "/a/"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    4
+  ],
+  "raw": "/a/\n",
+  "type": "Program"
 }

--- a/test/examples/remainder/output.json
+++ b/test/examples/remainder/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "3 % 4",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "3 % 4",
     "statements": [
       {
-        "type": "RemOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "3 % 4",
         "left": {
-          "type": "Int",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "3",
-          "data": 3
-        },
-        "right": {
-          "type": "Int",
+          "data": 3,
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "3",
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "3 % 4",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": 4,
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "4",
-          "data": 4
-        }
+          "type": "Int"
+        },
+        "type": "RemOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "3 % 4",
+  "type": "Program"
 }

--- a/test/examples/rest-param-in-bound-function/output.json
+++ b/test/examples/rest-param-in-bound-function/output.json
@@ -1,41 +1,56 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 12 ],
-  "raw": "(rest...) =>",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
     "raw": "(rest...) =>",
     "statements": [
       {
-        "type": "BoundFunction",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 12 ],
-        "raw": "(rest...) =>",
         "body": null,
+        "column": 1,
+        "line": 1,
         "parameters": [
           {
-            "type": "Rest",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 8 ],
-            "raw": "rest...",
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 2,
-              "range": [ 1, 5 ],
+              "data": "rest",
+              "line": 1,
+              "range": [
+                1,
+                5
+              ],
               "raw": "rest",
-              "data": "rest"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              1,
+              8
+            ],
+            "raw": "rest...",
+            "type": "Rest"
           }
-        ]
+        ],
+        "range": [
+          0,
+          12
+        ],
+        "raw": "(rest...) =>",
+        "type": "BoundFunction"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "(rest...) =>",
+  "type": "Program"
 }

--- a/test/examples/rest-param-in-function/output.json
+++ b/test/examples/rest-param-in-function/output.json
@@ -1,41 +1,56 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 12 ],
-  "raw": "(rest...) ->",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
     "raw": "(rest...) ->",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 12 ],
-        "raw": "(rest...) ->",
         "body": null,
+        "column": 1,
+        "line": 1,
         "parameters": [
           {
-            "type": "Rest",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 8 ],
-            "raw": "rest...",
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 2,
-              "range": [ 1, 5 ],
+              "data": "rest",
+              "line": 1,
+              "range": [
+                1,
+                5
+              ],
               "raw": "rest",
-              "data": "rest"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              1,
+              8
+            ],
+            "raw": "rest...",
+            "type": "Rest"
           }
-        ]
+        ],
+        "range": [
+          0,
+          12
+        ],
+        "raw": "(rest...) ->",
+        "type": "Function"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "(rest...) ->",
+  "type": "Program"
 }

--- a/test/examples/return-with-expression/output.json
+++ b/test/examples/return-with-expression/output.json
@@ -1,49 +1,68 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 13 ],
-  "raw": "->\n  return a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 13 ],
+    "line": 1,
+    "range": [
+      0,
+      13
+    ],
     "raw": "->\n  return a",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 13 ],
-        "raw": "->\n  return a",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 5, 13 ],
-          "raw": "return a",
           "inline": false,
+          "line": 2,
+          "range": [
+            5,
+            13
+          ],
+          "raw": "return a",
           "statements": [
             {
-              "type": "Return",
-              "line": 2,
               "column": 3,
-              "range": [ 5, 13 ],
-              "raw": "return a",
               "expression": {
-                "type": "Identifier",
-                "line": 2,
                 "column": 10,
-                "range": [ 12, 13 ],
+                "data": "a",
+                "line": 2,
+                "range": [
+                  12,
+                  13
+                ],
                 "raw": "a",
-                "data": "a"
-              }
+                "type": "Identifier"
+              },
+              "line": 2,
+              "range": [
+                5,
+                13
+              ],
+              "raw": "return a",
+              "type": "Return"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "parameters": []
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          13
+        ],
+        "raw": "->\n  return a",
+        "type": "Function"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    13
+  ],
+  "raw": "->\n  return a",
+  "type": "Program"
 }

--- a/test/examples/return-without-expression/output.json
+++ b/test/examples/return-without-expression/output.json
@@ -1,42 +1,58 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 11 ],
-  "raw": "->\n  return",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 11 ],
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
     "raw": "->\n  return",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 11 ],
-        "raw": "->\n  return",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 5, 11 ],
-          "raw": "return",
           "inline": false,
+          "line": 2,
+          "range": [
+            5,
+            11
+          ],
+          "raw": "return",
           "statements": [
             {
-              "type": "Return",
-              "line": 2,
               "column": 3,
-              "range": [ 5, 11 ],
+              "expression": null,
+              "line": 2,
+              "range": [
+                5,
+                11
+              ],
               "raw": "return",
-              "expression": null
+              "type": "Return"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "parameters": []
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          11
+        ],
+        "raw": "->\n  return",
+        "type": "Function"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    11
+  ],
+  "raw": "->\n  return",
+  "type": "Program"
 }

--- a/test/examples/shorthand-this-member-expression-with-dot/output.json
+++ b/test/examples/shorthand-this-member-expression-with-dot/output.json
@@ -1,53 +1,53 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    3
-  ],
-  "raw": "@.a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       3
     ],
+    "raw": "@.a",
     "statements": [
       {
-        "type": "MemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          3
-        ],
-        "raw": "@.a",
         "expression": {
-          "type": "This",
-          "line": 1,
           "column": 1,
+          "line": 1,
           "range": [
             0,
             1
           ],
-          "raw": "@"
+          "raw": "@",
+          "type": "This"
         },
+        "line": 1,
         "member": {
-          "type": "Identifier",
-          "line": 1,
           "column": 3,
+          "data": "a",
+          "line": 1,
           "range": [
             2,
             3
           ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          3
+        ],
+        "raw": "@.a",
+        "type": "MemberAccessOp"
       }
     ],
-    "raw": "@.a"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "@.a",
+  "type": "Program"
 }

--- a/test/examples/shorthand-this-member-expression/output.json
+++ b/test/examples/shorthand-this-member-expression/output.json
@@ -1,53 +1,53 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    2
-  ],
-  "raw": "@a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       2
     ],
+    "raw": "@a",
     "statements": [
       {
-        "type": "MemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          2
-        ],
-        "raw": "@a",
         "expression": {
-          "type": "This",
-          "line": 1,
           "column": 1,
+          "line": 1,
           "range": [
             0,
             1
           ],
-          "raw": "@"
+          "raw": "@",
+          "type": "This"
         },
+        "line": 1,
         "member": {
-          "type": "Identifier",
-          "line": 1,
           "column": 2,
+          "data": "a",
+          "line": 1,
           "range": [
             1,
             2
           ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          2
+        ],
+        "raw": "@a",
+        "type": "MemberAccessOp"
       }
     ],
-    "raw": "@a"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "@a",
+  "type": "Program"
 }

--- a/test/examples/shorthand-this/output.json
+++ b/test/examples/shorthand-this/output.json
@@ -1,23 +1,32 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 1 ],
-  "raw": "@",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 1 ],
+    "line": 1,
+    "range": [
+      0,
+      1
+    ],
     "raw": "@",
     "statements": [
       {
-        "type": "This",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 1 ],
-        "raw": "@"
+        "line": 1,
+        "range": [
+          0,
+          1
+        ],
+        "raw": "@",
+        "type": "This"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    1
+  ],
+  "raw": "@",
+  "type": "Program"
 }

--- a/test/examples/simple-call/output.json
+++ b/test/examples/simple-call/output.json
@@ -1,32 +1,45 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 3 ],
-  "raw": "a()",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 3 ],
+    "line": 1,
+    "range": [
+      0,
+      3
+    ],
     "raw": "a()",
     "statements": [
       {
-        "type": "FunctionApplication",
-        "line": 1,
+        "arguments": [
+        ],
         "column": 1,
-        "range": [ 0, 3 ],
-        "raw": "a()",
-        "arguments": [],
         "function": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          3
+        ],
+        "raw": "a()",
+        "type": "FunctionApplication"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "a()",
+  "type": "Program"
 }

--- a/test/examples/simple-member-expression/output.json
+++ b/test/examples/simple-member-expression/output.json
@@ -1,54 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    3
-  ],
-  "raw": "a.b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       3
     ],
+    "raw": "a.b",
     "statements": [
       {
-        "type": "MemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          3
-        ],
-        "raw": "a.b",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
+          "data": "a",
+          "line": 1,
           "range": [
             0,
             1
           ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
+        "line": 1,
         "member": {
-          "type": "Identifier",
-          "line": 1,
           "column": 3,
+          "data": "b",
+          "line": 1,
           "range": [
             2,
             3
           ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "range": [
+          0,
+          3
+        ],
+        "raw": "a.b",
+        "type": "MemberAccessOp"
       }
     ],
-    "raw": "a.b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    3
+  ],
+  "raw": "a.b",
+  "type": "Program"
 }

--- a/test/examples/slice-with-lower-and-upper-bounds/output.json
+++ b/test/examples/slice-with-lower-and-upper-bounds/output.json
@@ -1,48 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "a[b..c]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 7 ],
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
     "raw": "a[b..c]",
     "statements": [
       {
-        "type": "Slice",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 7 ],
-        "raw": "a[b..c]",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
         "isInclusive": true,
         "left": {
-          "type": "Identifier",
-          "line": 1,
           "column": 3,
-          "range": [ 2, 3 ],
-          "raw": "b",
-          "data": "b"
-        },
-        "right": {
-          "type": "Identifier",
+          "data": "b",
           "line": 1,
+          "range": [
+            2,
+            3
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          7
+        ],
+        "raw": "a[b..c]",
+        "right": {
           "column": 6,
-          "range": [ 5, 6 ],
+          "data": "c",
+          "line": 1,
+          "range": [
+            5,
+            6
+          ],
           "raw": "c",
-          "data": "c"
-        }
+          "type": "Identifier"
+        },
+        "type": "Slice"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "a[b..c]",
+  "type": "Program"
 }

--- a/test/examples/slice-with-no-bounds/output.json
+++ b/test/examples/slice-with-no-bounds/output.json
@@ -1,46 +1,46 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
+    "raw": "a[..]",
+    "statements": [
+      {
+        "column": 1,
+        "expression": {
+          "column": 1,
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "isInclusive": true,
+        "left": null,
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a[..]",
+        "right": null,
+        "type": "Slice"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     6
   ],
   "raw": "a[..]\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      5
-    ],
-    "statements": [
-      {
-        "type": "Slice",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          5
-        ],
-        "expression": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 1,
-          "raw": "a",
-          "range": [
-            0,
-            1
-          ],
-          "data": "a"
-        },
-        "left": null,
-        "right": null,
-        "isInclusive": true,
-        "raw": "a[..]"
-      }
-    ],
-    "raw": "a[..]"
-  }
+  "type": "Program"
 }

--- a/test/examples/soaked-dynamic-member-access/output.json
+++ b/test/examples/soaked-dynamic-member-access/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "a?[b]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "a?[b]",
     "statements": [
       {
-        "type": "SoakedDynamicMemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "a?[b]",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
         "indexingExpr": {
-          "type": "Identifier",
-          "line": 1,
           "column": 4,
-          "range": [ 3, 4 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            3,
+            4
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a?[b]",
+        "type": "SoakedDynamicMemberAccessOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "a?[b]",
+  "type": "Program"
 }

--- a/test/examples/soaked-function-call/output.json
+++ b/test/examples/soaked-function-call/output.json
@@ -1,32 +1,45 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 4 ],
-  "raw": "a?()",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 4 ],
+    "line": 1,
+    "range": [
+      0,
+      4
+    ],
     "raw": "a?()",
     "statements": [
       {
-        "type": "SoakedFunctionApplication",
-        "line": 1,
+        "arguments": [
+        ],
         "column": 1,
-        "range": [ 0, 4 ],
-        "raw": "a?()",
-        "arguments": [],
         "function": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          4
+        ],
+        "raw": "a?()",
+        "type": "SoakedFunctionApplication"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    4
+  ],
+  "raw": "a?()",
+  "type": "Program"
 }

--- a/test/examples/soaked-member-access/output.json
+++ b/test/examples/soaked-member-access/output.json
@@ -1,54 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    4
-  ],
-  "raw": "a?.b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       4
     ],
+    "raw": "a?.b",
     "statements": [
       {
-        "type": "SoakedMemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          4
-        ],
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
+          "data": "a",
+          "line": 1,
           "range": [
             0,
             1
           ],
           "raw": "a",
-          "data": "a"
+          "type": "Identifier"
         },
+        "line": 1,
         "member": {
-          "type": "Identifier",
-          "line": 1,
           "column": 4,
+          "data": "b",
+          "line": 1,
           "range": [
             3,
             4
           ],
           "raw": "b",
-          "data": "b"
+          "type": "Identifier"
         },
-        "raw": "a?.b"
+        "range": [
+          0,
+          4
+        ],
+        "raw": "a?.b",
+        "type": "SoakedMemberAccessOp"
       }
     ],
-    "raw": "a?.b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    4
+  ],
+  "raw": "a?.b",
+  "type": "Program"
 }

--- a/test/examples/soaked-method-call/output.json
+++ b/test/examples/soaked-method-call/output.json
@@ -1,65 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    6
-  ],
-  "raw": "a?.b()",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       6
     ],
+    "raw": "a?.b()",
     "statements": [
       {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          6
+        "arguments": [
         ],
+        "column": 1,
         "function": {
-          "type": "SoakedMemberAccessOp",
-          "line": 1,
           "column": 1,
-          "range": [
-            0,
-            4
-          ],
           "expression": {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
+            "data": "a",
+            "line": 1,
             "range": [
               0,
               1
             ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
+          "line": 1,
           "member": {
-            "type": "Identifier",
-            "line": 1,
             "column": 4,
+            "data": "b",
+            "line": 1,
             "range": [
               3,
               4
             ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           },
-          "raw": "a?.b"
+          "range": [
+            0,
+            4
+          ],
+          "raw": "a?.b",
+          "type": "SoakedMemberAccessOp"
         },
-        "arguments": [],
-        "raw": "a?.b()"
+        "line": 1,
+        "range": [
+          0,
+          6
+        ],
+        "raw": "a?.b()",
+        "type": "FunctionApplication"
       }
     ],
-    "raw": "a?.b()"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a?.b()",
+  "type": "Program"
 }

--- a/test/examples/soaked-new/output.json
+++ b/test/examples/soaked-new/output.json
@@ -1,56 +1,56 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
+    "raw": "new A? b",
+    "statements": [
+      {
+        "arguments": [
+          {
+            "column": 8,
+            "data": "b",
+            "line": 1,
+            "range": [
+              7,
+              8
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          }
+        ],
+        "column": 1,
+        "ctor": {
+          "column": 5,
+          "data": "A",
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "new A? b",
+        "type": "SoakedNewOp"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     9
   ],
   "raw": "new A? b\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      8
-    ],
-    "statements": [
-      {
-        "type": "SoakedNewOp",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          8
-        ],
-        "ctor": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 5,
-          "raw": "A",
-          "range": [
-            4,
-            5
-          ],
-          "data": "A"
-        },
-        "arguments": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 8,
-            "raw": "b",
-            "range": [
-              7,
-              8
-            ],
-            "data": "b"
-          }
-        ],
-        "raw": "new A? b"
-      }
-    ],
-    "raw": "new A? b"
-  }
+  "type": "Program"
 }

--- a/test/examples/soaked-prototype-access/output.json
+++ b/test/examples/soaked-prototype-access/output.json
@@ -1,64 +1,64 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    6
-  ],
-  "raw": "a?::b\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       5
     ],
+    "raw": "a?::b",
     "statements": [
       {
-        "type": "MemberAccessOp",
-        "line": 1,
         "column": 1,
-        "range": [
-          0,
-          5
-        ],
         "expression": {
-          "type": "SoakedProtoMemberAccessOp",
-          "line": 1,
           "column": 1,
-          "range": [
-            0,
-            4
-          ],
           "expression": {
-            "type": "Identifier",
-            "line": 1,
             "column": 1,
+            "data": "a",
+            "line": 1,
             "range": [
               0,
               1
             ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
-          "raw": "a?::"
-        },
-        "member": {
-          "type": "Identifier",
           "line": 1,
+          "range": [
+            0,
+            4
+          ],
+          "raw": "a?::",
+          "type": "SoakedProtoMemberAccessOp"
+        },
+        "line": 1,
+        "member": {
           "column": 5,
+          "data": "b",
+          "line": 1,
           "range": [
             4,
             5
           ],
           "raw": "b",
-          "data": "b"
+          "type": "Identifier"
         },
-        "raw": "a?::b"
+        "range": [
+          0,
+          5
+        ],
+        "raw": "a?::b",
+        "type": "MemberAccessOp"
       }
     ],
-    "raw": "a?::b"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "a?::b\n",
+  "type": "Program"
 }

--- a/test/examples/soaked-slice/output.json
+++ b/test/examples/soaked-slice/output.json
@@ -1,66 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
+    "raw": "a?[b..c]",
+    "statements": [
+      {
+        "column": 1,
+        "expression": {
+          "column": 1,
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "isInclusive": true,
+        "left": {
+          "column": 4,
+          "data": "b",
+          "line": 1,
+          "range": [
+            3,
+            4
+          ],
+          "raw": "b",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "a?[b..c]",
+        "right": {
+          "column": 7,
+          "data": "c",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "c",
+          "type": "Identifier"
+        },
+        "type": "SoakedSlice"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     9
   ],
   "raw": "a?[b..c]\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      8
-    ],
-    "statements": [
-      {
-        "type": "SoakedSlice",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          8
-        ],
-        "expression": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 1,
-          "raw": "a",
-          "range": [
-            0,
-            1
-          ],
-          "data": "a"
-        },
-        "left": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 4,
-          "raw": "b",
-          "range": [
-            3,
-            4
-          ],
-          "data": "b"
-        },
-        "right": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "raw": "c",
-          "range": [
-            6,
-            7
-          ],
-          "data": "c"
-        },
-        "isInclusive": true,
-        "raw": "a?[b..c]"
-      }
-    ],
-    "raw": "a?[b..c]"
-  }
+  "type": "Program"
 }

--- a/test/examples/soaked-splice/output.json
+++ b/test/examples/soaked-splice/output.json
@@ -1,87 +1,87 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
+    "raw": "a?[b..c] = d",
+    "statements": [
+      {
+        "assignee": {
+          "column": 1,
+          "expression": {
+            "column": 1,
+            "data": "a",
+            "line": 1,
+            "range": [
+              0,
+              1
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          "isInclusive": true,
+          "left": {
+            "column": 4,
+            "data": "b",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            0,
+            8
+          ],
+          "raw": "a?[b..c]",
+          "right": {
+            "column": 7,
+            "data": "c",
+            "line": 1,
+            "range": [
+              6,
+              7
+            ],
+            "raw": "c",
+            "type": "Identifier"
+          },
+          "type": "SoakedSlice"
+        },
+        "column": 1,
+        "expression": {
+          "column": 12,
+          "data": "d",
+          "line": 1,
+          "range": [
+            11,
+            12
+          ],
+          "raw": "d",
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "a?[b..c] = d",
+        "type": "AssignOp"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     13
   ],
   "raw": "a?[b..c] = d\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      12
-    ],
-    "statements": [
-      {
-        "type": "AssignOp",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          12
-        ],
-        "assignee": {
-          "type": "SoakedSlice",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            8
-          ],
-          "expression": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 1,
-            "raw": "a",
-            "range": [
-              0,
-              1
-            ],
-            "data": "a"
-          },
-          "left": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 4,
-            "raw": "b",
-            "range": [
-              3,
-              4
-            ],
-            "data": "b"
-          },
-          "right": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 7,
-            "raw": "c",
-            "range": [
-              6,
-              7
-            ],
-            "data": "c"
-          },
-          "isInclusive": true,
-          "raw": "a?[b..c]"
-        },
-        "expression": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 12,
-          "raw": "d",
-          "range": [
-            11,
-            12
-          ],
-          "data": "d"
-        },
-        "raw": "a?[b..c] = d"
-      }
-    ],
-    "raw": "a?[b..c] = d"
-  }
+  "type": "Program"
 }

--- a/test/examples/splat-in-array-with-other-members/output.json
+++ b/test/examples/splat-in-array-with-other-members/output.json
@@ -1,56 +1,77 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 12 ],
-  "raw": "[a, b..., c]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
     "raw": "[a, b..., c]",
     "statements": [
       {
-        "type": "ArrayInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 12 ],
-        "raw": "[a, b..., c]",
+        "line": 1,
         "members": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 2 ],
+            "data": "a",
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
             "raw": "a",
-            "data": "a"
+            "type": "Identifier"
           },
           {
-            "type": "Spread",
-            "line": 1,
             "column": 5,
-            "range": [ 4, 8 ],
-            "raw": "b...",
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 5,
-              "range": [ 4, 5 ],
+              "data": "b",
+              "line": 1,
+              "range": [
+                4,
+                5
+              ],
               "raw": "b",
-              "data": "b"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              4,
+              8
+            ],
+            "raw": "b...",
+            "type": "Spread"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 11,
-            "range": [ 10, 11 ],
+            "data": "c",
+            "line": 1,
+            "range": [
+              10,
+              11
+            ],
             "raw": "c",
-            "data": "c"
+            "type": "Identifier"
           }
-        ]
+        ],
+        "range": [
+          0,
+          12
+        ],
+        "raw": "[a, b..., c]",
+        "type": "ArrayInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "[a, b..., c]",
+  "type": "Program"
 }

--- a/test/examples/splat-in-array/output.json
+++ b/test/examples/splat-in-array/output.json
@@ -1,40 +1,55 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 6 ],
-  "raw": "[a...]",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 6 ],
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
     "raw": "[a...]",
     "statements": [
       {
-        "type": "ArrayInitialiser",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 6 ],
-        "raw": "[a...]",
+        "line": 1,
         "members": [
           {
-            "type": "Spread",
-            "line": 1,
             "column": 2,
-            "range": [ 1, 5 ],
-            "raw": "a...",
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 2,
-              "range": [ 1, 2 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                1,
+                2
+              ],
               "raw": "a",
-              "data": "a"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              1,
+              5
+            ],
+            "raw": "a...",
+            "type": "Spread"
           }
-        ]
+        ],
+        "range": [
+          0,
+          6
+        ],
+        "raw": "[a...]",
+        "type": "ArrayInitialiser"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    6
+  ],
+  "raw": "[a...]",
+  "type": "Program"
 }

--- a/test/examples/splat-in-function-call-with-other-args/output.json
+++ b/test/examples/splat-in-function-call-with-other-args/output.json
@@ -1,64 +1,88 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 12 ],
-  "raw": "a b, c..., d",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 12 ],
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
     "raw": "a b, c..., d",
     "statements": [
       {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 12 ],
-        "raw": "a b, c..., d",
         "arguments": [
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 3,
-            "range": [ 2, 3 ],
+            "data": "b",
+            "line": 1,
+            "range": [
+              2,
+              3
+            ],
             "raw": "b",
-            "data": "b"
+            "type": "Identifier"
           },
           {
-            "type": "Spread",
-            "line": 1,
             "column": 6,
-            "range": [ 5, 9 ],
-            "raw": "c...",
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 6,
-              "range": [ 5, 6 ],
+              "data": "c",
+              "line": 1,
+              "range": [
+                5,
+                6
+              ],
               "raw": "c",
-              "data": "c"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              5,
+              9
+            ],
+            "raw": "c...",
+            "type": "Spread"
           },
           {
-            "type": "Identifier",
-            "line": 1,
             "column": 12,
-            "range": [ 11, 12 ],
+            "data": "d",
+            "line": 1,
+            "range": [
+              11,
+              12
+            ],
             "raw": "d",
-            "data": "d"
+            "type": "Identifier"
           }
         ],
+        "column": 1,
         "function": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "a b, c..., d",
+        "type": "FunctionApplication"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    12
+  ],
+  "raw": "a b, c..., d",
+  "type": "Program"
 }

--- a/test/examples/splat-in-function-call/output.json
+++ b/test/examples/splat-in-function-call/output.json
@@ -1,48 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "a(b...)",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 7 ],
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
     "raw": "a(b...)",
     "statements": [
       {
-        "type": "FunctionApplication",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 7 ],
-        "raw": "a(b...)",
         "arguments": [
           {
-            "type": "Spread",
-            "line": 1,
             "column": 3,
-            "range": [ 2, 6 ],
-            "raw": "b...",
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 3,
-              "range": [ 2, 3 ],
+              "data": "b",
+              "line": 1,
+              "range": [
+                2,
+                3
+              ],
               "raw": "b",
-              "data": "b"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              2,
+              6
+            ],
+            "raw": "b...",
+            "type": "Spread"
           }
         ],
+        "column": 1,
         "function": {
-          "type": "Identifier",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          7
+        ],
+        "raw": "a(b...)",
+        "type": "FunctionApplication"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "a(b...)",
+  "type": "Program"
 }

--- a/test/examples/splat-in-new-call/output.json
+++ b/test/examples/splat-in-new-call/output.json
@@ -1,48 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 16 ],
-  "raw": "new Foo(args...)",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 16 ],
+    "line": 1,
+    "range": [
+      0,
+      16
+    ],
     "raw": "new Foo(args...)",
     "statements": [
       {
-        "type": "NewOp",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 16 ],
-        "raw": "new Foo(args...)",
         "arguments": [
           {
-            "type": "Spread",
-            "line": 1,
             "column": 9,
-            "range": [ 8, 15 ],
-            "raw": "args...",
             "expression": {
-              "type": "Identifier",
-              "line": 1,
               "column": 9,
-              "range": [ 8, 12 ],
+              "data": "args",
+              "line": 1,
+              "range": [
+                8,
+                12
+              ],
               "raw": "args",
-              "data": "args"
-            }
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              8,
+              15
+            ],
+            "raw": "args...",
+            "type": "Spread"
           }
         ],
+        "column": 1,
         "ctor": {
-          "type": "Identifier",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 7 ],
+          "data": "Foo",
+          "line": 1,
+          "range": [
+            4,
+            7
+          ],
           "raw": "Foo",
-          "data": "Foo"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          16
+        ],
+        "raw": "new Foo(args...)",
+        "type": "NewOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    16
+  ],
+  "raw": "new Foo(args...)",
+  "type": "Program"
 }

--- a/test/examples/string-ending-with-interpolation/output.json
+++ b/test/examples/string-ending-with-interpolation/output.json
@@ -1,69 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
+    "raw": "\"a#{b}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 5,
+            "data": "b",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "a",
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
+            "raw": "a",
+            "type": "Quasi"
+          },
+          {
+            "column": 7,
+            "data": "",
+            "line": 1,
+            "range": [
+              6,
+              6
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          7
+        ],
+        "raw": "\"a#{b}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     7
   ],
   "raw": "\"a#{b}\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      7
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          7
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "a",
-            "range": [
-              1,
-              2
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 7,
-            "raw": "",
-            "range": [
-              6,
-              6
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 5,
-            "raw": "b",
-            "range": [
-              4,
-              5
-            ],
-            "data": "b"
-          }
-        ],
-        "raw": "\"a#{b}\""
-      }
-    ],
-    "raw": "\"a#{b}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-interpolation-in-object-literal/output.json
+++ b/test/examples/string-interpolation-in-object-literal/output.json
@@ -1,102 +1,102 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
+    "raw": "{a: \"#{b}\"}",
+    "statements": [
+      {
+        "column": 1,
+        "line": 1,
+        "members": [
+          {
+            "column": 2,
+            "expression": {
+              "column": 5,
+              "expressions": [
+                {
+                  "column": 8,
+                  "data": "b",
+                  "line": 1,
+                  "range": [
+                    7,
+                    8
+                  ],
+                  "raw": "b",
+                  "type": "Identifier"
+                }
+              ],
+              "line": 1,
+              "quasis": [
+                {
+                  "column": 6,
+                  "data": "",
+                  "line": 1,
+                  "range": [
+                    5,
+                    5
+                  ],
+                  "raw": "",
+                  "type": "Quasi"
+                },
+                {
+                  "column": 10,
+                  "data": "",
+                  "line": 1,
+                  "range": [
+                    9,
+                    9
+                  ],
+                  "raw": "",
+                  "type": "Quasi"
+                }
+              ],
+              "range": [
+                4,
+                10
+              ],
+              "raw": "\"#{b}\"",
+              "type": "String"
+            },
+            "key": {
+              "column": 2,
+              "data": "a",
+              "line": 1,
+              "range": [
+                1,
+                2
+              ],
+              "raw": "a",
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              1,
+              10
+            ],
+            "raw": "a: \"#{b}\"",
+            "type": "ObjectInitialiserMember"
+          }
+        ],
+        "range": [
+          0,
+          11
+        ],
+        "raw": "{a: \"#{b}\"}",
+        "type": "ObjectInitialiser"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     12
   ],
   "raw": "{a: \"#{b}\"}\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      11
-    ],
-    "statements": [
-      {
-        "type": "ObjectInitialiser",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          11
-        ],
-        "members": [
-          {
-            "type": "ObjectInitialiserMember",
-            "line": 1,
-            "column": 2,
-            "range": [
-              1,
-              10
-            ],
-            "key": {
-              "type": "Identifier",
-              "line": 1,
-              "column": 2,
-              "raw": "a",
-              "range": [
-                1,
-                2
-              ],
-              "data": "a"
-            },
-            "expression": {
-              "type": "String",
-              "line": 1,
-              "column": 5,
-              "range": [
-                4,
-                10
-              ],
-              "quasis": [
-                {
-                  "type": "Quasi",
-                  "line": 1,
-                  "column": 6,
-                  "raw": "",
-                  "range": [
-                    5,
-                    5
-                  ],
-                  "data": ""
-                },
-                {
-                  "type": "Quasi",
-                  "line": 1,
-                  "column": 10,
-                  "raw": "",
-                  "range": [
-                    9,
-                    9
-                  ],
-                  "data": ""
-                }
-              ],
-              "expressions": [
-                {
-                  "type": "Identifier",
-                  "line": 1,
-                  "column": 8,
-                  "raw": "b",
-                  "range": [
-                    7,
-                    8
-                  ],
-                  "data": "b"
-                }
-              ],
-              "raw": "\"#{b}\""
-            },
-            "raw": "a: \"#{b}\""
-          }
-        ],
-        "raw": "{a: \"#{b}\"}"
-      }
-    ],
-    "raw": "{a: \"#{b}\"}"
-  }
+  "type": "Program"
 }

--- a/test/examples/string-interpolation-plus-normal-string/output.json
+++ b/test/examples/string-interpolation-plus-normal-string/output.json
@@ -1,103 +1,104 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
+    "raw": "\"#{a}\" + \"b\"",
+    "statements": [
+      {
+        "column": 1,
+        "left": {
+          "column": 1,
+          "expressions": [
+            {
+              "column": 4,
+              "data": "a",
+              "line": 1,
+              "range": [
+                3,
+                4
+              ],
+              "raw": "a",
+              "type": "Identifier"
+            }
+          ],
+          "line": 1,
+          "quasis": [
+            {
+              "column": 2,
+              "data": "",
+              "line": 1,
+              "range": [
+                1,
+                1
+              ],
+              "raw": "",
+              "type": "Quasi"
+            },
+            {
+              "column": 6,
+              "data": "",
+              "line": 1,
+              "range": [
+                5,
+                5
+              ],
+              "raw": "",
+              "type": "Quasi"
+            }
+          ],
+          "range": [
+            0,
+            6
+          ],
+          "raw": "\"#{a}\"",
+          "type": "String"
+        },
+        "line": 1,
+        "range": [
+          0,
+          12
+        ],
+        "raw": "\"#{a}\" + \"b\"",
+        "right": {
+          "column": 10,
+          "expressions": [
+          ],
+          "line": 1,
+          "quasis": [
+            {
+              "column": 11,
+              "data": "b",
+              "line": 1,
+              "range": [
+                10,
+                11
+              ],
+              "raw": "b",
+              "type": "Quasi"
+            }
+          ],
+          "range": [
+            9,
+            12
+          ],
+          "raw": "\"b\"",
+          "type": "String"
+        },
+        "type": "PlusOp"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     13
   ],
   "raw": "\"#{a}\" + \"b\"\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      12
-    ],
-    "statements": [
-      {
-        "type": "PlusOp",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          12
-        ],
-        "left": {
-          "type": "String",
-          "line": 1,
-          "column": 1,
-          "range": [
-            0,
-            6
-          ],
-          "quasis": [
-            {
-              "type": "Quasi",
-              "line": 1,
-              "column": 2,
-              "raw": "",
-              "range": [
-                1,
-                1
-              ],
-              "data": ""
-            },
-            {
-              "type": "Quasi",
-              "line": 1,
-              "column": 6,
-              "raw": "",
-              "range": [
-                5,
-                5
-              ],
-              "data": ""
-            }
-          ],
-          "expressions": [
-            {
-              "type": "Identifier",
-              "line": 1,
-              "column": 4,
-              "raw": "a",
-              "range": [
-                3,
-                4
-              ],
-              "data": "a"
-            }
-          ],
-          "raw": "\"#{a}\""
-        },
-        "right": {
-          "type": "String",
-          "line": 1,
-          "column": 10,
-          "raw": "\"b\"",
-          "range": [
-            9,
-            12
-          ],
-          "quasis": [
-            {
-              "type": "Quasi",
-              "line": 1,
-              "column": 11,
-              "raw": "b",
-              "range": [
-                10,
-                11
-              ],
-              "data": "b"
-            }
-          ],
-          "expressions": []
-        },
-        "raw": "\"#{a}\" + \"b\""
-      }
-    ],
-    "raw": "\"#{a}\" + \"b\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-interpolation-preceded-by-parenthesis/output.json
+++ b/test/examples/string-interpolation-preceded-by-parenthesis/output.json
@@ -1,69 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 2,
+    "range": [
+      58,
+      65
+    ],
+    "raw": "\"(#{a}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 5,
+            "data": "a",
+            "line": 2,
+            "range": [
+              62,
+              63
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          }
+        ],
+        "line": 2,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "(",
+            "line": 2,
+            "range": [
+              59,
+              60
+            ],
+            "raw": "(",
+            "type": "Quasi"
+          },
+          {
+            "column": 7,
+            "data": "",
+            "line": 2,
+            "range": [
+              64,
+              64
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          58,
+          65
+        ],
+        "raw": "\"(#{a}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     66
   ],
   "raw": "# https://github.com/decaffeinate/decaffeinate/issues/212\n\"(#{a}\"\n",
-  "body": {
-    "type": "Block",
-    "line": 2,
-    "column": 1,
-    "range": [
-      58,
-      65
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 2,
-        "column": 1,
-        "range": [
-          58,
-          65
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 2,
-            "column": 2,
-            "raw": "(",
-            "range": [
-              59,
-              60
-            ],
-            "data": "("
-          },
-          {
-            "type": "Quasi",
-            "line": 2,
-            "column": 7,
-            "raw": "",
-            "range": [
-              64,
-              64
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 2,
-            "column": 5,
-            "raw": "a",
-            "range": [
-              62,
-              63
-            ],
-            "data": "a"
-          }
-        ],
-        "raw": "\"(#{a}\""
-      }
-    ],
-    "raw": "\"(#{a}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-interpolation-with-escaped-newline/output.json
+++ b/test/examples/string-interpolation-with-escaped-newline/output.json
@@ -1,91 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
+    "raw": "\"#{a}\\\n#{b}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 4,
+            "data": "a",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          {
+            "column": 3,
+            "data": "b",
+            "line": 2,
+            "range": [
+              9,
+              10
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 6,
+            "data": "",
+            "line": 1,
+            "range": [
+              5,
+              7
+            ],
+            "raw": "\\\n",
+            "type": "Quasi"
+          },
+          {
+            "column": 5,
+            "data": "",
+            "line": 2,
+            "range": [
+              11,
+              11
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          12
+        ],
+        "raw": "\"#{a}\\\n#{b}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     13
   ],
   "raw": "\"#{a}\\\n#{b}\"\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      12
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          12
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 6,
-            "raw": "\\\n",
-            "range": [
-              5,
-              7
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 2,
-            "column": 5,
-            "raw": "",
-            "range": [
-              11,
-              11
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 4,
-            "raw": "a",
-            "range": [
-              3,
-              4
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Identifier",
-            "line": 2,
-            "column": 3,
-            "raw": "b",
-            "range": [
-              9,
-              10
-            ],
-            "data": "b"
-          }
-        ],
-        "raw": "\"#{a}\\\n#{b}\""
-      }
-    ],
-    "raw": "\"#{a}\\\n#{b}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-interpolation-with-plus/output.json
+++ b/test/examples/string-interpolation-with-plus/output.json
@@ -1,90 +1,90 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
+    "raw": "\"#{a + b}c\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 4,
+            "left": {
+              "column": 4,
+              "data": "a",
+              "line": 1,
+              "range": [
+                3,
+                4
+              ],
+              "raw": "a",
+              "type": "Identifier"
+            },
+            "line": 1,
+            "range": [
+              3,
+              8
+            ],
+            "raw": "a + b",
+            "right": {
+              "column": 8,
+              "data": "b",
+              "line": 1,
+              "range": [
+                7,
+                8
+              ],
+              "raw": "b",
+              "type": "Identifier"
+            },
+            "type": "PlusOp"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 10,
+            "data": "c",
+            "line": 1,
+            "range": [
+              9,
+              10
+            ],
+            "raw": "c",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          11
+        ],
+        "raw": "\"#{a + b}c\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     12
   ],
   "raw": "\"#{a + b}c\"\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      11
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          11
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 10,
-            "raw": "c",
-            "range": [
-              9,
-              10
-            ],
-            "data": "c"
-          }
-        ],
-        "expressions": [
-          {
-            "type": "PlusOp",
-            "line": 1,
-            "column": 4,
-            "range": [
-              3,
-              8
-            ],
-            "left": {
-              "type": "Identifier",
-              "line": 1,
-              "column": 4,
-              "raw": "a",
-              "range": [
-                3,
-                4
-              ],
-              "data": "a"
-            },
-            "right": {
-              "type": "Identifier",
-              "line": 1,
-              "column": 8,
-              "raw": "b",
-              "range": [
-                7,
-                8
-              ],
-              "data": "b"
-            },
-            "raw": "a + b"
-          }
-        ],
-        "raw": "\"#{a + b}c\""
-      }
-    ],
-    "raw": "\"#{a + b}c\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-starting-with-interpolation/output.json
+++ b/test/examples/string-starting-with-interpolation/output.json
@@ -1,69 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
+    "raw": "\"#{a}b\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 4,
+            "data": "a",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 6,
+            "data": "b",
+            "line": 1,
+            "range": [
+              5,
+              6
+            ],
+            "raw": "b",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          7
+        ],
+        "raw": "\"#{a}b\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     7
   ],
   "raw": "\"#{a}b\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      7
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          7
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 6,
-            "raw": "b",
-            "range": [
-              5,
-              6
-            ],
-            "data": "b"
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 4,
-            "raw": "a",
-            "range": [
-              3,
-              4
-            ],
-            "data": "a"
-          }
-        ],
-        "raw": "\"#{a}b\""
-      }
-    ],
-    "raw": "\"#{a}b\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-double-quotes/output.json
+++ b/test/examples/string-with-double-quotes/output.json
@@ -1,46 +1,47 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
+    "raw": "\"coffee me\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "coffee me",
+            "line": 1,
+            "range": [
+              1,
+              10
+            ],
+            "raw": "coffee me",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          11
+        ],
+        "raw": "\"coffee me\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     11
   ],
   "raw": "\"coffee me\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      11
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "raw": "\"coffee me\"",
-        "range": [
-          0,
-          11
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "coffee me",
-            "range": [
-              1,
-              10
-            ],
-            "data": "coffee me"
-          }
-        ],
-        "expressions": []
-      }
-    ],
-    "raw": "\"coffee me\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-interpolation/output.json
+++ b/test/examples/string-with-interpolation/output.json
@@ -1,69 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
+    "raw": "\"a#{b}c\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 5,
+            "data": "b",
+            "line": 1,
+            "range": [
+              4,
+              5
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "a",
+            "line": 1,
+            "range": [
+              1,
+              2
+            ],
+            "raw": "a",
+            "type": "Quasi"
+          },
+          {
+            "column": 7,
+            "data": "c",
+            "line": 1,
+            "range": [
+              6,
+              7
+            ],
+            "raw": "c",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          8
+        ],
+        "raw": "\"a#{b}c\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     8
   ],
   "raw": "\"a#{b}c\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      8
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          8
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "a",
-            "range": [
-              1,
-              2
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 7,
-            "raw": "c",
-            "range": [
-              6,
-              7
-            ],
-            "data": "c"
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 5,
-            "raw": "b",
-            "range": [
-              4,
-              5
-            ],
-            "data": "b"
-          }
-        ],
-        "raw": "\"a#{b}c\""
-      }
-    ],
-    "raw": "\"a#{b}c\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-interpolations-at-start-and-end/output.json
+++ b/test/examples/string-with-interpolations-at-start-and-end/output.json
@@ -1,91 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
+    "raw": "\"#{a} #{b}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 4,
+            "data": "a",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          {
+            "column": 9,
+            "data": "b",
+            "line": 1,
+            "range": [
+              8,
+              9
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 6,
+            "data": " ",
+            "line": 1,
+            "range": [
+              5,
+              6
+            ],
+            "raw": " ",
+            "type": "Quasi"
+          },
+          {
+            "column": 11,
+            "data": "",
+            "line": 1,
+            "range": [
+              10,
+              10
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          11
+        ],
+        "raw": "\"#{a} #{b}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     11
   ],
   "raw": "\"#{a} #{b}\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      11
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          11
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 6,
-            "raw": " ",
-            "range": [
-              5,
-              6
-            ],
-            "data": " "
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 11,
-            "raw": "",
-            "range": [
-              10,
-              10
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 4,
-            "raw": "a",
-            "range": [
-              3,
-              4
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 9,
-            "raw": "b",
-            "range": [
-              8,
-              9
-            ],
-            "data": "b"
-          }
-        ],
-        "raw": "\"#{a} #{b}\""
-      }
-    ],
-    "raw": "\"#{a} #{b}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-noop-escape/output.json
+++ b/test/examples/string-with-noop-escape/output.json
@@ -1,46 +1,47 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      4
+    ],
+    "raw": "'\\.'",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": ".",
+            "line": 1,
+            "range": [
+              1,
+              3
+            ],
+            "raw": "\\.",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          4
+        ],
+        "raw": "'\\.'",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     4
   ],
   "raw": "'\\.'",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      4
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "raw": "'\\.'",
-        "range": [
-          0,
-          4
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "\\.",
-            "range": [
-              1,
-              3
-            ],
-            "data": "."
-          }
-        ],
-        "expressions": []
-      }
-    ],
-    "raw": "'\\.'"
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-only-multiple-interpolations/output.json
+++ b/test/examples/string-with-only-multiple-interpolations/output.json
@@ -1,113 +1,113 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      14
+    ],
+    "raw": "\"#{a}#{b}#{c}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 4,
+            "data": "a",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          {
+            "column": 8,
+            "data": "b",
+            "line": 1,
+            "range": [
+              7,
+              8
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          },
+          {
+            "column": 12,
+            "data": "c",
+            "line": 1,
+            "range": [
+              11,
+              12
+            ],
+            "raw": "c",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 6,
+            "data": "",
+            "line": 1,
+            "range": [
+              5,
+              5
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 10,
+            "data": "",
+            "line": 1,
+            "range": [
+              9,
+              9
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 14,
+            "data": "",
+            "line": 1,
+            "range": [
+              13,
+              13
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          14
+        ],
+        "raw": "\"#{a}#{b}#{c}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     14
   ],
   "raw": "\"#{a}#{b}#{c}\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      14
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          14
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 6,
-            "raw": "",
-            "range": [
-              5,
-              5
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 10,
-            "raw": "",
-            "range": [
-              9,
-              9
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 14,
-            "raw": "",
-            "range": [
-              13,
-              13
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 4,
-            "raw": "a",
-            "range": [
-              3,
-              4
-            ],
-            "data": "a"
-          },
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 8,
-            "raw": "b",
-            "range": [
-              7,
-              8
-            ],
-            "data": "b"
-          },
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 12,
-            "raw": "c",
-            "range": [
-              11,
-              12
-            ],
-            "data": "c"
-          }
-        ],
-        "raw": "\"#{a}#{b}#{c}\""
-      }
-    ],
-    "raw": "\"#{a}#{b}#{c}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-only-single-interpolation/output.json
+++ b/test/examples/string-with-only-single-interpolation/output.json
@@ -1,69 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      6
+    ],
+    "raw": "\"#{a}\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 4,
+            "data": "a",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "",
+            "line": 1,
+            "range": [
+              1,
+              1
+            ],
+            "raw": "",
+            "type": "Quasi"
+          },
+          {
+            "column": 6,
+            "data": "",
+            "line": 1,
+            "range": [
+              5,
+              5
+            ],
+            "raw": "",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          6
+        ],
+        "raw": "\"#{a}\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     6
   ],
   "raw": "\"#{a}\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      6
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          6
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "",
-            "range": [
-              1,
-              1
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 6,
-            "raw": "",
-            "range": [
-              5,
-              5
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 1,
-            "column": 4,
-            "raw": "a",
-            "range": [
-              3,
-              4
-            ],
-            "data": "a"
-          }
-        ],
-        "raw": "\"#{a}\""
-      }
-    ],
-    "raw": "\"#{a}\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-parentheses-inside/output.json
+++ b/test/examples/string-with-parentheses-inside/output.json
@@ -1,46 +1,47 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
+    "raw": "\"( a\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "( a",
+            "line": 1,
+            "range": [
+              1,
+              4
+            ],
+            "raw": "( a",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          5
+        ],
+        "raw": "\"( a\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     5
   ],
   "raw": "\"( a\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      5
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "raw": "\"( a\"",
-        "range": [
-          0,
-          5
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "( a",
-            "range": [
-              1,
-              4
-            ],
-            "data": "( a"
-          }
-        ],
-        "expressions": []
-      }
-    ],
-    "raw": "\"( a\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-single-quotes/output.json
+++ b/test/examples/string-with-single-quotes/output.json
@@ -1,46 +1,47 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      15
+    ],
+    "raw": "'coffee script'",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 2,
+            "data": "coffee script",
+            "line": 1,
+            "range": [
+              1,
+              14
+            ],
+            "raw": "coffee script",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          15
+        ],
+        "raw": "'coffee script'",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     15
   ],
   "raw": "'coffee script'",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      15
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "raw": "'coffee script'",
-        "range": [
-          0,
-          15
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 2,
-            "raw": "coffee script",
-            "range": [
-              1,
-              14
-            ],
-            "data": "coffee script"
-          }
-        ],
-        "expressions": []
-      }
-    ],
-    "raw": "'coffee script'"
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-triple-double-quotes/output.json
+++ b/test/examples/string-with-triple-double-quotes/output.json
@@ -1,46 +1,47 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      26
+    ],
+    "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "multi-line strings",
+            "line": 1,
+            "range": [
+              3,
+              23
+            ],
+            "raw": "\nmulti-line strings\n",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          26
+        ],
+        "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     26
   ],
   "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      26
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
-        "range": [
-          0,
-          26
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "\nmulti-line strings\n",
-            "range": [
-              3,
-              23
-            ],
-            "data": "multi-line strings"
-          }
-        ],
-        "expressions": []
-      }
-    ],
-    "raw": "\"\"\"\nmulti-line strings\n\"\"\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-triple-quote-interpolation-containing-quotes/output.json
+++ b/test/examples/string-with-triple-quote-interpolation-containing-quotes/output.json
@@ -1,69 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      20
+    ],
+    "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 8,
+            "data": "bar",
+            "line": 2,
+            "range": [
+              11,
+              14
+            ],
+            "raw": "bar",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "bar=\"",
+            "line": 1,
+            "range": [
+              3,
+              9
+            ],
+            "raw": "\nbar=\"",
+            "type": "Quasi"
+          },
+          {
+            "column": 12,
+            "data": "\"",
+            "line": 2,
+            "range": [
+              15,
+              17
+            ],
+            "raw": "\"\n",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          20
+        ],
+        "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     20
   ],
   "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      20
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          20
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "\nbar=\"",
-            "range": [
-              3,
-              9
-            ],
-            "data": "bar=\""
-          },
-          {
-            "type": "Quasi",
-            "line": 2,
-            "column": 12,
-            "raw": "\"\n",
-            "range": [
-              15,
-              17
-            ],
-            "data": "\""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 2,
-            "column": 8,
-            "raw": "bar",
-            "range": [
-              11,
-              14
-            ],
-            "data": "bar"
-          }
-        ],
-        "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\""
-      }
-    ],
-    "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-triple-quote-interpolation/output.json
+++ b/test/examples/string-with-triple-quote-interpolation/output.json
@@ -1,69 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      12
+    ],
+    "raw": "\"\"\"\n#{a}\n\"\"\"",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+          {
+            "column": 3,
+            "data": "a",
+            "line": 2,
+            "range": [
+              6,
+              7
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          }
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "",
+            "line": 1,
+            "range": [
+              3,
+              4
+            ],
+            "raw": "\n",
+            "type": "Quasi"
+          },
+          {
+            "column": 5,
+            "data": "",
+            "line": 2,
+            "range": [
+              8,
+              9
+            ],
+            "raw": "\n",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          12
+        ],
+        "raw": "\"\"\"\n#{a}\n\"\"\"",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     12
   ],
   "raw": "\"\"\"\n#{a}\n\"\"\"",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      12
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          12
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "\n",
-            "range": [
-              3,
-              4
-            ],
-            "data": ""
-          },
-          {
-            "type": "Quasi",
-            "line": 2,
-            "column": 5,
-            "raw": "\n",
-            "range": [
-              8,
-              9
-            ],
-            "data": ""
-          }
-        ],
-        "expressions": [
-          {
-            "type": "Identifier",
-            "line": 2,
-            "column": 3,
-            "raw": "a",
-            "range": [
-              6,
-              7
-            ],
-            "data": "a"
-          }
-        ],
-        "raw": "\"\"\"\n#{a}\n\"\"\""
-      }
-    ],
-    "raw": "\"\"\"\n#{a}\n\"\"\""
-  }
+  "type": "Program"
 }

--- a/test/examples/string-with-triple-single-quotes/output.json
+++ b/test/examples/string-with-triple-single-quotes/output.json
@@ -1,46 +1,47 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      26
+    ],
+    "raw": "'''\nmulti-line strings\n'''",
+    "statements": [
+      {
+        "column": 1,
+        "expressions": [
+        ],
+        "line": 1,
+        "quasis": [
+          {
+            "column": 4,
+            "data": "multi-line strings",
+            "line": 1,
+            "range": [
+              3,
+              23
+            ],
+            "raw": "\nmulti-line strings\n",
+            "type": "Quasi"
+          }
+        ],
+        "range": [
+          0,
+          26
+        ],
+        "raw": "'''\nmulti-line strings\n'''",
+        "type": "String"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     26
   ],
   "raw": "'''\nmulti-line strings\n'''",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      26
-    ],
-    "statements": [
-      {
-        "type": "String",
-        "line": 1,
-        "column": 1,
-        "raw": "'''\nmulti-line strings\n'''",
-        "range": [
-          0,
-          26
-        ],
-        "quasis": [
-          {
-            "type": "Quasi",
-            "line": 1,
-            "column": 4,
-            "raw": "\nmulti-line strings\n",
-            "range": [
-              3,
-              23
-            ],
-            "data": "multi-line strings"
-          }
-        ],
-        "expressions": []
-      }
-    ],
-    "raw": "'''\nmulti-line strings\n'''"
-  }
+  "type": "Program"
 }

--- a/test/examples/subtraction/output.json
+++ b/test/examples/subtraction/output.json
@@ -1,39 +1,54 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "3 - 4",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "3 - 4",
     "statements": [
       {
-        "type": "SubtractOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "3 - 4",
         "left": {
-          "type": "Int",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "3",
-          "data": 3
-        },
-        "right": {
-          "type": "Int",
+          "data": 3,
           "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "3",
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "3 - 4",
+        "right": {
           "column": 5,
-          "range": [ 4, 5 ],
+          "data": 4,
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
           "raw": "4",
-          "data": 4
-        }
+          "type": "Int"
+        },
+        "type": "SubtractOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "3 - 4",
+  "type": "Program"
 }

--- a/test/examples/switch-with-alternate/output.json
+++ b/test/examples/switch-with-alternate/output.json
@@ -1,86 +1,116 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 37 ],
-  "raw": "switch a\n  when b\n    c\n\n  else\n    d",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 37 ],
+    "line": 1,
+    "range": [
+      0,
+      37
+    ],
     "raw": "switch a\n  when b\n    c\n\n  else\n    d",
     "statements": [
       {
-        "type": "Switch",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 37 ],
-        "raw": "switch a\n  when b\n    c\n\n  else\n    d",
         "alternate": {
-          "type": "Block",
-          "line": 6,
           "column": 5,
-          "range": [ 36, 37 ],
-          "raw": "d",
           "inline": false,
+          "line": 6,
+          "range": [
+            36,
+            37
+          ],
+          "raw": "d",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 6,
               "column": 5,
-              "range": [ 36, 37 ],
+              "data": "d",
+              "line": 6,
+              "range": [
+                36,
+                37
+              ],
               "raw": "d",
-              "data": "d"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
         "cases": [
           {
-            "type": "SwitchCase",
-            "line": 2,
             "column": 3,
-            "range": [ 11, 23 ],
-            "raw": "when b\n    c",
             "conditions": [
               {
-                "type": "Identifier",
-                "line": 2,
                 "column": 8,
-                "range": [ 16, 17 ],
+                "data": "b",
+                "line": 2,
+                "range": [
+                  16,
+                  17
+                ],
                 "raw": "b",
-                "data": "b"
+                "type": "Identifier"
               }
             ],
             "consequent": {
-              "type": "Block",
-              "line": 3,
               "column": 5,
-              "range": [ 22, 23 ],
-              "raw": "c",
               "inline": false,
+              "line": 3,
+              "range": [
+                22,
+                23
+              ],
+              "raw": "c",
               "statements": [
                 {
-                  "type": "Identifier",
-                  "line": 3,
                   "column": 5,
-                  "range": [ 22, 23 ],
+                  "data": "c",
+                  "line": 3,
+                  "range": [
+                    22,
+                    23
+                  ],
                   "raw": "c",
-                  "data": "c"
+                  "type": "Identifier"
                 }
-              ]
-            }
+              ],
+              "type": "Block"
+            },
+            "line": 2,
+            "range": [
+              11,
+              23
+            ],
+            "raw": "when b\n    c",
+            "type": "SwitchCase"
           }
         ],
+        "column": 1,
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          37
+        ],
+        "raw": "switch a\n  when b\n    c\n\n  else\n    d",
+        "type": "Switch"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    37
+  ],
+  "raw": "switch a\n  when b\n    c\n\n  else\n    d",
+  "type": "Program"
 }

--- a/test/examples/switch-with-multiple-cases/output.json
+++ b/test/examples/switch-with-multiple-cases/output.json
@@ -1,104 +1,140 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 39 ],
-  "raw": "switch a\n  when b\n    c\n  when d\n    e\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 38 ],
+    "line": 1,
+    "range": [
+      0,
+      38
+    ],
     "raw": "switch a\n  when b\n    c\n  when d\n    e",
     "statements": [
       {
-        "type": "Switch",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 38 ],
-        "raw": "switch a\n  when b\n    c\n  when d\n    e",
         "alternate": null,
         "cases": [
           {
-            "type": "SwitchCase",
-            "line": 2,
             "column": 3,
-            "range": [ 11, 23 ],
-            "raw": "when b\n    c",
             "conditions": [
               {
-                "type": "Identifier",
-                "line": 2,
                 "column": 8,
-                "range": [ 16, 17 ],
+                "data": "b",
+                "line": 2,
+                "range": [
+                  16,
+                  17
+                ],
                 "raw": "b",
-                "data": "b"
+                "type": "Identifier"
               }
             ],
             "consequent": {
-              "type": "Block",
-              "line": 3,
               "column": 5,
-              "range": [ 22, 23 ],
-              "raw": "c",
               "inline": false,
+              "line": 3,
+              "range": [
+                22,
+                23
+              ],
+              "raw": "c",
               "statements": [
                 {
-                  "type": "Identifier",
-                  "line": 3,
                   "column": 5,
-                  "range": [ 22, 23 ],
+                  "data": "c",
+                  "line": 3,
+                  "range": [
+                    22,
+                    23
+                  ],
                   "raw": "c",
-                  "data": "c"
+                  "type": "Identifier"
                 }
-              ]
-            }
+              ],
+              "type": "Block"
+            },
+            "line": 2,
+            "range": [
+              11,
+              23
+            ],
+            "raw": "when b\n    c",
+            "type": "SwitchCase"
           },
           {
-            "type": "SwitchCase",
-            "line": 4,
             "column": 3,
-            "range": [ 26, 38 ],
-            "raw": "when d\n    e",
             "conditions": [
               {
-                "type": "Identifier",
-                "line": 4,
                 "column": 8,
-                "range": [ 31, 32 ],
+                "data": "d",
+                "line": 4,
+                "range": [
+                  31,
+                  32
+                ],
                 "raw": "d",
-                "data": "d"
+                "type": "Identifier"
               }
             ],
             "consequent": {
-              "type": "Block",
-              "line": 5,
               "column": 5,
-              "range": [ 37, 38 ],
-              "raw": "e",
               "inline": false,
+              "line": 5,
+              "range": [
+                37,
+                38
+              ],
+              "raw": "e",
               "statements": [
                 {
-                  "type": "Identifier",
-                  "line": 5,
                   "column": 5,
-                  "range": [ 37, 38 ],
+                  "data": "e",
+                  "line": 5,
+                  "range": [
+                    37,
+                    38
+                  ],
                   "raw": "e",
-                  "data": "e"
+                  "type": "Identifier"
                 }
-              ]
-            }
+              ],
+              "type": "Block"
+            },
+            "line": 4,
+            "range": [
+              26,
+              38
+            ],
+            "raw": "when d\n    e",
+            "type": "SwitchCase"
           }
         ],
+        "column": 1,
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          38
+        ],
+        "raw": "switch a\n  when b\n    c\n  when d\n    e",
+        "type": "Switch"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    39
+  ],
+  "raw": "switch a\n  when b\n    c\n  when d\n    e\n",
+  "type": "Program"
 }

--- a/test/examples/switch-with-multiple-conditions/output.json
+++ b/test/examples/switch-with-multiple-conditions/output.json
@@ -1,77 +1,104 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 26 ],
-  "raw": "switch a\n  when b, c\n    d",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 26 ],
+    "line": 1,
+    "range": [
+      0,
+      26
+    ],
     "raw": "switch a\n  when b, c\n    d",
     "statements": [
       {
-        "type": "Switch",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 26 ],
-        "raw": "switch a\n  when b, c\n    d",
         "alternate": null,
         "cases": [
           {
-            "type": "SwitchCase",
-            "line": 2,
             "column": 3,
-            "range": [ 11, 26 ],
-            "raw": "when b, c\n    d",
             "conditions": [
               {
-                "type": "Identifier",
-                "line": 2,
                 "column": 8,
-                "range": [ 16, 17 ],
+                "data": "b",
+                "line": 2,
+                "range": [
+                  16,
+                  17
+                ],
                 "raw": "b",
-                "data": "b"
+                "type": "Identifier"
               },
               {
-                "type": "Identifier",
-                "line": 2,
                 "column": 11,
-                "range": [ 19, 20 ],
+                "data": "c",
+                "line": 2,
+                "range": [
+                  19,
+                  20
+                ],
                 "raw": "c",
-                "data": "c"
+                "type": "Identifier"
               }
             ],
             "consequent": {
-              "type": "Block",
-              "line": 3,
               "column": 5,
-              "range": [ 25, 26 ],
-              "raw": "d",
               "inline": false,
+              "line": 3,
+              "range": [
+                25,
+                26
+              ],
+              "raw": "d",
               "statements": [
                 {
-                  "type": "Identifier",
-                  "line": 3,
                   "column": 5,
-                  "range": [ 25, 26 ],
+                  "data": "d",
+                  "line": 3,
+                  "range": [
+                    25,
+                    26
+                  ],
                   "raw": "d",
-                  "data": "d"
+                  "type": "Identifier"
                 }
-              ]
-            }
+              ],
+              "type": "Block"
+            },
+            "line": 2,
+            "range": [
+              11,
+              26
+            ],
+            "raw": "when b, c\n    d",
+            "type": "SwitchCase"
           }
         ],
+        "column": 1,
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          26
+        ],
+        "raw": "switch a\n  when b, c\n    d",
+        "type": "Switch"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    26
+  ],
+  "raw": "switch a\n  when b, c\n    d",
+  "type": "Program"
 }

--- a/test/examples/switch-with-one-case/output.json
+++ b/test/examples/switch-with-one-case/output.json
@@ -1,69 +1,93 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 24 ],
-  "raw": "switch a\n  when b\n    c\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 23 ],
+    "line": 1,
+    "range": [
+      0,
+      23
+    ],
     "raw": "switch a\n  when b\n    c",
     "statements": [
       {
-        "type": "Switch",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 23 ],
-        "raw": "switch a\n  when b\n    c",
         "alternate": null,
         "cases": [
           {
-            "type": "SwitchCase",
-            "line": 2,
             "column": 3,
-            "range": [ 11, 23 ],
-            "raw": "when b\n    c",
             "conditions": [
               {
-                "type": "Identifier",
-                "line": 2,
                 "column": 8,
-                "range": [ 16, 17 ],
+                "data": "b",
+                "line": 2,
+                "range": [
+                  16,
+                  17
+                ],
                 "raw": "b",
-                "data": "b"
+                "type": "Identifier"
               }
             ],
             "consequent": {
-              "type": "Block",
-              "line": 3,
               "column": 5,
-              "range": [ 22, 23 ],
-              "raw": "c",
               "inline": false,
+              "line": 3,
+              "range": [
+                22,
+                23
+              ],
+              "raw": "c",
               "statements": [
                 {
-                  "type": "Identifier",
-                  "line": 3,
                   "column": 5,
-                  "range": [ 22, 23 ],
+                  "data": "c",
+                  "line": 3,
+                  "range": [
+                    22,
+                    23
+                  ],
                   "raw": "c",
-                  "data": "c"
+                  "type": "Identifier"
                 }
-              ]
-            }
+              ],
+              "type": "Block"
+            },
+            "line": 2,
+            "range": [
+              11,
+              23
+            ],
+            "raw": "when b\n    c",
+            "type": "SwitchCase"
           }
         ],
+        "column": 1,
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          23
+        ],
+        "raw": "switch a\n  when b\n    c",
+        "type": "Switch"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    24
+  ],
+  "raw": "switch a\n  when b\n    c\n",
+  "type": "Program"
 }

--- a/test/examples/this-assign-with-keyword/output.json
+++ b/test/examples/this-assign-with-keyword/output.json
@@ -1,66 +1,66 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    11
-  ],
-  "raw": "(@case) ->\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       10
     ],
+    "raw": "(@case) ->",
     "statements": [
       {
-        "type": "Function",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          10
-        ],
         "body": null,
+        "column": 1,
+        "line": 1,
         "parameters": [
           {
-            "type": "MemberAccessOp",
-            "line": 1,
             "column": 2,
-            "range": [
-              1,
-              6
-            ],
-            "raw": "@case",
             "expression": {
-              "type": "This",
-              "line": 1,
               "column": 2,
+              "line": 1,
               "range": [
                 1,
                 2
               ],
-              "raw": "@"
+              "raw": "@",
+              "type": "This"
             },
+            "line": 1,
             "member": {
-              "type": "Identifier",
-              "line": 1,
               "column": 3,
+              "data": "case",
+              "line": 1,
               "range": [
                 2,
                 6
               ],
               "raw": "case",
-              "data": "case"
-            }
+              "type": "Identifier"
+            },
+            "range": [
+              1,
+              6
+            ],
+            "raw": "@case",
+            "type": "MemberAccessOp"
           }
         ],
-        "raw": "(@case) ->"
+        "range": [
+          0,
+          10
+        ],
+        "raw": "(@case) ->",
+        "type": "Function"
       }
     ],
-    "raw": "(@case) ->"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    11
+  ],
+  "raw": "(@case) ->\n",
+  "type": "Program"
 }

--- a/test/examples/throw/output.json
+++ b/test/examples/throw/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 8 ],
-  "raw": "throw 42",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 8 ],
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
     "raw": "throw 42",
     "statements": [
       {
-        "type": "Throw",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 8 ],
-        "raw": "throw 42",
         "expression": {
-          "type": "Int",
-          "line": 1,
           "column": 7,
-          "range": [ 6, 8 ],
+          "data": 42,
+          "line": 1,
+          "range": [
+            6,
+            8
+          ],
           "raw": "42",
-          "data": 42
-        }
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "throw 42",
+        "type": "Throw"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    8
+  ],
+  "raw": "throw 42",
+  "type": "Program"
 }

--- a/test/examples/true/output.json
+++ b/test/examples/true/output.json
@@ -1,24 +1,33 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 4 ],
-  "raw": "true",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 4 ],
+    "line": 1,
+    "range": [
+      0,
+      4
+    ],
     "raw": "true",
     "statements": [
       {
-        "type": "Bool",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 4 ],
+        "data": true,
+        "line": 1,
+        "range": [
+          0,
+          4
+        ],
         "raw": "true",
-        "data": true
+        "type": "Bool"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    4
+  ],
+  "raw": "true",
+  "type": "Program"
 }

--- a/test/examples/try-with-catch-and-finally/output.json
+++ b/test/examples/try-with-catch-and-finally/output.json
@@ -1,78 +1,105 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 30 ],
-  "raw": "try\n  a\ncatch\n  b\nfinally\n  c\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 29 ],
+    "line": 1,
+    "range": [
+      0,
+      29
+    ],
     "raw": "try\n  a\ncatch\n  b\nfinally\n  c",
     "statements": [
       {
-        "type": "Try",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 29 ],
-        "raw": "try\n  a\ncatch\n  b\nfinally\n  c",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 6, 7 ],
-          "raw": "a",
           "inline": false,
+          "line": 2,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 6, 7 ],
+              "data": "a",
+              "line": 2,
+              "range": [
+                6,
+                7
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
         "catchAssignee": null,
         "catchBody": {
-          "type": "Block",
+          "column": 3,
+          "inline": false,
           "line": 4,
-          "column": 3,
-          "range": [ 16, 17 ],
+          "range": [
+            16,
+            17
+          ],
           "raw": "b",
-          "inline": false,
           "statements": [
             {
-              "type": "Identifier",
+              "column": 3,
+              "data": "b",
               "line": 4,
-              "column": 3,
-              "range": [ 16, 17 ],
+              "range": [
+                16,
+                17
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "finallyBody": {
-          "type": "Block",
-          "line": 6,
           "column": 3,
-          "range": [ 28, 29 ],
-          "raw": "c",
           "inline": false,
+          "line": 6,
+          "range": [
+            28,
+            29
+          ],
+          "raw": "c",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 6,
               "column": 3,
-              "range": [ 28, 29 ],
+              "data": "c",
+              "line": 6,
+              "range": [
+                28,
+                29
+              ],
               "raw": "c",
-              "data": "c"
+              "type": "Identifier"
             }
-          ]
-        }
+          ],
+          "type": "Block"
+        },
+        "line": 1,
+        "range": [
+          0,
+          29
+        ],
+        "raw": "try\n  a\ncatch\n  b\nfinally\n  c",
+        "type": "Try"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    30
+  ],
+  "raw": "try\n  a\ncatch\n  b\nfinally\n  c\n",
+  "type": "Program"
 }

--- a/test/examples/try-with-catch-assignee/output.json
+++ b/test/examples/try-with-catch-assignee/output.json
@@ -1,68 +1,92 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 21 ],
-  "raw": "try\n  a\ncatch err\n  b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 21 ],
+    "line": 1,
+    "range": [
+      0,
+      21
+    ],
     "raw": "try\n  a\ncatch err\n  b",
     "statements": [
       {
-        "type": "Try",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 21 ],
-        "raw": "try\n  a\ncatch err\n  b",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 6, 7 ],
-          "raw": "a",
           "inline": false,
+          "line": 2,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 6, 7 ],
+              "data": "a",
+              "line": 2,
+              "range": [
+                6,
+                7
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
         "catchAssignee": {
-          "type": "Identifier",
-          "line": 3,
           "column": 7,
-          "range": [ 14, 17 ],
+          "data": "err",
+          "line": 3,
+          "range": [
+            14,
+            17
+          ],
           "raw": "err",
-          "data": "err"
+          "type": "Identifier"
         },
         "catchBody": {
-          "type": "Block",
-          "line": 4,
           "column": 3,
-          "range": [ 20, 21 ],
-          "raw": "b",
           "inline": false,
+          "line": 4,
+          "range": [
+            20,
+            21
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 4,
               "column": 3,
-              "range": [ 20, 21 ],
+              "data": "b",
+              "line": 4,
+              "range": [
+                20,
+                21
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "finallyBody": null
+        "column": 1,
+        "finallyBody": null,
+        "line": 1,
+        "range": [
+          0,
+          21
+        ],
+        "raw": "try\n  a\ncatch err\n  b",
+        "type": "Try"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    21
+  ],
+  "raw": "try\n  a\ncatch err\n  b",
+  "type": "Program"
 }

--- a/test/examples/try-with-catch-single-line/output.json
+++ b/test/examples/try-with-catch-single-line/output.json
@@ -1,51 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 13 ],
-  "raw": "try a catch b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 13 ],
+    "line": 1,
+    "range": [
+      0,
+      13
+    ],
     "raw": "try a catch b",
     "statements": [
       {
-        "type": "Try",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 13 ],
-        "raw": "try a catch b",
         "body": {
-          "type": "Block",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 5 ],
-          "raw": "a",
           "inline": true,
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 5,
-              "range": [ 4, 5 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                4,
+                5
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
         "catchAssignee": {
-          "type": "Identifier",
-          "line": 1,
           "column": 13,
-          "range": [ 12, 13 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            12,
+            13
+          ],
           "raw": "b",
-          "data": "b"
+          "type": "Identifier"
         },
         "catchBody": null,
-        "finallyBody": null
+        "column": 1,
+        "finallyBody": null,
+        "line": 1,
+        "range": [
+          0,
+          13
+        ],
+        "raw": "try a catch b",
+        "type": "Try"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    13
+  ],
+  "raw": "try a catch b",
+  "type": "Program"
 }

--- a/test/examples/try-with-catch-without-assignee/output.json
+++ b/test/examples/try-with-catch-without-assignee/output.json
@@ -1,61 +1,82 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 17 ],
-  "raw": "try\n  a\ncatch\n  b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
     "raw": "try\n  a\ncatch\n  b",
     "statements": [
       {
-        "type": "Try",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 17 ],
-        "raw": "try\n  a\ncatch\n  b",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 6, 7 ],
-          "raw": "a",
           "inline": false,
+          "line": 2,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 6, 7 ],
+              "data": "a",
+              "line": 2,
+              "range": [
+                6,
+                7
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
         "catchAssignee": null,
         "catchBody": {
-          "type": "Block",
-          "line": 4,
           "column": 3,
-          "range": [ 16, 17 ],
-          "raw": "b",
           "inline": false,
+          "line": 4,
+          "range": [
+            16,
+            17
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 4,
               "column": 3,
-              "range": [ 16, 17 ],
+              "data": "b",
+              "line": 4,
+              "range": [
+                16,
+                17
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "finallyBody": null
+        "column": 1,
+        "finallyBody": null,
+        "line": 1,
+        "range": [
+          0,
+          17
+        ],
+        "raw": "try\n  a\ncatch\n  b",
+        "type": "Try"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "try\n  a\ncatch\n  b",
+  "type": "Program"
 }

--- a/test/examples/try-without-catch-or-finally/output.json
+++ b/test/examples/try-without-catch-or-finally/output.json
@@ -1,44 +1,59 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 7 ],
-  "raw": "try\n  a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 7 ],
+    "line": 1,
+    "range": [
+      0,
+      7
+    ],
     "raw": "try\n  a",
     "statements": [
       {
-        "type": "Try",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 7 ],
-        "raw": "try\n  a",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 6, 7 ],
-          "raw": "a",
           "inline": false,
+          "line": 2,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 6, 7 ],
+              "data": "a",
+              "line": 2,
+              "range": [
+                6,
+                7
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
         "catchAssignee": null,
         "catchBody": null,
-        "finallyBody": null
+        "column": 1,
+        "finallyBody": null,
+        "line": 1,
+        "range": [
+          0,
+          7
+        ],
+        "raw": "try\n  a",
+        "type": "Try"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    7
+  ],
+  "raw": "try\n  a",
+  "type": "Program"
 }

--- a/test/examples/try-without-catch-single-line/output.json
+++ b/test/examples/try-without-catch-single-line/output.json
@@ -1,44 +1,59 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 5 ],
-  "raw": "try a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 5 ],
+    "line": 1,
+    "range": [
+      0,
+      5
+    ],
     "raw": "try a",
     "statements": [
       {
-        "type": "Try",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 5 ],
-        "raw": "try a",
         "body": {
-          "type": "Block",
-          "line": 1,
           "column": 5,
-          "range": [ 4, 5 ],
-          "raw": "a",
           "inline": true,
+          "line": 1,
+          "range": [
+            4,
+            5
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 5,
-              "range": [ 4, 5 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                4,
+                5
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
         "catchAssignee": null,
         "catchBody": null,
-        "finallyBody": null
+        "column": 1,
+        "finallyBody": null,
+        "line": 1,
+        "range": [
+          0,
+          5
+        ],
+        "raw": "try a",
+        "type": "Try"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    5
+  ],
+  "raw": "try a",
+  "type": "Program"
 }

--- a/test/examples/try-without-catch-with-finally/output.json
+++ b/test/examples/try-without-catch-with-finally/output.json
@@ -1,61 +1,82 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 19 ],
-  "raw": "try\n  a\nfinally\n  b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 19 ],
+    "line": 1,
+    "range": [
+      0,
+      19
+    ],
     "raw": "try\n  a\nfinally\n  b",
     "statements": [
       {
-        "type": "Try",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 19 ],
-        "raw": "try\n  a\nfinally\n  b",
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 6, 7 ],
-          "raw": "a",
           "inline": false,
+          "line": 2,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 6, 7 ],
+              "data": "a",
+              "line": 2,
+              "range": [
+                6,
+                7
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
         "catchAssignee": null,
         "catchBody": null,
+        "column": 1,
         "finallyBody": {
-          "type": "Block",
-          "line": 4,
           "column": 3,
-          "range": [ 18, 19 ],
-          "raw": "b",
           "inline": false,
+          "line": 4,
+          "range": [
+            18,
+            19
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 4,
               "column": 3,
-              "range": [ 18, 19 ],
+              "data": "b",
+              "line": 4,
+              "range": [
+                18,
+                19
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
-        }
+          ],
+          "type": "Block"
+        },
+        "line": 1,
+        "range": [
+          0,
+          19
+        ],
+        "raw": "try\n  a\nfinally\n  b",
+        "type": "Try"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    19
+  ],
+  "raw": "try\n  a\nfinally\n  b",
+  "type": "Program"
 }

--- a/test/examples/typeof/output.json
+++ b/test/examples/typeof/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 8 ],
-  "raw": "typeof a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 8 ],
+    "line": 1,
+    "range": [
+      0,
+      8
+    ],
     "raw": "typeof a",
     "statements": [
       {
-        "type": "TypeofOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 8 ],
-        "raw": "typeof a",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 8 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            7,
+            8
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          8
+        ],
+        "raw": "typeof a",
+        "type": "TypeofOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    8
+  ],
+  "raw": "typeof a",
+  "type": "Program"
 }

--- a/test/examples/unary-bitwise-negation/output.json
+++ b/test/examples/unary-bitwise-negation/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 2 ],
-  "raw": "~a",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "~a",
     "statements": [
       {
-        "type": "BitNotOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 2 ],
-        "raw": "~a",
         "expression": {
-          "type": "Identifier",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 2 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            1,
+            2
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "line": 1,
+        "range": [
+          0,
+          2
+        ],
+        "raw": "~a",
+        "type": "BitNotOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "~a",
+  "type": "Program"
 }

--- a/test/examples/unary-minus/output.json
+++ b/test/examples/unary-minus/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 2 ],
-  "raw": "-1",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "-1",
     "statements": [
       {
-        "type": "UnaryNegateOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 2 ],
-        "raw": "-1",
         "expression": {
-          "type": "Int",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 2 ],
+          "data": 1,
+          "line": 1,
+          "range": [
+            1,
+            2
+          ],
           "raw": "1",
-          "data": 1
-        }
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          2
+        ],
+        "raw": "-1",
+        "type": "UnaryNegateOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "-1",
+  "type": "Program"
 }

--- a/test/examples/unary-plus/output.json
+++ b/test/examples/unary-plus/output.json
@@ -1,31 +1,43 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 2 ],
-  "raw": "+1",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 2 ],
+    "line": 1,
+    "range": [
+      0,
+      2
+    ],
     "raw": "+1",
     "statements": [
       {
-        "type": "UnaryPlusOp",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 2 ],
-        "raw": "+1",
         "expression": {
-          "type": "Int",
-          "line": 1,
           "column": 2,
-          "range": [ 1, 2 ],
+          "data": 1,
+          "line": 1,
+          "range": [
+            1,
+            2
+          ],
           "raw": "1",
-          "data": 1
-        }
+          "type": "Int"
+        },
+        "line": 1,
+        "range": [
+          0,
+          2
+        ],
+        "raw": "+1",
+        "type": "UnaryPlusOp"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    2
+  ],
+  "raw": "+1",
+  "type": "Program"
 }

--- a/test/examples/undefined/output.json
+++ b/test/examples/undefined/output.json
@@ -1,23 +1,32 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "undefined",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "undefined",
     "statements": [
       {
-        "type": "Undefined",
-        "line": 1,
         "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "undefined"
+        "line": 1,
+        "range": [
+          0,
+          9
+        ],
+        "raw": "undefined",
+        "type": "Undefined"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "undefined",
+  "type": "Program"
 }

--- a/test/examples/unless-in/output.json
+++ b/test/examples/unless-in/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 18 ],
-  "raw": "unless a in b\n  c\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 17 ],
+    "line": 1,
+    "range": [
+      0,
+      17
+    ],
+    "raw": "unless a in b\n  c",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
+        "alternate": null,
         "column": 1,
-        "range": [ 0, 17 ],
-        "isUnless": true,
         "condition": {
-          "type": "InOp",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 13 ],
-          "left": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 8,
-            "range": [ 7, 8 ],
-            "data": "a",
-            "raw": "a"
-          },
-          "right": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 13,
-            "range": [ 12, 13 ],
-            "data": "b",
-            "raw": "b"
-          },
           "isNot": false,
-          "raw": "a in b"
+          "left": {
+            "column": 8,
+            "data": "a",
+            "line": 1,
+            "range": [
+              7,
+              8
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            7,
+            13
+          ],
+          "raw": "a in b",
+          "right": {
+            "column": 13,
+            "data": "b",
+            "line": 1,
+            "range": [
+              12,
+              13
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          },
+          "type": "InOp"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 16, 17 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 2,
-              "column": 3,
-              "range": [ 16, 17 ],
-              "data": "c",
-              "raw": "c"
-            }
+          "inline": false,
+          "line": 2,
+          "range": [
+            16,
+            17
           ],
           "raw": "c",
-          "inline": false
+          "statements": [
+            {
+              "column": 3,
+              "data": "c",
+              "line": 2,
+              "range": [
+                16,
+                17
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
         },
-        "alternate": null,
-        "raw": "unless a in b\n  c"
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          17
+        ],
+        "raw": "unless a in b\n  c",
+        "type": "Conditional"
       }
     ],
-    "raw": "unless a in b\n  c"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    18
+  ],
+  "raw": "unless a in b\n  c\n",
+  "type": "Program"
 }

--- a/test/examples/unless-not-in/output.json
+++ b/test/examples/unless-not-in/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 22 ],
-  "raw": "unless a not in b\n  c\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 21 ],
+    "line": 1,
+    "range": [
+      0,
+      21
+    ],
+    "raw": "unless a not in b\n  c",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
+        "alternate": null,
         "column": 1,
-        "range": [ 0, 21 ],
-        "isUnless": true,
         "condition": {
-          "type": "InOp",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 17 ],
-          "left": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 8,
-            "range": [ 7, 8 ],
-            "data": "a",
-            "raw": "a"
-          },
-          "right": {
-            "type": "Identifier",
-            "line": 1,
-            "column": 17,
-            "range": [ 16, 17 ],
-            "data": "b",
-            "raw": "b"
-          },
           "isNot": true,
-          "raw": "a not in b"
+          "left": {
+            "column": 8,
+            "data": "a",
+            "line": 1,
+            "range": [
+              7,
+              8
+            ],
+            "raw": "a",
+            "type": "Identifier"
+          },
+          "line": 1,
+          "range": [
+            7,
+            17
+          ],
+          "raw": "a not in b",
+          "right": {
+            "column": 17,
+            "data": "b",
+            "line": 1,
+            "range": [
+              16,
+              17
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          },
+          "type": "InOp"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 20, 21 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 2,
-              "column": 3,
-              "range": [ 20, 21 ],
-              "data": "c",
-              "raw": "c"
-            }
+          "inline": false,
+          "line": 2,
+          "range": [
+            20,
+            21
           ],
           "raw": "c",
-          "inline": false
+          "statements": [
+            {
+              "column": 3,
+              "data": "c",
+              "line": 2,
+              "range": [
+                20,
+                21
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
         },
-        "alternate": null,
-        "raw": "unless a not in b\n  c"
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          21
+        ],
+        "raw": "unless a not in b\n  c",
+        "type": "Conditional"
       }
     ],
-    "raw": "unless a not in b\n  c"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    22
+  ],
+  "raw": "unless a not in b\n  c\n",
+  "type": "Program"
 }

--- a/test/examples/unless-not-instanceof/output.json
+++ b/test/examples/unless-not-instanceof/output.json
@@ -1,67 +1,91 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 30 ],
-  "raw": "unless a not instanceof b\n  c\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 29 ],
+    "line": 1,
+    "range": [
+      0,
+      29
+    ],
+    "raw": "unless a not instanceof b\n  c",
     "statements": [
       {
-        "type": "Conditional",
-        "line": 1,
+        "alternate": null,
         "column": 1,
-        "range": [ 0, 29 ],
-        "isUnless": true,
         "condition": {
-          "type": "InstanceofOp",
-          "line": 1,
           "column": 8,
-          "range": [ 7, 25 ],
+          "isNot": true,
           "left": {
-            "type": "Identifier",
-            "line": 1,
             "column": 8,
-            "range": [ 7, 8 ],
             "data": "a",
-            "raw": "a"
-          },
-          "right": {
-            "type": "Identifier",
             "line": 1,
-            "column": 25,
-            "range": [ 24, 25 ],
-            "data": "b",
-            "raw": "b"
+            "range": [
+              7,
+              8
+            ],
+            "raw": "a",
+            "type": "Identifier"
           },
+          "line": 1,
+          "range": [
+            7,
+            25
+          ],
           "raw": "a not instanceof b",
-          "isNot": true
+          "right": {
+            "column": 25,
+            "data": "b",
+            "line": 1,
+            "range": [
+              24,
+              25
+            ],
+            "raw": "b",
+            "type": "Identifier"
+          },
+          "type": "InstanceofOp"
         },
         "consequent": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 28, 29 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 2,
-              "column": 3,
-              "range": [ 28, 29 ],
-              "data": "c",
-              "raw": "c"
-            }
+          "inline": false,
+          "line": 2,
+          "range": [
+            28,
+            29
           ],
           "raw": "c",
-          "inline": false
+          "statements": [
+            {
+              "column": 3,
+              "data": "c",
+              "line": 2,
+              "range": [
+                28,
+                29
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
         },
-        "alternate": null,
-        "raw": "unless a not instanceof b\n  c"
+        "isUnless": true,
+        "line": 1,
+        "range": [
+          0,
+          29
+        ],
+        "raw": "unless a not instanceof b\n  c",
+        "type": "Conditional"
       }
     ],
-    "raw": "unless a not instanceof b\n  c"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    30
+  ],
+  "raw": "unless a not instanceof b\n  c\n",
+  "type": "Program"
 }

--- a/test/examples/until/output.json
+++ b/test/examples/until/output.json
@@ -1,51 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 11 ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 11 ],
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
+    "raw": "until a\n  b",
     "statements": [
       {
-        "type": "While",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 11 ],
-        "isUntil": true,
-        "condition": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [ 6, 7 ],
-          "data": "a",
-          "raw": "a"
-        },
-        "guard": null,
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 10, 11 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 2,
-              "column": 3,
-              "range": [ 10, 11 ],
-              "data": "b",
-              "raw": "b"
-            }
+          "inline": false,
+          "line": 2,
+          "range": [
+            10,
+            11
           ],
           "raw": "b",
-          "inline": false
+          "statements": [
+            {
+              "column": 3,
+              "data": "b",
+              "line": 2,
+              "range": [
+                10,
+                11
+              ],
+              "raw": "b",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
         },
-        "raw": "until a\n  b"
+        "column": 1,
+        "condition": {
+          "column": 7,
+          "data": "a",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "guard": null,
+        "isUntil": true,
+        "line": 1,
+        "range": [
+          0,
+          11
+        ],
+        "raw": "until a\n  b",
+        "type": "While"
       }
     ],
-    "raw": "until a\n  b"
+    "type": "Block"
   },
-  "raw": "until a\n  b"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    11
+  ],
+  "raw": "until a\n  b",
+  "type": "Program"
 }

--- a/test/examples/while-on-multiple-lines/output.json
+++ b/test/examples/while-on-multiple-lines/output.json
@@ -1,51 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 11 ],
-  "raw": "while a\n  b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 11 ],
+    "line": 1,
+    "range": [
+      0,
+      11
+    ],
     "raw": "while a\n  b",
     "statements": [
       {
-        "type": "While",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 11 ],
-        "raw": "while a\n  b",
-        "isUntil": false,
-        "guard": null,
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 10, 11 ],
-          "raw": "b",
           "inline": false,
+          "line": 2,
+          "range": [
+            10,
+            11
+          ],
+          "raw": "b",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 2,
               "column": 3,
-              "range": [ 10, 11 ],
+              "data": "b",
+              "line": 2,
+              "range": [
+                10,
+                11
+              ],
               "raw": "b",
-              "data": "b"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 7,
-          "range": [ 6, 7 ],
+          "data": "a",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
           "raw": "a",
-          "data": "a"
-        }
+          "type": "Identifier"
+        },
+        "guard": null,
+        "isUntil": false,
+        "line": 1,
+        "range": [
+          0,
+          11
+        ],
+        "raw": "while a\n  b",
+        "type": "While"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    11
+  ],
+  "raw": "while a\n  b",
+  "type": "Program"
 }

--- a/test/examples/while-on-one-line/output.json
+++ b/test/examples/while-on-one-line/output.json
@@ -1,51 +1,69 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 9 ],
-  "raw": "a while b",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 9 ],
+    "line": 1,
+    "range": [
+      0,
+      9
+    ],
     "raw": "a while b",
     "statements": [
       {
-        "type": "While",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 9 ],
-        "raw": "a while b",
-        "isUntil": false,
-        "guard": null,
         "body": {
-          "type": "Block",
-          "line": 1,
           "column": 1,
-          "range": [ 0, 1 ],
-          "raw": "a",
           "inline": true,
+          "line": 1,
+          "range": [
+            0,
+            1
+          ],
+          "raw": "a",
           "statements": [
             {
-              "type": "Identifier",
-              "line": 1,
               "column": 1,
-              "range": [ 0, 1 ],
+              "data": "a",
+              "line": 1,
+              "range": [
+                0,
+                1
+              ],
               "raw": "a",
-              "data": "a"
+              "type": "Identifier"
             }
-          ]
+          ],
+          "type": "Block"
         },
+        "column": 1,
         "condition": {
-          "type": "Identifier",
-          "line": 1,
           "column": 9,
-          "range": [ 8, 9 ],
+          "data": "b",
+          "line": 1,
+          "range": [
+            8,
+            9
+          ],
           "raw": "b",
-          "data": "b"
-        }
+          "type": "Identifier"
+        },
+        "guard": null,
+        "isUntil": false,
+        "line": 1,
+        "range": [
+          0,
+          9
+        ],
+        "raw": "a while b",
+        "type": "While"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    9
+  ],
+  "raw": "a while b",
+  "type": "Program"
 }

--- a/test/examples/while-with-guard/output.json
+++ b/test/examples/while-with-guard/output.json
@@ -1,58 +1,79 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 18 ],
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 18 ],
+    "line": 1,
+    "range": [
+      0,
+      18
+    ],
+    "raw": "while a when b\n  c",
     "statements": [
       {
-        "type": "While",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 18 ],
-        "condition": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 7,
-          "range": [ 6, 7 ],
-          "data": "a",
-          "raw": "a"
-        },
-        "guard": {
-          "type": "Identifier",
-          "line": 1,
-          "column": 14,
-          "range": [ 13, 14 ],
-          "data": "b",
-          "raw": "b"
-        },
         "body": {
-          "type": "Block",
-          "line": 2,
           "column": 3,
-          "range": [ 17, 18 ],
-          "statements": [
-            {
-              "type": "Identifier",
-              "line": 2,
-              "column": 3,
-              "range": [ 17, 18 ],
-              "data": "c",
-              "raw": "c"
-            }
+          "inline": false,
+          "line": 2,
+          "range": [
+            17,
+            18
           ],
           "raw": "c",
-          "inline": false
+          "statements": [
+            {
+              "column": 3,
+              "data": "c",
+              "line": 2,
+              "range": [
+                17,
+                18
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            }
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "condition": {
+          "column": 7,
+          "data": "a",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "a",
+          "type": "Identifier"
+        },
+        "guard": {
+          "column": 14,
+          "data": "b",
+          "line": 1,
+          "range": [
+            13,
+            14
+          ],
+          "raw": "b",
+          "type": "Identifier"
         },
         "isUntil": false,
-        "raw": "while a when b\n  c"
+        "line": 1,
+        "range": [
+          0,
+          18
+        ],
+        "raw": "while a when b\n  c",
+        "type": "While"
       }
     ],
-    "raw": "while a when b\n  c"
+    "type": "Block"
   },
-  "raw": "while a when b\n  c"
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    18
+  ],
+  "raw": "while a when b\n  c",
+  "type": "Program"
 }

--- a/test/examples/yield-from/output.json
+++ b/test/examples/yield-from/output.json
@@ -1,78 +1,80 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      18
+    ],
+    "raw": "-> yield from fn()",
+    "statements": [
+      {
+        "body": {
+          "column": 4,
+          "inline": true,
+          "line": 1,
+          "range": [
+            3,
+            18
+          ],
+          "raw": "yield from fn()",
+          "statements": [
+            {
+              "column": 4,
+              "expression": {
+                "arguments": [
+                ],
+                "column": 15,
+                "function": {
+                  "column": 15,
+                  "data": "fn",
+                  "line": 1,
+                  "range": [
+                    14,
+                    16
+                  ],
+                  "raw": "fn",
+                  "type": "Identifier"
+                },
+                "line": 1,
+                "range": [
+                  14,
+                  18
+                ],
+                "raw": "fn()",
+                "type": "FunctionApplication"
+              },
+              "line": 1,
+              "range": [
+                3,
+                18
+              ],
+              "raw": "yield from fn()",
+              "type": "YieldFrom"
+            }
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          18
+        ],
+        "raw": "-> yield from fn()",
+        "type": "GeneratorFunction"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     18
   ],
   "raw": "-> yield from fn()",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      18
-    ],
-    "statements": [
-      {
-        "type": "GeneratorFunction",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          18
-        ],
-        "body": {
-          "type": "Block",
-          "line": 1,
-          "column": 4,
-          "range": [
-            3,
-            18
-          ],
-          "statements": [
-            {
-              "type": "YieldFrom",
-              "line": 1,
-              "column": 4,
-              "range": [
-                3,
-                18
-              ],
-              "expression": {
-                "type": "FunctionApplication",
-                "line": 1,
-                "column": 15,
-                "range": [
-                  14,
-                  18
-                ],
-                "function": {
-                  "type": "Identifier",
-                  "line": 1,
-                  "column": 15,
-                  "range": [
-                    14,
-                    16
-                  ],
-                  "data": "fn",
-                  "raw": "fn"
-                },
-                "arguments": [],
-                "raw": "fn()"
-              },
-              "raw": "yield from fn()"
-            }
-          ],
-          "raw": "yield from fn()",
-          "inline": true
-        },
-        "parameters": [],
-        "raw": "-> yield from fn()"
-      }
-    ],
-    "raw": "-> yield from fn()"
-  }
+  "type": "Program"
 }

--- a/test/examples/yield-return-empty/output.json
+++ b/test/examples/yield-return-empty/output.json
@@ -1,57 +1,58 @@
 {
-  "type": "Program",
-  "line": 1,
+  "body": {
+    "column": 1,
+    "line": 1,
+    "range": [
+      0,
+      15
+    ],
+    "raw": "-> yield return",
+    "statements": [
+      {
+        "body": {
+          "column": 4,
+          "inline": true,
+          "line": 1,
+          "range": [
+            3,
+            15
+          ],
+          "raw": "yield return",
+          "statements": [
+            {
+              "column": 4,
+              "expression": null,
+              "line": 1,
+              "range": [
+                3,
+                15
+              ],
+              "raw": "yield return",
+              "type": "YieldReturn"
+            }
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          15
+        ],
+        "raw": "-> yield return",
+        "type": "GeneratorFunction"
+      }
+    ],
+    "type": "Block"
+  },
   "column": 1,
+  "line": 1,
   "range": [
     0,
     16
   ],
   "raw": "-> yield return\n",
-  "body": {
-    "type": "Block",
-    "line": 1,
-    "column": 1,
-    "range": [
-      0,
-      15
-    ],
-    "statements": [
-      {
-        "type": "GeneratorFunction",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          15
-        ],
-        "body": {
-          "type": "Block",
-          "line": 1,
-          "column": 4,
-          "range": [
-            3,
-            15
-          ],
-          "statements": [
-            {
-              "type": "YieldReturn",
-              "line": 1,
-              "column": 4,
-              "range": [
-                3,
-                15
-              ],
-              "expression": null,
-              "raw": "yield return"
-            }
-          ],
-          "raw": "yield return",
-          "inline": true
-        },
-        "parameters": [],
-        "raw": "-> yield return"
-      }
-    ],
-    "raw": "-> yield return"
-  }
+  "type": "Program"
 }

--- a/test/examples/yield-return/output.json
+++ b/test/examples/yield-return/output.json
@@ -1,67 +1,68 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [
-    0,
-    18
-  ],
-  "raw": "-> yield return 3\n",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
+    "line": 1,
     "range": [
       0,
       17
     ],
+    "raw": "-> yield return 3",
     "statements": [
       {
-        "type": "GeneratorFunction",
-        "line": 1,
-        "column": 1,
-        "range": [
-          0,
-          17
-        ],
         "body": {
-          "type": "Block",
-          "line": 1,
           "column": 4,
+          "inline": true,
+          "line": 1,
           "range": [
             3,
             17
           ],
+          "raw": "yield return 3",
           "statements": [
             {
-              "type": "YieldReturn",
-              "line": 1,
               "column": 4,
-              "range": [
-                3,
-                17
-              ],
               "expression": {
-                "type": "Int",
-                "line": 1,
                 "column": 17,
+                "data": 3,
+                "line": 1,
                 "range": [
                   16,
                   17
                 ],
                 "raw": "3",
-                "data": 3
+                "type": "Int"
               },
-              "raw": "yield return 3"
+              "line": 1,
+              "range": [
+                3,
+                17
+              ],
+              "raw": "yield return 3",
+              "type": "YieldReturn"
             }
           ],
-          "raw": "yield return 3",
-          "inline": true
+          "type": "Block"
         },
-        "parameters": [],
-        "raw": "-> yield return 3"
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          17
+        ],
+        "raw": "-> yield return 3",
+        "type": "GeneratorFunction"
       }
     ],
-    "raw": "-> yield return 3"
-  }
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    18
+  ],
+  "raw": "-> yield return 3\n",
+  "type": "Program"
 }

--- a/test/examples/yield/output.json
+++ b/test/examples/yield/output.json
@@ -1,49 +1,68 @@
 {
-  "type": "Program",
-  "line": 1,
-  "column": 1,
-  "range": [ 0, 10 ],
-  "raw": "-> yield 1",
   "body": {
-    "type": "Block",
-    "line": 1,
     "column": 1,
-    "range": [ 0, 10 ],
+    "line": 1,
+    "range": [
+      0,
+      10
+    ],
     "raw": "-> yield 1",
     "statements": [
       {
-        "type": "GeneratorFunction",
-        "line": 1,
-        "column": 1,
-        "range": [ 0, 10 ],
-        "raw": "-> yield 1",
         "body": {
-          "type": "Block",
-          "line": 1,
           "column": 4,
-          "range": [ 3, 10 ],
-          "raw": "yield 1",
           "inline": true,
+          "line": 1,
+          "range": [
+            3,
+            10
+          ],
+          "raw": "yield 1",
           "statements": [
             {
-              "type": "Yield",
-              "line": 1,
               "column": 4,
-              "range": [ 3, 10 ],
-              "raw": "yield 1",
               "expression": {
-                "type": "Int",
-                "line": 1,
                 "column": 10,
-                "range": [ 9, 10 ],
+                "data": 1,
+                "line": 1,
+                "range": [
+                  9,
+                  10
+                ],
                 "raw": "1",
-                "data": 1
-              }
+                "type": "Int"
+              },
+              "line": 1,
+              "range": [
+                3,
+                10
+              ],
+              "raw": "yield 1",
+              "type": "Yield"
             }
-          ]
+          ],
+          "type": "Block"
         },
-        "parameters": []
+        "column": 1,
+        "line": 1,
+        "parameters": [
+        ],
+        "range": [
+          0,
+          10
+        ],
+        "raw": "-> yield 1",
+        "type": "GeneratorFunction"
       }
-    ]
-  }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    10
+  ],
+  "raw": "-> yield 1",
+  "type": "Program"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 import { deepEqual } from 'assert';
 import { join } from 'path';
+import stringify from 'json-stable-stringify';
 import { inspect } from 'util';
 import { parse } from '../src/parser';
 import { readFileSync, readdirSync, writeFileSync } from 'fs';
@@ -20,7 +21,10 @@ function runWithOptions(parseOptions: { useMappers?: boolean, useFallback?: bool
       testFn(config.description || entry, () => {
         let input = readFileSync(join(dir, 'input.coffee'), { encoding: 'utf8' });
         let actual = stripExtraInfo(parse(input, parseOptions));
-        writeFileSync(join(dir, '_actual.json'), JSON.stringify(actual, null, 2), { encoding: 'utf8' });
+        writeFileSync(join(dir, '_actual.json'), stringify(actual, {space: 2}), { encoding: 'utf8' });
+        if (process.env['OVERWRITE_EXPECTED_OUTPUT'] === 'true') {
+          writeFileSync(join(dir, 'output.json'), stringify(actual, {space: 2}), { encoding: 'utf8' });
+        }
         let expected = JSON.parse(readFileSync(join(dir, 'output.json'), { encoding: 'utf8' }));
         deepEqual(actual, expected);
       });


### PR DESCRIPTION
Rather than using JSON.stringify, which prints keys in iteration order (i.e.
insertion order), we now use the json-stable-stringify package, which is just
alphabetical. I also added an OVERWRITE_EXPECTED_OUTPUT env variable flag that
makes it easy to clobbber the expected output with the actual output, which I
also intend to use in an upcoming diff.

This should make it a lot easier to manually compare changes and to more safely
make large-scale changes.