### PR TITLE
fix: properly traverse nested blocks within class bodies

### DIFF
--- a/src/mappers/mapClass.ts
+++ b/src/mappers/mapClass.ts
@@ -1,76 +1,22 @@
-import { Assign, Class as CoffeeClass, Comment, Obj, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
-import { inspect } from 'util';
-import {
-  AssignOp, Block, BoundFunction, BoundGeneratorFunction, Class, ClassProtoAssignOp, Constructor,
-  Identifier, MemberAccessOp, Node, This
-} from '../nodes';
+import { Class as CoffeeClass } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Class } from '../nodes';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
 import mapBase from './mapBase';
+import mapPossiblyEmptyBlock from './mapPossiblyEmptyBlock';
 
 export default function mapClass(context: ParseContext, node: CoffeeClass): Class {
   let { line, column, start, end, raw } = mapBase(context, node);
 
-  let body: Block | null = null;
-  let ctor: Constructor | null = null;
-  let boundMethods: Array<ClassProtoAssignOp> = [];
-
-  if (node.body && node.body.expressions.length > 0) {
-    let statements: Array<Node> = [];
-
-    for (let expression of node.body.expressions) {
-      if (expression instanceof Value && expression.base instanceof Obj) {
-        for (let property of expression.base.properties) {
-          if (property instanceof Comment) {
-            continue;
-          } else if (property instanceof Assign) {
-            let { line, column, start, end, raw } = mapBase(context, property);
-            let key = mapAny(context, property.variable);
-            let value = mapAny(context, property.value);
-            let Node = ClassProtoAssignOp;
-
-            if (key instanceof Identifier && key.data === 'constructor') {
-              Node = Constructor;
-            } else if (key instanceof MemberAccessOp && key.expression instanceof This) {
-              Node = AssignOp;
-            }
-
-            let assignment = new Node(
-              line, column, start, end, raw,
-              key,
-              value
-            );
-
-            statements.push(assignment);
-
-            if (assignment instanceof ClassProtoAssignOp && (assignment.expression instanceof BoundFunction || assignment.expression instanceof BoundGeneratorFunction)) {
-              boundMethods.push(assignment);
-            }
-
-            if (assignment instanceof Constructor) {
-              ctor = assignment;
-            }
-          } else {
-            throw new Error(`unexpected class assignment: ${inspect(property)}`);
-          }
-        }
-      } else {
-        statements.push(mapAny(context, expression));
-      }
-    }
-
-    if (statements.length > 0) {
-      let { line, column, start, end, raw } = mapBase(context, node.body);
-      body = new Block(
-        line, column, start, end, raw,
-        statements,
-        false
-      );
-    }
-  }
-
   let nameAssignee = node.variable ? mapAny(context, node.variable) : null;
   let parent = node.parent ? mapAny(context, node.parent) : null;
+
+  let childContext = context.updateState(s => s.pushCurrentClass());
+  let body = mapPossiblyEmptyBlock(childContext, node.body);
+  let boundMethods = childContext.parseState.currentClassBoundMethods;
+  if (!boundMethods) {
+    throw new Error('Expected a non-null bound method name array.');
+  }
 
   return new Class(
     line, column, start, end, raw,
@@ -79,6 +25,6 @@ export default function mapClass(context: ParseContext, node: CoffeeClass): Clas
     body,
     boundMethods,
     parent,
-    ctor
+    childContext.parseState.currentClassCtor
   );
 }

--- a/src/mappers/mapCode.ts
+++ b/src/mappers/mapCode.ts
@@ -10,10 +10,12 @@ export default function mapCode(context: ParseContext, node: Code): BaseFunction
 
   let Node = getNodeTypeForCode(node);
 
+  let childContext = context.updateState(s => s.dropCurrentClass());
+
   return new Node(
     line, column, start, end, raw,
-    node.params.map(param => mapAny(context, param)),
-    mapPossiblyEmptyBlock(context, node.body)
+    node.params.map(param => mapAny(childContext, param)),
+    mapPossiblyEmptyBlock(childContext, node.body)
   );
 }
 

--- a/src/util/ParseContext.ts
+++ b/src/util/ParseContext.ts
@@ -1,7 +1,7 @@
 import SourceTokenList from 'coffee-lex/dist/SourceTokenList';
 import { Base, Block, LocationData } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import LinesAndColumns from 'lines-and-columns';
-import { RealNode } from '../nodes';
+import { ClassProtoAssignOp, Constructor, RealNode } from '../nodes';
 
 class ParseError extends Error {
   syntaxError: SyntaxError;
@@ -12,17 +12,52 @@ class ParseError extends Error {
   }
 }
 
-export default class ParseContext {
-  source: string;
-  linesAndColumns: LinesAndColumns;
-  ast: Block;
-  sourceTokens: SourceTokenList;
+/**
+ * Any information we need to know about the current state of parsing. While the
+ * hope is that this is mostly immutable, with replace operations as we walk the
+ * AST, it is partially mutable to collect bound method names in a class.
+ */
+export class ParseState {
+  currentClassCtor: Constructor | null;
+  constructor(readonly currentClassBoundMethods: Array<ClassProtoAssignOp> | null) {
+    this.currentClassCtor = null;
+  }
 
-  constructor(source: string, sourceTokens: SourceTokenList, ast: Block) {
-    this.source = source;
-    this.linesAndColumns = new LinesAndColumns(source);
-    this.ast = ast;
-    this.sourceTokens = sourceTokens;
+  isInClassBody() {
+    return this.currentClassBoundMethods !== null;
+  }
+
+  recordBoundMethod(method: ClassProtoAssignOp) {
+    if (!this.currentClassBoundMethods) {
+      throw new Error('Cannot assign a bound method name when there is no current class.');
+    }
+    this.currentClassBoundMethods.push(method);
+  }
+
+  recordConstructor(ctor: Constructor) {
+    this.currentClassCtor = ctor;
+  }
+
+  pushCurrentClass() {
+    return new ParseState([]);
+  }
+
+  dropCurrentClass() {
+    return new ParseState(null);
+  }
+
+  static initialState(): ParseState {
+    return new ParseState(null);
+  }
+}
+
+export default class ParseContext {
+  constructor(
+    readonly source: string,
+    readonly linesAndColumns: LinesAndColumns,
+    readonly sourceTokens: SourceTokenList,
+    readonly ast: Block,
+    readonly parseState: ParseState) {
   }
 
   getRange(locatable: RealNode | Base | LocationData): [number, number] | null {
@@ -46,7 +81,13 @@ export default class ParseContext {
   static fromSource(source: string, sourceLex: (source: string) => SourceTokenList, parse: (source: string) => Block) {
     try {
       const sourceTokens = sourceLex(source);
-      return new ParseContext(source, sourceTokens, parse(source));
+      return new ParseContext(
+        source,
+        new LinesAndColumns(source),
+        sourceTokens,
+        parse(source),
+        ParseState.initialState()
+      );
     } catch (ex) {
       if (ex instanceof SyntaxError) {
         throw new ParseError(ex);
@@ -54,5 +95,12 @@ export default class ParseContext {
         throw ex;
       }
     }
+  }
+
+  updateState(updater: (oldState: ParseState) => ParseState): ParseContext {
+    return new ParseContext(
+      this.source, this.linesAndColumns, this.sourceTokens, this.ast,
+      updater(this.parseState)
+    );
   }
 }

--- a/test/examples/class-with-conditional-bound-method/input.coffee
+++ b/test/examples/class-with-conditional-bound-method/input.coffee
@@ -1,0 +1,3 @@
+class A
+  if b
+    c: => d

--- a/test/examples/class-with-conditional-bound-method/output.json
+++ b/test/examples/class-with-conditional-bound-method/output.json
@@ -1,0 +1,222 @@
+{
+  "body": {
+    "column": 1,
+    "inline": false,
+    "line": 1,
+    "range": [
+      0,
+      26
+    ],
+    "raw": "class A\n  if b\n    c: => d",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            10,
+            26
+          ],
+          "raw": "if b\n    c: => d",
+          "statements": [
+            {
+              "alternate": null,
+              "column": 3,
+              "condition": {
+                "column": 6,
+                "data": "b",
+                "line": 2,
+                "range": [
+                  13,
+                  14
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "consequent": {
+                "column": 5,
+                "inline": false,
+                "line": 3,
+                "range": [
+                  19,
+                  26
+                ],
+                "raw": "c: => d",
+                "statements": [
+                  {
+                    "assignee": {
+                      "column": 5,
+                      "data": "c",
+                      "line": 3,
+                      "range": [
+                        19,
+                        20
+                      ],
+                      "raw": "c",
+                      "type": "Identifier"
+                    },
+                    "column": 5,
+                    "expression": {
+                      "body": {
+                        "column": 11,
+                        "inline": true,
+                        "line": 3,
+                        "range": [
+                          25,
+                          26
+                        ],
+                        "raw": "d",
+                        "statements": [
+                          {
+                            "column": 11,
+                            "data": "d",
+                            "line": 3,
+                            "range": [
+                              25,
+                              26
+                            ],
+                            "raw": "d",
+                            "type": "Identifier"
+                          }
+                        ],
+                        "type": "Block"
+                      },
+                      "column": 8,
+                      "line": 3,
+                      "parameters": [
+                      ],
+                      "range": [
+                        22,
+                        26
+                      ],
+                      "raw": "=> d",
+                      "type": "BoundFunction"
+                    },
+                    "line": 3,
+                    "range": [
+                      19,
+                      26
+                    ],
+                    "raw": "c: => d",
+                    "type": "ClassProtoAssignOp"
+                  }
+                ],
+                "type": "Block"
+              },
+              "isUnless": false,
+              "line": 2,
+              "range": [
+                10,
+                26
+              ],
+              "raw": "if b\n    c: => d",
+              "type": "Conditional"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+          {
+            "assignee": {
+              "column": 5,
+              "data": "c",
+              "line": 3,
+              "range": [
+                19,
+                20
+              ],
+              "raw": "c",
+              "type": "Identifier"
+            },
+            "column": 5,
+            "expression": {
+              "body": {
+                "column": 11,
+                "inline": true,
+                "line": 3,
+                "range": [
+                  25,
+                  26
+                ],
+                "raw": "d",
+                "statements": [
+                  {
+                    "column": 11,
+                    "data": "d",
+                    "line": 3,
+                    "range": [
+                      25,
+                      26
+                    ],
+                    "raw": "d",
+                    "type": "Identifier"
+                  }
+                ],
+                "type": "Block"
+              },
+              "column": 8,
+              "line": 3,
+              "parameters": [
+              ],
+              "range": [
+                22,
+                26
+              ],
+              "raw": "=> d",
+              "type": "BoundFunction"
+            },
+            "line": 3,
+            "range": [
+              19,
+              26
+            ],
+            "raw": "c: => d",
+            "type": "ClassProtoAssignOp"
+          }
+        ],
+        "column": 1,
+        "ctor": null,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          26
+        ],
+        "raw": "class A\n  if b\n    c: => d",
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    27
+  ],
+  "raw": "class A\n  if b\n    c: => d\n",
+  "type": "Program"
+}

--- a/test/examples/class-with-conditional-method/input.coffee
+++ b/test/examples/class-with-conditional-method/input.coffee
@@ -1,0 +1,3 @@
+class A
+  if b
+    c: -> d

--- a/test/examples/class-with-conditional-method/output.json
+++ b/test/examples/class-with-conditional-method/output.json
@@ -1,0 +1,165 @@
+{
+  "body": {
+    "column": 1,
+    "inline": false,
+    "line": 1,
+    "range": [
+      0,
+      26
+    ],
+    "raw": "class A\n  if b\n    c: -> d",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            10,
+            26
+          ],
+          "raw": "if b\n    c: -> d",
+          "statements": [
+            {
+              "alternate": null,
+              "column": 3,
+              "condition": {
+                "column": 6,
+                "data": "b",
+                "line": 2,
+                "range": [
+                  13,
+                  14
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "consequent": {
+                "column": 5,
+                "inline": false,
+                "line": 3,
+                "range": [
+                  19,
+                  26
+                ],
+                "raw": "c: -> d",
+                "statements": [
+                  {
+                    "assignee": {
+                      "column": 5,
+                      "data": "c",
+                      "line": 3,
+                      "range": [
+                        19,
+                        20
+                      ],
+                      "raw": "c",
+                      "type": "Identifier"
+                    },
+                    "column": 5,
+                    "expression": {
+                      "body": {
+                        "column": 11,
+                        "inline": true,
+                        "line": 3,
+                        "range": [
+                          25,
+                          26
+                        ],
+                        "raw": "d",
+                        "statements": [
+                          {
+                            "column": 11,
+                            "data": "d",
+                            "line": 3,
+                            "range": [
+                              25,
+                              26
+                            ],
+                            "raw": "d",
+                            "type": "Identifier"
+                          }
+                        ],
+                        "type": "Block"
+                      },
+                      "column": 8,
+                      "line": 3,
+                      "parameters": [
+                      ],
+                      "range": [
+                        22,
+                        26
+                      ],
+                      "raw": "-> d",
+                      "type": "Function"
+                    },
+                    "line": 3,
+                    "range": [
+                      19,
+                      26
+                    ],
+                    "raw": "c: -> d",
+                    "type": "ClassProtoAssignOp"
+                  }
+                ],
+                "type": "Block"
+              },
+              "isUnless": false,
+              "line": 2,
+              "range": [
+                10,
+                26
+              ],
+              "raw": "if b\n    c: -> d",
+              "type": "Conditional"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": null,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          26
+        ],
+        "raw": "class A\n  if b\n    c: -> d",
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    27
+  ],
+  "raw": "class A\n  if b\n    c: -> d\n",
+  "type": "Program"
+}

--- a/test/examples/class-with-explicit-object-literal/input.coffee
+++ b/test/examples/class-with-explicit-object-literal/input.coffee
@@ -1,0 +1,2 @@
+class A
+  {b: c}

--- a/test/examples/class-with-explicit-object-literal/output.json
+++ b/test/examples/class-with-explicit-object-literal/output.json
@@ -1,0 +1,116 @@
+{
+  "body": {
+    "column": 1,
+    "inline": false,
+    "line": 1,
+    "range": [
+      0,
+      16
+    ],
+    "raw": "class A\n  {b: c}",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            10,
+            16
+          ],
+          "raw": "{b: c}",
+          "statements": [
+            {
+              "column": 3,
+              "line": 2,
+              "members": [
+                {
+                  "column": 4,
+                  "expression": {
+                    "column": 7,
+                    "data": "c",
+                    "line": 2,
+                    "range": [
+                      14,
+                      15
+                    ],
+                    "raw": "c",
+                    "type": "Identifier"
+                  },
+                  "key": {
+                    "column": 4,
+                    "data": "b",
+                    "line": 2,
+                    "range": [
+                      11,
+                      12
+                    ],
+                    "raw": "b",
+                    "type": "Identifier"
+                  },
+                  "line": 2,
+                  "range": [
+                    11,
+                    15
+                  ],
+                  "raw": "b: c",
+                  "type": "ObjectInitialiserMember"
+                }
+              ],
+              "range": [
+                10,
+                16
+              ],
+              "raw": "{b: c}",
+              "type": "ObjectInitialiser"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": null,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          16
+        ],
+        "raw": "class A\n  {b: c}",
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    17
+  ],
+  "raw": "class A\n  {b: c}\n",
+  "type": "Program"
+}

--- a/test/examples/class-with-implicit-object-literal-within-function/input.coffee
+++ b/test/examples/class-with-implicit-object-literal-within-function/input.coffee
@@ -1,0 +1,4 @@
+class A
+  b = ->
+    c: d
+    return 1

--- a/test/examples/class-with-implicit-object-literal-within-function/output.json
+++ b/test/examples/class-with-implicit-object-literal-within-function/output.json
@@ -1,0 +1,183 @@
+{
+  "body": {
+    "column": 1,
+    "inline": false,
+    "line": 1,
+    "range": [
+      0,
+      38
+    ],
+    "raw": "class A\n  b = ->\n    c: d\n    return 1",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            10,
+            38
+          ],
+          "raw": "b = ->\n    c: d\n    return 1",
+          "statements": [
+            {
+              "assignee": {
+                "column": 3,
+                "data": "b",
+                "line": 2,
+                "range": [
+                  10,
+                  11
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "column": 3,
+              "expression": {
+                "body": {
+                  "column": 5,
+                  "inline": false,
+                  "line": 3,
+                  "range": [
+                    21,
+                    38
+                  ],
+                  "raw": "c: d\n    return 1",
+                  "statements": [
+                    {
+                      "column": 5,
+                      "line": 3,
+                      "members": [
+                        {
+                          "column": 5,
+                          "expression": {
+                            "column": 8,
+                            "data": "d",
+                            "line": 3,
+                            "range": [
+                              24,
+                              25
+                            ],
+                            "raw": "d",
+                            "type": "Identifier"
+                          },
+                          "key": {
+                            "column": 5,
+                            "data": "c",
+                            "line": 3,
+                            "range": [
+                              21,
+                              22
+                            ],
+                            "raw": "c",
+                            "type": "Identifier"
+                          },
+                          "line": 3,
+                          "range": [
+                            21,
+                            25
+                          ],
+                          "raw": "c: d",
+                          "type": "ObjectInitialiserMember"
+                        }
+                      ],
+                      "range": [
+                        21,
+                        25
+                      ],
+                      "raw": "c: d",
+                      "type": "ObjectInitialiser"
+                    },
+                    {
+                      "column": 5,
+                      "expression": {
+                        "column": 12,
+                        "data": 1,
+                        "line": 4,
+                        "range": [
+                          37,
+                          38
+                        ],
+                        "raw": "1",
+                        "type": "Int"
+                      },
+                      "line": 4,
+                      "range": [
+                        30,
+                        38
+                      ],
+                      "raw": "return 1",
+                      "type": "Return"
+                    }
+                  ],
+                  "type": "Block"
+                },
+                "column": 7,
+                "line": 2,
+                "parameters": [
+                ],
+                "range": [
+                  14,
+                  38
+                ],
+                "raw": "->\n    c: d\n    return 1",
+                "type": "Function"
+              },
+              "line": 2,
+              "range": [
+                10,
+                38
+              ],
+              "raw": "b = ->\n    c: d\n    return 1",
+              "type": "AssignOp"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": null,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          38
+        ],
+        "raw": "class A\n  b = ->\n    c: d\n    return 1",
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    39
+  ],
+  "raw": "class A\n  b = ->\n    c: d\n    return 1\n",
+  "type": "Program"
+}

--- a/test/examples/class-with-outer-assign-blocking-conditional-assign/input.coffee
+++ b/test/examples/class-with-outer-assign-blocking-conditional-assign/input.coffee
@@ -1,0 +1,4 @@
+class A
+  if b
+    c: d
+  e: f

--- a/test/examples/class-with-outer-assign-blocking-conditional-assign/output.json
+++ b/test/examples/class-with-outer-assign-blocking-conditional-assign/output.json
@@ -1,0 +1,184 @@
+{
+  "body": {
+    "column": 1,
+    "inline": false,
+    "line": 1,
+    "range": [
+      0,
+      30
+    ],
+    "raw": "class A\n  if b\n    c: d\n  e: f",
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "inline": false,
+          "line": 2,
+          "range": [
+            10,
+            30
+          ],
+          "raw": "if b\n    c: d\n  e: f",
+          "statements": [
+            {
+              "alternate": null,
+              "column": 3,
+              "condition": {
+                "column": 6,
+                "data": "b",
+                "line": 2,
+                "range": [
+                  13,
+                  14
+                ],
+                "raw": "b",
+                "type": "Identifier"
+              },
+              "consequent": {
+                "column": 5,
+                "inline": false,
+                "line": 3,
+                "range": [
+                  19,
+                  23
+                ],
+                "raw": "c: d",
+                "statements": [
+                  {
+                    "column": 5,
+                    "line": 3,
+                    "members": [
+                      {
+                        "column": 5,
+                        "expression": {
+                          "column": 8,
+                          "data": "d",
+                          "line": 3,
+                          "range": [
+                            22,
+                            23
+                          ],
+                          "raw": "d",
+                          "type": "Identifier"
+                        },
+                        "key": {
+                          "column": 5,
+                          "data": "c",
+                          "line": 3,
+                          "range": [
+                            19,
+                            20
+                          ],
+                          "raw": "c",
+                          "type": "Identifier"
+                        },
+                        "line": 3,
+                        "range": [
+                          19,
+                          23
+                        ],
+                        "raw": "c: d",
+                        "type": "ObjectInitialiserMember"
+                      }
+                    ],
+                    "range": [
+                      19,
+                      23
+                    ],
+                    "raw": "c: d",
+                    "type": "ObjectInitialiser"
+                  }
+                ],
+                "type": "Block"
+              },
+              "isUnless": false,
+              "line": 2,
+              "range": [
+                10,
+                23
+              ],
+              "raw": "if b\n    c: d",
+              "type": "Conditional"
+            },
+            {
+              "assignee": {
+                "column": 3,
+                "data": "e",
+                "line": 4,
+                "range": [
+                  26,
+                  27
+                ],
+                "raw": "e",
+                "type": "Identifier"
+              },
+              "column": 3,
+              "expression": {
+                "column": 6,
+                "data": "f",
+                "line": 4,
+                "range": [
+                  29,
+                  30
+                ],
+                "raw": "f",
+                "type": "Identifier"
+              },
+              "line": 4,
+              "range": [
+                26,
+                30
+              ],
+              "raw": "e: f",
+              "type": "ClassProtoAssignOp"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": null,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "line": 1,
+          "range": [
+            6,
+            7
+          ],
+          "raw": "A",
+          "type": "Identifier"
+        },
+        "parent": null,
+        "range": [
+          0,
+          30
+        ],
+        "raw": "class A\n  if b\n    c: d\n  e: f",
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "line": 1,
+  "range": [
+    0,
+    31
+  ],
+  "raw": "class A\n  if b\n    c: d\n  e: f\n",
+  "type": "Program"
+}


### PR DESCRIPTION
Rather than just looking at top-level class statements, we need to traverse all
nested code within classes to distinguish object literals from class proto
assign ops, and we also need to collect all bound methods that we see and the
constructor. Since this happens at different levels of the AST, I needed to make
traversal stateful by adding some state to the context.