### PR TITLE
fix: change top-level program creation to use mapBlock

### DIFF
--- a/src/mappers/mapAny.ts
+++ b/src/mappers/mapAny.ts
@@ -1,6 +1,7 @@
 import {
-  Arr, Assign, Base, Block, Bool, Call, Class, Code, Existence, Extends, For, If, In, Literal, Null, Obj, Op,
-  Param, Parens, Range, Return, Splat, Switch, Throw, Try, Undefined, Value, While
+  Arr, Assign, Base, Block, Bool, Call, Class, Code, Comment, Existence, Extends,
+  For, If, In, Literal, Null, Obj, Op, Param, Parens, Range, Return, Splat, Switch,
+  Throw, Try, Undefined, Value, While
 } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Node } from '../nodes';
 import ParseContext from '../util/ParseContext';
@@ -140,6 +141,11 @@ export default function mapAny(context: ParseContext, node: Base): Node {
 
   if (node instanceof Extends) {
     return mapExtends(context, node);
+  }
+
+  if (node instanceof Comment) {
+    throw new UnsupportedNodeError(
+      node, 'Expected comment notes to be filtered out by mapBlock rather than processed directly.');
   }
 
   throw new UnsupportedNodeError(node);

--- a/src/mappers/mapAnyWithFallback.ts
+++ b/src/mappers/mapAnyWithFallback.ts
@@ -7,8 +7,9 @@ import mapAny from './mapAny';
 export class UnsupportedNodeError extends Error {
   readonly node: Base;
 
-  constructor(node: Base) {
-    super(`node type '${node.constructor.name}' is not supported: ${inspect(node)}`);
+  constructor(node: Base, message: string | null = null) {
+    let prefix = message ? `${message}\n\n` : '';
+    super(`${prefix}node type '${node.constructor.name}' is not supported: ${inspect(node)}`);
 
     // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, UnsupportedNodeError.prototype);

--- a/src/mappers/mapBlock.ts
+++ b/src/mappers/mapBlock.ts
@@ -12,7 +12,7 @@ export default function mapBlock(context: ParseContext, node: CoffeeBlock): Bloc
   }
 
   let { line, column, start, end, raw } = mapBase(context, node);
-  let previousTokenIndex = context.sourceTokens.indexOfTokenNearSourceIndex(start - 1);
+  let previousTokenIndex = context.sourceTokens.indexOfTokenNearSourceIndex(start).previous();
   let previousToken = previousTokenIndex ? context.sourceTokens.tokenAtIndex(previousTokenIndex) : null;
   let inline = previousToken ? previousToken.type !== SourceType.NEWLINE : false;
 

--- a/src/mappers/mapFor.ts
+++ b/src/mappers/mapFor.ts
@@ -14,6 +14,10 @@ export default function mapFor(context: ParseContext, node: CoffeeFor): For {
   let target = mapAny(context, node.source);
   let filter = node.guard ? mapAny(context, node.guard) : null;
 
+  if (body.start < target.start) {
+    body = body.withInline(true);
+  }
+
   if (node.object) {
     let isOwn = node.own;
 

--- a/src/mappers/mapIf.ts
+++ b/src/mappers/mapIf.ts
@@ -19,6 +19,7 @@ export default function mapIf(context: ParseContext, node: If): Conditional {
   let right: SourceTokenListIndex | null = null;
 
   if (consequent.start < condition.start) {
+    consequent = consequent.withInline(true);
     // POST-if, so look for tokens between the consequent and the condition
     left = context.sourceTokens.indexOfTokenEndingAtSourceIndex(consequent.end);
     right = context.sourceTokens.indexOfTokenStartingAtSourceIndex(condition.start);

--- a/src/mappers/mapWhile.ts
+++ b/src/mappers/mapWhile.ts
@@ -1,6 +1,6 @@
 import { SourceType } from 'coffee-lex';
 import { While as CoffeeWhile } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
-import { Loop, While } from '../nodes';
+import { Block, Loop, While } from '../nodes';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
 import mapBase from './mapBase';
@@ -17,11 +17,17 @@ export default function mapWhile(context: ParseContext, node: CoffeeWhile): Whil
     );
   }
 
+  let condition = mapAny(context, node.condition);
+  let guard = node.guard ? mapAny(context, node.guard) : null;
+  let body = node.body ? mapAny(context, node.body) : null;
+
+  if (body instanceof Block && body.start < condition.start) {
+    body = body.withInline(true);
+  }
+
   return new While(
     line, column, start, end, raw,
-    mapAny(context, node.condition),
-    node.guard ? mapAny(context, node.guard) : null,
-    node.body ? mapAny(context, node.body) : null,
+    condition, guard, body,
     node.condition.inverted === true
   );
 }

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -279,6 +279,12 @@ export class Block extends Node {
   ) {
     super('Block', line, column, start, end, raw);
   }
+
+  withInline(inline: boolean): Block {
+    return new Block(
+      this.line, this.column, this.start, this.end, this.raw, this.statements, inline
+    );
+  }
 }
 
 export class Loop extends Node {

--- a/test/examples/addition/output.json
+++ b/test/examples/addition/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/array-with-multiple-members/output.json
+++ b/test/examples/array-with-multiple-members/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/array-with-single-member/output.json
+++ b/test/examples/array-with-single-member/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/assign/output.json
+++ b/test/examples/assign/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/backticks-with-string-inside/output.json
+++ b/test/examples/backticks-with-string-inside/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/bitshift-left/output.json
+++ b/test/examples/bitshift-left/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/bitshift-right-unsigned/output.json
+++ b/test/examples/bitshift-right-unsigned/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/bitshift-right/output.json
+++ b/test/examples/bitshift-right/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/bitwise-and/output.json
+++ b/test/examples/bitwise-and/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/bitwise-or/output.json
+++ b/test/examples/bitwise-or/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/bitwise-xor/output.json
+++ b/test/examples/bitwise-xor/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/block-comment-in-function/output.json
+++ b/test/examples/block-comment-in-function/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/block-comment/output.json
+++ b/test/examples/block-comment/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/bound-function-with-parameters/output.json
+++ b/test/examples/bound-function-with-parameters/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/bound-generator-function/output.json
+++ b/test/examples/bound-generator-function/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/break/output.json
+++ b/test/examples/break/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/call-dynamic-member-access-result/output.json
+++ b/test/examples/call-dynamic-member-access-result/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chain-calls-with-parens/output.json
+++ b/test/examples/chain-calls-with-parens/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chain-calls-without-indent/output.json
+++ b/test/examples/chain-calls-without-indent/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chain-calls-without-parens/output.json
+++ b/test/examples/chain-calls-without-parens/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-equals/output.json
+++ b/test/examples/chained-comparison-equals/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-extended/output.json
+++ b/test/examples/chained-comparison-extended/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-greater-than/output.json
+++ b/test/examples/chained-comparison-greater-than/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-less-than/output.json
+++ b/test/examples/chained-comparison-less-than/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-mixed/output.json
+++ b/test/examples/chained-comparison-mixed/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-nested/output.json
+++ b/test/examples/chained-comparison-nested/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-not-equal/output.json
+++ b/test/examples/chained-comparison-not-equal/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-three/output.json
+++ b/test/examples/chained-comparison-three/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-with-increment/output.json
+++ b/test/examples/chained-comparison-with-increment/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-with-other-operators/output.json
+++ b/test/examples/chained-comparison-with-other-operators/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-comparison-with-unary-negate/output.json
+++ b/test/examples/chained-comparison-with-unary-negate/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/chained-prototype-member-access/output.json
+++ b/test/examples/chained-prototype-member-access/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-extends/output.json
+++ b/test/examples/class-extends/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-member-with-block-comment/output.json
+++ b/test/examples/class-member-with-block-comment/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-super-call/output.json
+++ b/test/examples/class-super-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-with-body-statements/output.json
+++ b/test/examples/class-with-body-statements/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-with-bound-methods/output.json
+++ b/test/examples/class-with-bound-methods/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-with-constructor/output.json
+++ b/test/examples/class-with-constructor/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-with-members/output.json
+++ b/test/examples/class-with-members/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-with-parenthesized-value/output.json
+++ b/test/examples/class-with-parenthesized-value/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-with-proto-access-name/output.json
+++ b/test/examples/class-with-proto-access-name/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/class-with-static-members/output.json
+++ b/test/examples/class-with-static-members/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/complex-template-literal/output.json
+++ b/test/examples/complex-template-literal/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/compound-assignment-addition/output.json
+++ b/test/examples/compound-assignment-addition/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/compound-assignment-subtraction/output.json
+++ b/test/examples/compound-assignment-subtraction/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-empty-consequent-alternate/output.json
+++ b/test/examples/conditional-empty-consequent-alternate/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-on-one-line/output.json
+++ b/test/examples/conditional-on-one-line/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-unless-equal-condition/output.json
+++ b/test/examples/conditional-unless-equal-condition/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-unless-exists-op/output.json
+++ b/test/examples/conditional-unless-exists-op/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-unless-virtual-parens/output.json
+++ b/test/examples/conditional-unless-virtual-parens/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-using-unless/output.json
+++ b/test/examples/conditional-using-unless/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-with-alternate/output.json
+++ b/test/examples/conditional-with-alternate/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-with-braces-on-one-line/output.json
+++ b/test/examples/conditional-with-braces-on-one-line/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-with-post-if/output.json
+++ b/test/examples/conditional-with-post-if/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-with-post-unless/output.json
+++ b/test/examples/conditional-with-post-unless/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/conditional-without-alternate/output.json
+++ b/test/examples/conditional-without-alternate/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/continue/output.json
+++ b/test/examples/continue/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/dangling-prototype-access-of-call/output.json
+++ b/test/examples/dangling-prototype-access-of-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/dangling-prototype-access/output.json
+++ b/test/examples/dangling-prototype-access/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/delete/output.json
+++ b/test/examples/delete/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/division/output.json
+++ b/test/examples/division/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/do-expression/output.json
+++ b/test/examples/do-expression/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/do-with-assign-and-defaults/output.json
+++ b/test/examples/do-with-assign-and-defaults/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/do-with-assign-expression/output.json
+++ b/test/examples/do-with-assign-expression/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/do-with-bound-function/output.json
+++ b/test/examples/do-with-bound-function/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/do-with-default-parameters/output.json
+++ b/test/examples/do-with-default-parameters/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/do-with-defaults-with-same-name/output.json
+++ b/test/examples/do-with-defaults-with-same-name/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/do-with-simple-parameters/output.json
+++ b/test/examples/do-with-simple-parameters/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/do/output.json
+++ b/test/examples/do/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/double-negation/output.json
+++ b/test/examples/double-negation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/dynamic-member-expressions/output.json
+++ b/test/examples/dynamic-member-expressions/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-anonymous-class/output.json
+++ b/test/examples/empty-anonymous-class/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-array/output.json
+++ b/test/examples/empty-array/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-bound-function-without-body/output.json
+++ b/test/examples/empty-bound-function-without-body/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-class-with-superclass/output.json
+++ b/test/examples/empty-class-with-superclass/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-class/output.json
+++ b/test/examples/empty-class/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-function-without-parameters/output.json
+++ b/test/examples/empty-function-without-parameters/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-heregex-interpolation/output.json
+++ b/test/examples/empty-heregex-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-object/output.json
+++ b/test/examples/empty-object/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/empty-string-interpolation/output.json
+++ b/test/examples/empty-string-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/equality-longhand/output.json
+++ b/test/examples/equality-longhand/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/equality/output.json
+++ b/test/examples/equality/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/existential-binary/output.json
+++ b/test/examples/existential-binary/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/existential-unary/output.json
+++ b/test/examples/existential-unary/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/expansion/output.json
+++ b/test/examples/expansion/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/external-constructor/output.json
+++ b/test/examples/external-constructor/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/false/output.json
+++ b/test/examples/false/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/float-int-value/output.json
+++ b/test/examples/float-int-value/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/float-leading-period/output.json
+++ b/test/examples/float-leading-period/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/float/output.json
+++ b/test/examples/float/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/floor-division/output.json
+++ b/test/examples/floor-division/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-comprehension/output.json
+++ b/test/examples/for-comprehension/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-in-by/output.json
+++ b/test/examples/for-in-by/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-in-when/output.json
+++ b/test/examples/for-in-when/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-in-with-key-and-value-assignees/output.json
+++ b/test/examples/for-in-with-key-and-value-assignees/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-in/output.json
+++ b/test/examples/for-in/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-of-expression/output.json
+++ b/test/examples/for-of-expression/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-of-when/output.json
+++ b/test/examples/for-of-when/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-of-with-key-and-value-assignees/output.json
+++ b/test/examples/for-of-with-key-and-value-assignees/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-of/output.json
+++ b/test/examples/for-of/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-own-of/output.json
+++ b/test/examples/for-own-of/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/for-repeater/output.json
+++ b/test/examples/for-repeater/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/function-ending-in-block-comment/output.json
+++ b/test/examples/function-ending-in-block-comment/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/function-followed-by-block-comment/output.json
+++ b/test/examples/function-followed-by-block-comment/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/function-trailing-spaces/output.json
+++ b/test/examples/function-trailing-spaces/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/function-with-body/output.json
+++ b/test/examples/function-with-body/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/function-with-default-parameter/output.json
+++ b/test/examples/function-with-default-parameter/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/function-with-parameters/output.json
+++ b/test/examples/function-with-parameters/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/function-with-statement-after-block-and-comments/output.json
+++ b/test/examples/function-with-statement-after-block-and-comments/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/greater-than-equal/output.json
+++ b/test/examples/greater-than-equal/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/greater-than/output.json
+++ b/test/examples/greater-than/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/heregex-in-method-call/output.json
+++ b/test/examples/heregex-in-method-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/heregex-with-flags/output.json
+++ b/test/examples/heregex-with-flags/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/heregex-with-interpolations-and-flags/output.json
+++ b/test/examples/heregex-with-interpolations-and-flags/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/heregex-with-interpolations/output.json
+++ b/test/examples/heregex-with-interpolations/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/heregex-with-spaces-and-comments/output.json
+++ b/test/examples/heregex-with-spaces-and-comments/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/heregex-with-strange-whitespace/output.json
+++ b/test/examples/heregex-with-strange-whitespace/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 2,
     "range": [
       37,

--- a/test/examples/heregex/output.json
+++ b/test/examples/heregex/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/hexidecimal-number/output.json
+++ b/test/examples/hexidecimal-number/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/iife-in-function-call/output.json
+++ b/test/examples/iife-in-function-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/in-not/output.json
+++ b/test/examples/in-not/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/in/output.json
+++ b/test/examples/in/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/instanceof-not/output.json
+++ b/test/examples/instanceof-not/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/instanceof/output.json
+++ b/test/examples/instanceof/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/integer/output.json
+++ b/test/examples/integer/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/js/output.json
+++ b/test/examples/js/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/keyword-member-access/output.json
+++ b/test/examples/keyword-member-access/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/less-than-equal/output.json
+++ b/test/examples/less-than-equal/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/less-than/output.json
+++ b/test/examples/less-than/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/logical-and-longform/output.json
+++ b/test/examples/logical-and-longform/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/logical-and/output.json
+++ b/test/examples/logical-and/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/logical-or-longform/output.json
+++ b/test/examples/logical-or-longform/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/logical-or/output.json
+++ b/test/examples/logical-or/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/loop/output.json
+++ b/test/examples/loop/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/many-expressions-in-parens/output.json
+++ b/test/examples/many-expressions-in-parens/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/modulo/output.json
+++ b/test/examples/modulo/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/multiline-interpolated-string-with-escaped-newline/output.json
+++ b/test/examples/multiline-interpolated-string-with-escaped-newline/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/multiline-string-with-interpolations-and-quotes/output.json
+++ b/test/examples/multiline-string-with-interpolations-and-quotes/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/multiline-string-with-quoted-interpolations-and-non-interpolations/output.json
+++ b/test/examples/multiline-string-with-quoted-interpolations-and-non-interpolations/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/multiple-expressions-in-parens/output.json
+++ b/test/examples/multiple-expressions-in-parens/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/multiplication/output.json
+++ b/test/examples/multiplication/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/negated-equality-longhand/output.json
+++ b/test/examples/negated-equality-longhand/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/negated-equality/output.json
+++ b/test/examples/negated-equality/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/negation-with-not/output.json
+++ b/test/examples/negation-with-not/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/negation/output.json
+++ b/test/examples/negation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/nested-code-with-outdent/output.json
+++ b/test/examples/nested-code-with-outdent/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/nested-conditionals/output.json
+++ b/test/examples/nested-conditionals/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/nested-member-expressions/output.json
+++ b/test/examples/nested-member-expressions/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/nested-object-literals/output.json
+++ b/test/examples/nested-object-literals/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/nested-string-interpolation/output.json
+++ b/test/examples/nested-string-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/new-with-method-call/output.json
+++ b/test/examples/new-with-method-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/new-without-parens/output.json
+++ b/test/examples/new-without-parens/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/new/output.json
+++ b/test/examples/new/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/null/output.json
+++ b/test/examples/null/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/object-destructure-with-default/output.json
+++ b/test/examples/object-destructure-with-default/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/object-with-block-comments/output.json
+++ b/test/examples/object-with-block-comments/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/object-with-braces/output.json
+++ b/test/examples/object-with-braces/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/object-with-combined-key-value/output.json
+++ b/test/examples/object-with-combined-key-value/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/object-with-multiple-properties/output.json
+++ b/test/examples/object-with-multiple-properties/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/object-with-parenthesized-value/output.json
+++ b/test/examples/object-with-parenthesized-value/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/object-without-braces/output.json
+++ b/test/examples/object-without-braces/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/octal-number/output.json
+++ b/test/examples/octal-number/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/of-not/output.json
+++ b/test/examples/of-not/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/of/output.json
+++ b/test/examples/of/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/only-empty-string-interpolation/output.json
+++ b/test/examples/only-empty-string-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/parentheses/output.json
+++ b/test/examples/parentheses/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/parenthesized-member-access/output.json
+++ b/test/examples/parenthesized-member-access/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/post-decrement/output.json
+++ b/test/examples/post-decrement/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/post-for/output.json
+++ b/test/examples/post-for/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/post-increment/output.json
+++ b/test/examples/post-increment/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/post-unless-not-if/output.json
+++ b/test/examples/post-unless-not-if/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/post-while-with-loop/output.json
+++ b/test/examples/post-while-with-loop/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/pow/output.json
+++ b/test/examples/pow/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/pre-decrement/output.json
+++ b/test/examples/pre-decrement/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/pre-increment/output.json
+++ b/test/examples/pre-increment/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/prototype-member-access/output.json
+++ b/test/examples/prototype-member-access/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/range-exclusive/output.json
+++ b/test/examples/range-exclusive/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/range-inclusive/output.json
+++ b/test/examples/range-inclusive/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/regexp/output.json
+++ b/test/examples/regexp/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/remainder/output.json
+++ b/test/examples/remainder/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/rest-param-in-bound-function/output.json
+++ b/test/examples/rest-param-in-bound-function/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/rest-param-in-function/output.json
+++ b/test/examples/rest-param-in-function/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/return-with-expression/output.json
+++ b/test/examples/return-with-expression/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/return-without-expression/output.json
+++ b/test/examples/return-without-expression/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/shorthand-this-member-expression-with-dot/output.json
+++ b/test/examples/shorthand-this-member-expression-with-dot/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/shorthand-this-member-expression/output.json
+++ b/test/examples/shorthand-this-member-expression/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/shorthand-this/output.json
+++ b/test/examples/shorthand-this/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/simple-call/output.json
+++ b/test/examples/simple-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/simple-member-expression/output.json
+++ b/test/examples/simple-member-expression/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/slice-with-lower-and-upper-bounds/output.json
+++ b/test/examples/slice-with-lower-and-upper-bounds/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/slice-with-no-bounds/output.json
+++ b/test/examples/slice-with-no-bounds/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/soaked-dynamic-member-access/output.json
+++ b/test/examples/soaked-dynamic-member-access/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/soaked-function-call/output.json
+++ b/test/examples/soaked-function-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/soaked-member-access/output.json
+++ b/test/examples/soaked-member-access/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/soaked-method-call/output.json
+++ b/test/examples/soaked-method-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/soaked-new/output.json
+++ b/test/examples/soaked-new/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/soaked-prototype-access/output.json
+++ b/test/examples/soaked-prototype-access/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/soaked-slice/output.json
+++ b/test/examples/soaked-slice/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/soaked-splice/output.json
+++ b/test/examples/soaked-splice/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/splat-in-array-with-other-members/output.json
+++ b/test/examples/splat-in-array-with-other-members/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/splat-in-array/output.json
+++ b/test/examples/splat-in-array/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/splat-in-function-call-with-other-args/output.json
+++ b/test/examples/splat-in-function-call-with-other-args/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/splat-in-function-call/output.json
+++ b/test/examples/splat-in-function-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/splat-in-new-call/output.json
+++ b/test/examples/splat-in-new-call/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-ending-with-interpolation/output.json
+++ b/test/examples/string-ending-with-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-interpolation-in-object-literal/output.json
+++ b/test/examples/string-interpolation-in-object-literal/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-interpolation-plus-normal-string/output.json
+++ b/test/examples/string-interpolation-plus-normal-string/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-interpolation-preceded-by-parenthesis/output.json
+++ b/test/examples/string-interpolation-preceded-by-parenthesis/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 2,
     "range": [
       58,

--- a/test/examples/string-interpolation-with-escaped-newline/output.json
+++ b/test/examples/string-interpolation-with-escaped-newline/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-interpolation-with-plus/output.json
+++ b/test/examples/string-interpolation-with-plus/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-starting-with-interpolation/output.json
+++ b/test/examples/string-starting-with-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-double-quotes/output.json
+++ b/test/examples/string-with-double-quotes/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-interpolation/output.json
+++ b/test/examples/string-with-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-interpolations-at-start-and-end/output.json
+++ b/test/examples/string-with-interpolations-at-start-and-end/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-noop-escape/output.json
+++ b/test/examples/string-with-noop-escape/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-only-multiple-interpolations/output.json
+++ b/test/examples/string-with-only-multiple-interpolations/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-only-single-interpolation/output.json
+++ b/test/examples/string-with-only-single-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-parentheses-inside/output.json
+++ b/test/examples/string-with-parentheses-inside/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-single-quotes/output.json
+++ b/test/examples/string-with-single-quotes/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-triple-double-quotes/output.json
+++ b/test/examples/string-with-triple-double-quotes/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-triple-quote-interpolation-containing-quotes/output.json
+++ b/test/examples/string-with-triple-quote-interpolation-containing-quotes/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-triple-quote-interpolation/output.json
+++ b/test/examples/string-with-triple-quote-interpolation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/string-with-triple-single-quotes/output.json
+++ b/test/examples/string-with-triple-single-quotes/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/subtraction/output.json
+++ b/test/examples/subtraction/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/switch-with-alternate/output.json
+++ b/test/examples/switch-with-alternate/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/switch-with-multiple-cases/output.json
+++ b/test/examples/switch-with-multiple-cases/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/switch-with-multiple-conditions/output.json
+++ b/test/examples/switch-with-multiple-conditions/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/switch-with-one-case/output.json
+++ b/test/examples/switch-with-one-case/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/this-assign-with-keyword/output.json
+++ b/test/examples/this-assign-with-keyword/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/throw/output.json
+++ b/test/examples/throw/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/true/output.json
+++ b/test/examples/true/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/try-with-catch-and-finally/output.json
+++ b/test/examples/try-with-catch-and-finally/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/try-with-catch-assignee/output.json
+++ b/test/examples/try-with-catch-assignee/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/try-with-catch-single-line/output.json
+++ b/test/examples/try-with-catch-single-line/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/try-with-catch-without-assignee/output.json
+++ b/test/examples/try-with-catch-without-assignee/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/try-without-catch-or-finally/output.json
+++ b/test/examples/try-without-catch-or-finally/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/try-without-catch-single-line/output.json
+++ b/test/examples/try-without-catch-single-line/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/try-without-catch-with-finally/output.json
+++ b/test/examples/try-without-catch-with-finally/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/typeof/output.json
+++ b/test/examples/typeof/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/unary-bitwise-negation/output.json
+++ b/test/examples/unary-bitwise-negation/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/unary-minus/output.json
+++ b/test/examples/unary-minus/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/unary-plus/output.json
+++ b/test/examples/unary-plus/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/undefined/output.json
+++ b/test/examples/undefined/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/unless-in/output.json
+++ b/test/examples/unless-in/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/unless-not-in/output.json
+++ b/test/examples/unless-not-in/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/unless-not-instanceof/output.json
+++ b/test/examples/unless-not-instanceof/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/until/output.json
+++ b/test/examples/until/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/while-on-multiple-lines/output.json
+++ b/test/examples/while-on-multiple-lines/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/while-on-one-line/output.json
+++ b/test/examples/while-on-one-line/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/while-with-guard/output.json
+++ b/test/examples/while-with-guard/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/yield-from/output.json
+++ b/test/examples/yield-from/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/yield-return-empty/output.json
+++ b/test/examples/yield-return-empty/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/yield-return/output.json
+++ b/test/examples/yield-return/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,

--- a/test/examples/yield/output.json
+++ b/test/examples/yield/output.json
@@ -1,6 +1,7 @@
 {
   "body": {
     "column": 1,
+    "inline": false,
     "line": 1,
     "range": [
       0,


### PR DESCRIPTION
This fixes an issue where top-level comments weren't being filtered out
correctly.

Also fix some issues exposed by this change when computing the "inline" status
of a block. The mapper side needs to set post-if consequents as inline, and we
should not treat the block as inline if it's at the very start of the program.
Also fix post-for and post-while bodies to be inline, which was only happening
by accident before.