### PR TITLE
refactor: change mapBase to getLocation

### DIFF
--- a/src/mappers/mapArr.ts
+++ b/src/mappers/mapArr.ts
@@ -1,11 +1,11 @@
 import { Arr } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { ArrayInitialiser } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapArr(context: ParseContext, node: Arr): ArrayInitialiser {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let members = node.objects.map(object => mapAny(context, object));
   return new ArrayInitialiser(line, column, start, end, raw, members);
 }

--- a/src/mappers/mapAssign.ts
+++ b/src/mappers/mapAssign.ts
@@ -1,9 +1,9 @@
 import { Assign } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { AssignOp, BaseAssignOp, BitAndOp, BitOrOp, BitXorOp, CompoundAssignOp, DivideOp, ExistsOp, ExpOp, FloorDivideOp, LeftShiftOp, LogicalAndOp, LogicalOrOp, ModuloOp, MultiplyOp, PlusOp, RemOp, SignedRightShiftOp, SubtractOp, UnsignedRightShiftOp } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import UnsupportedNodeError from '../util/UnsupportedNodeError';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 const COMPOUND_ASSIGN_OPS: {[op: string]: string | undefined} = {
   '-=': SubtractOp.name,
@@ -30,7 +30,7 @@ export default function mapAssign(context: ParseContext, node: Assign): BaseAssi
     throw new UnsupportedNodeError(node, 'Unexpected object context when mapping regular assign op.');
   }
 
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   if (node.context) {
     let opName = COMPOUND_ASSIGN_OPS[node.context];
     if (!opName) {

--- a/src/mappers/mapBlock.ts
+++ b/src/mappers/mapBlock.ts
@@ -2,9 +2,9 @@ import { SourceType } from 'coffee-lex';
 import { Assign, Base, Block as CoffeeBlock, Comment, Obj, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { inspect } from 'util';
 import { AssignOp, Block, BoundFunction, BoundGeneratorFunction, ClassProtoAssignOp, Constructor, Identifier, MemberAccessOp, Node, This } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapBlock(context: ParseContext, node: CoffeeBlock): Block {
   let childContext = context;
@@ -20,7 +20,7 @@ export default function mapBlock(context: ParseContext, node: CoffeeBlock): Bloc
     }
   }
 
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let previousTokenIndex = context.sourceTokens.indexOfTokenNearSourceIndex(start).previous();
   let previousToken = previousTokenIndex ? context.sourceTokens.tokenAtIndex(previousTokenIndex) : null;
   let inline = previousToken ? previousToken.type !== SourceType.NEWLINE : false;
@@ -47,7 +47,7 @@ function mapChild(blockContext: ParseContext, childContext: ParseContext, node: 
       if (property instanceof Comment) {
         continue;
       } else if (property instanceof Assign) {
-        let { line, column, start, end, raw } = mapBase(childContext, property);
+        let { line, column, start, end, raw } = getLocation(childContext, property);
         let key = mapAny(childContext, property.variable);
         let value = mapAny(childContext, property.value);
         let Node = ClassProtoAssignOp;

--- a/src/mappers/mapBool.ts
+++ b/src/mappers/mapBool.ts
@@ -1,9 +1,9 @@
 import { Bool as CoffeeBool } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Bool } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
-import mapBase from './mapBase';
 
 export default function mapBool(context: ParseContext, node: CoffeeBool): Bool {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   return new Bool(line, column, start, end, raw, JSON.parse(node.val));
 }

--- a/src/mappers/mapCall.ts
+++ b/src/mappers/mapCall.ts
@@ -6,6 +6,7 @@ import {
   BareSuperFunctionApplication, BaseFunction, DefaultParam, DoOp, FunctionApplication, Identifier, NewOp,
   Node, SoakedFunctionApplication, SoakedNewOp, Super
 } from '../nodes';
+import getLocation from '../util/getLocation';
 import isHeregexTemplateNode from '../util/isHeregexTemplateNode';
 import locationsEqual from '../util/locationsEqual';
 import makeHeregex from '../util/makeHeregex';
@@ -13,10 +14,9 @@ import ParseContext from '../util/ParseContext';
 import parseString from '../util/parseString';
 import UnsupportedNodeError from '../util/UnsupportedNodeError';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapCall(context: ParseContext, node: Call): Node {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   if (isHeregexTemplateNode(node, context)) {
     let firstArg = node.args[0];
@@ -128,7 +128,7 @@ function mapNewOp(context: ParseContext, node: Call): NewOp {
     throw new UnsupportedNodeError(node);
   }
 
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let callee = mapAny(context, node.variable);
   let args = node.args.map(arg => mapAny(context, arg));
 
@@ -162,7 +162,7 @@ function mapDoOp(context: ParseContext, node: Call): DoOp {
     throw new UnsupportedNodeError(node);
   }
 
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   let expression = mapAny(context, node.variable);
 

--- a/src/mappers/mapClass.ts
+++ b/src/mappers/mapClass.ts
@@ -1,12 +1,12 @@
 import { Class as CoffeeClass } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Class } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 import mapPossiblyEmptyBlock from './mapPossiblyEmptyBlock';
 
 export default function mapClass(context: ParseContext, node: CoffeeClass): Class {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   let nameAssignee = node.variable ? mapAny(context, node.variable) : null;
   let parent = node.parent ? mapAny(context, node.parent) : null;

--- a/src/mappers/mapCode.ts
+++ b/src/mappers/mapCode.ts
@@ -1,12 +1,12 @@
 import { Code } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { BaseFunction, BoundFunction, BoundGeneratorFunction, Function, GeneratorFunction } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 import mapPossiblyEmptyBlock from './mapPossiblyEmptyBlock';
 
 export default function mapCode(context: ParseContext, node: Code): BaseFunction {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   let Node = getNodeTypeForCode(node);
 

--- a/src/mappers/mapExistence.ts
+++ b/src/mappers/mapExistence.ts
@@ -1,10 +1,10 @@
 import { Existence } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { UnaryExistsOp } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapExistence(context: ParseContext, node: Existence): UnaryExistsOp {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   return new UnaryExistsOp(line, column, start, end, raw, mapAny(context, node.expression));
 }

--- a/src/mappers/mapExpansion.ts
+++ b/src/mappers/mapExpansion.ts
@@ -1,9 +1,9 @@
 import { Expansion as CoffeeExpansion } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Expansion } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
-import mapBase from './mapBase';
 
 export default function mapExpansion(context: ParseContext, node: CoffeeExpansion): Expansion {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   return new Expansion(line, column, start, end, raw);
 }

--- a/src/mappers/mapExtends.ts
+++ b/src/mappers/mapExtends.ts
@@ -1,11 +1,11 @@
 import { Extends } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { ExtendsOp } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapExtends(context: ParseContext, node: Extends): ExtendsOp {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   return new ExtendsOp(
     line, column, start, end, raw,
     mapAny(context, node.child),

--- a/src/mappers/mapFor.ts
+++ b/src/mappers/mapFor.ts
@@ -1,12 +1,12 @@
 import { For as CoffeeFor } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { For, ForIn, ForOf } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 import mapPossiblyEmptyBlock from './mapPossiblyEmptyBlock';
 
 export default function mapFor(context: ParseContext, node: CoffeeFor): For {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   let keyAssignee = node.index ? mapAny(context, node.index) : null;
   let valAssignee = node.name ? mapAny(context, node.name) : null;

--- a/src/mappers/mapIf.ts
+++ b/src/mappers/mapIf.ts
@@ -2,13 +2,13 @@ import { SourceType } from 'coffee-lex';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
 import { If } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Conditional } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 import mapPossiblyEmptyBlock from './mapPossiblyEmptyBlock';
 
 export default function mapIf(context: ParseContext, node: If): Conditional {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   let condition = mapAny(context, node.condition);
   let consequent = mapPossiblyEmptyBlock(context, node.body);

--- a/src/mappers/mapIn.ts
+++ b/src/mappers/mapIn.ts
@@ -1,14 +1,14 @@
 import SourceType from 'coffee-lex/dist/SourceType';
 import { In as CoffeeIn } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { InOp } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapIn(context: ParseContext, node: CoffeeIn): InOp {
   // We don't use the `negated` flag on `node` because it gets set to
   // `true` when a parent `If` is an `unless`.
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let left = mapAny(context, node.object);
   let right = mapAny(context, node.array);
   let isNot = false;

--- a/src/mappers/mapLiteral.ts
+++ b/src/mappers/mapLiteral.ts
@@ -2,18 +2,18 @@ import SourceType from 'coffee-lex/dist/SourceType';
 import { Literal } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { inspect } from 'util';
 import { Break, Continue, Float, Identifier, Int, JavaScript, Node, Regex, RegexFlags, This } from '../nodes';
+import getLocation from '../util/getLocation';
 import isStringAtPosition from '../util/isStringAtPosition';
 import makeHeregex from '../util/makeHeregex';
 import makeString from '../util/makeString';
 import ParseContext from '../util/ParseContext';
 import parseNumber from '../util/parseNumber';
 import parseRegExp from '../util/parseRegExp';
-import mapBase from './mapBase';
 
 const HEREGEX_PATTERN = /^\/\/\/((?:.|\s)*)\/\/\/([gimy]*)$/;
 
 export default function mapLiteral(context: ParseContext, node: Literal): Node {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   if (node.value === 'this') {
     return new This(line, column, start, end, raw);

--- a/src/mappers/mapNull.ts
+++ b/src/mappers/mapNull.ts
@@ -1,9 +1,9 @@
 import { Null as CoffeeNull } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Null } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
-import mapBase from './mapBase';
 
 export default function mapNull(context: ParseContext, node: CoffeeNull): Null {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   return new Null(line, column, start, end, raw);
 }

--- a/src/mappers/mapObj.ts
+++ b/src/mappers/mapObj.ts
@@ -1,18 +1,18 @@
 import { Assign, Comment, Obj, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { AssignOp, ObjectInitialiser, ObjectInitialiserMember } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import UnsupportedNodeError from '../util/UnsupportedNodeError';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 import mapValue from './mapValue';
 
 export default function mapObj(context: ParseContext, node: Obj): ObjectInitialiser {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   let members: Array<ObjectInitialiserMember | AssignOp> = [];
 
   for (let property of node.properties) {
-    let { line, column, start, end, raw } = mapBase(context, property);
+    let { line, column, start, end, raw } = getLocation(context, property);
 
     if (property instanceof Value) {
       // shorthand property

--- a/src/mappers/mapOp.ts
+++ b/src/mappers/mapOp.ts
@@ -8,6 +8,7 @@ import {
   PreDecrementOp, PreIncrementOp, RemOp, SignedRightShiftOp, SubtractOp, TypeofOp, UnaryNegateOp, UnaryOp, UnaryPlusOp,
   UnsignedRightShiftOp, Yield, YieldFrom, YieldReturn
 } from '../nodes';
+import getLocation from '../util/getLocation';
 import getOperatorInfoInRange from '../util/getOperatorInfoInRange';
 import isChainedComparison from '../util/isChainedComparison';
 import isImplicitPlusOp from '../util/isImplicitPlusOp';
@@ -16,7 +17,6 @@ import ParseContext from '../util/ParseContext';
 import UnsupportedNodeError from '../util/UnsupportedNodeError';
 import unwindChainedComparison from '../util/unwindChainedComparison';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapOp(context: ParseContext, node: CoffeeOp): Node {
   if (isChainedComparison(node)) {
@@ -27,7 +27,7 @@ export default function mapOp(context: ParseContext, node: CoffeeOp): Node {
 }
 
 function mapChainedComparisonOp(context: ParseContext, node: CoffeeOp) {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let coffeeOperands = unwindChainedComparison(node);
   let operands = coffeeOperands.map(operand => mapAny(context, operand));
   let operators: Array<OperatorInfo> = [];
@@ -174,7 +174,7 @@ function mapNewOp(context: ParseContext, node: CoffeeOp): NewOp {
     throw new Error(`unexpected 'new' operator with multiple operands: ${inspect(node)}`);
   }
 
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   return new NewOp(
     line, column, start, end, raw,
@@ -184,7 +184,7 @@ function mapNewOp(context: ParseContext, node: CoffeeOp): NewOp {
 }
 
 function mapYieldOp(context: ParseContext, node: CoffeeOp): YieldReturn | Yield {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   if (node.first instanceof CoffeeReturn) {
     let expression = node.first.expression;
@@ -213,7 +213,7 @@ interface IBinaryOp {
 }
 
 function mapBinaryOp<T extends IBinaryOp>(context: ParseContext, node: CoffeeOp, Op: T): BinaryOp {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   if (!node.second) {
     throw new Error(`unexpected '${node.operator}' operator with only one operand: ${inspect(node)}`);
@@ -238,7 +238,7 @@ interface IUnaryOp {
 }
 
 function mapUnaryOp<T extends IUnaryOp>(context: ParseContext, node: CoffeeOp, Op: T): UnaryOp {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   if (node.second) {
     throw new Error(`unexpected '${node.operator}' operator with two operands: ${inspect(node)}`);

--- a/src/mappers/mapParam.ts
+++ b/src/mappers/mapParam.ts
@@ -1,11 +1,11 @@
 import { Param } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { DefaultParam, Node, Rest } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapParam(context: ParseContext, node: Param): Node {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let param = mapAny(context, node.name);
 
   if (node.value) {

--- a/src/mappers/mapRange.ts
+++ b/src/mappers/mapRange.ts
@@ -1,12 +1,12 @@
 import { Range as CoffeeRange } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { inspect } from 'util';
 import { Range } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapRange(context: ParseContext, node: CoffeeRange): Range {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   if (!node.from || !node.to) {
     throw new Error(`'from' or 'to' unexpectedly missing: ${inspect(node)}`);

--- a/src/mappers/mapReturn.ts
+++ b/src/mappers/mapReturn.ts
@@ -1,11 +1,11 @@
 import { Return as CoffeeReturn } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Return } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapReturn(context: ParseContext, node: CoffeeReturn): Return {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let argument = node.expression ? mapAny(context, node.expression) : null;
   return new Return(line, column, start, end, raw, argument);
 }

--- a/src/mappers/mapSplat.ts
+++ b/src/mappers/mapSplat.ts
@@ -1,10 +1,10 @@
 import { Splat } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Spread } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapSplat(context: ParseContext, node: Splat): Spread {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   return new Spread(line, column, start, end, raw, mapAny(context, node.name));
 }

--- a/src/mappers/mapSwitch.ts
+++ b/src/mappers/mapSwitch.ts
@@ -2,13 +2,13 @@ import SourceToken from 'coffee-lex/dist/SourceToken';
 import SourceType from 'coffee-lex/dist/SourceType';
 import { Switch as CoffeeSwitch } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Switch, SwitchCase } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 import mapPossiblyEmptyBlock from './mapPossiblyEmptyBlock';
 
 export default function mapSwitch(context: ParseContext, node: CoffeeSwitch): Switch {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   let expression = node.subject ? mapAny(context, node.subject) : null;
   let cases = node.cases.map(([conditions, body]) => {
@@ -25,7 +25,7 @@ export default function mapSwitch(context: ParseContext, node: CoffeeSwitch): Sw
     }
 
     let { line: caseLine, column: caseColumn } = locationForIndex;
-    let { end } = mapBase(context, body);
+    let { end } = getLocation(context, body);
     return new SwitchCase(
       caseLine + 1, caseColumn + 1, whenToken.start, end,
       context.source.slice(whenToken.start, end),

--- a/src/mappers/mapThrow.ts
+++ b/src/mappers/mapThrow.ts
@@ -1,11 +1,11 @@
 import { Throw as CoffeeThrow } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Throw } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 
 export default function mapThrow(context: ParseContext, node: CoffeeThrow): Throw {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let expression = node.expression ? mapAny(context, node.expression) : null;
   return new Throw(line, column, start, end, raw, expression);
 }

--- a/src/mappers/mapTry.ts
+++ b/src/mappers/mapTry.ts
@@ -1,12 +1,12 @@
 import { Try as CoffeeTry } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Try } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 import mapPossiblyEmptyBlock from './mapPossiblyEmptyBlock';
 
 export default function mapTry(context: ParseContext, node: CoffeeTry): Try {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
 
   return new Try(
     line, column, start, end, raw,

--- a/src/mappers/mapUndefined.ts
+++ b/src/mappers/mapUndefined.ts
@@ -1,9 +1,9 @@
 import { Undefined as CoffeeUndefined } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Undefined } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
-import mapBase from './mapBase';
 
 export default function mapUndefined(context: ParseContext, node: CoffeeUndefined): Undefined {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   return new Undefined(line, column, start, end, raw);
 }

--- a/src/mappers/mapWhile.ts
+++ b/src/mappers/mapWhile.ts
@@ -1,13 +1,13 @@
 import { SourceType } from 'coffee-lex';
 import { While as CoffeeWhile } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Block, Loop, While } from '../nodes';
+import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
-import mapBase from './mapBase';
 import mapPossiblyEmptyBlock from './mapPossiblyEmptyBlock';
 
 export default function mapWhile(context: ParseContext, node: CoffeeWhile): While | Loop {
-  let { line, column, start, end, raw } = mapBase(context, node);
+  let { line, column, start, end, raw } = getLocation(context, node);
   let startTokenIndex = context.sourceTokens.indexOfTokenStartingAtSourceIndex(start);
   let startToken = startTokenIndex && context.sourceTokens.tokenAtIndex(startTokenIndex);
 

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -9,7 +9,7 @@ export interface RealNode {
   raw: string;
 }
 
-export class Node {
+export abstract class Node {
   readonly range: [number, number];
 
   constructor(

--- a/src/util/getLocation.ts
+++ b/src/util/getLocation.ts
@@ -2,10 +2,17 @@ import { SourceType } from 'coffee-lex';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
 import { Base } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { inspect } from 'util';
-import { Node } from '../nodes';
-import ParseContext from '../util/ParseContext';
+import ParseContext from './ParseContext';
 
-export default function mapBase(context: ParseContext, node: Base): Node {
+export type NodeLocation = {
+  line: number,
+  column: number,
+  start: number,
+  end: number,
+  raw: string,
+};
+
+export default function getLocation(context: ParseContext, node: Base): NodeLocation {
   let loc = node.locationData;
   let start = context.linesAndColumns.indexForLocation({ line: loc.first_line, column: loc.first_column });
   let last = context.linesAndColumns.indexForLocation({ line: loc.last_line, column: loc.last_column });
@@ -33,7 +40,7 @@ export default function mapBase(context: ParseContext, node: Base): Node {
   end = lastTokenOfNode.end;
   let raw = context.source.slice(start, end);
 
-  return new Node('Node', line, column, start, end, raw);
+  return {line, column, start, end, raw};
 }
 
 function firstSemanticTokenAfter(context: ParseContext, index: number, node: Base) {


### PR DESCRIPTION
I want `Node` to be abstract, but `mapBase` was returning an instance of `Node`
as a way to return the location information. Now, we don't view it as a mapper
anymore and just return a custom `NodeLocation` type.