### PR TITLE
feat: disable the fallback code by default

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -24,7 +24,7 @@ import { patchCoffeeScript } from './ext/coffee-script';
 import type { Base } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import type { Node, Program } from './nodes';
 
-export function parse(source: string, { useFallback = true, useMappers = true } = {}): Program {
+export function parse(source: string, { useFallback = false, useMappers = true } = {}): Program {
   patchCoffeeScript();
 
   let context = ParseContext.fromSource(source, lex, CoffeeScript.nodes);


### PR DESCRIPTION
Everything seems to be working on the decaffeinate test suite and my codebase,
so seems like it's safe to release and try out on all example projects.

I'm still leaving all other code in place for now so that it's easy to switch
back if necessary.