### PR TITLE
refactor: get rid of RealNode interface

### DIFF
--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -1,14 +1,6 @@
 import SourceToken from 'coffee-lex/dist/SourceToken';
 import ParseContext from './util/ParseContext';
 
-export interface RealNode {
-  type: string;
-  line: number;
-  column: number;
-  range: [number, number];
-  raw: string;
-}
-
 export abstract class Node {
   readonly range: [number, number];
 

--- a/src/util/ParseContext.ts
+++ b/src/util/ParseContext.ts
@@ -1,7 +1,7 @@
 import SourceTokenList from 'coffee-lex/dist/SourceTokenList';
 import { Base, Block, LocationData } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import LinesAndColumns from 'lines-and-columns';
-import { ClassProtoAssignOp, Constructor, RealNode } from '../nodes';
+import { ClassProtoAssignOp, Constructor } from '../nodes';
 
 class ParseError extends Error {
   syntaxError: SyntaxError;
@@ -60,10 +60,8 @@ export default class ParseContext {
     readonly parseState: ParseState) {
   }
 
-  getRange(locatable: RealNode | Base | LocationData): [number, number] | null {
-    if ('range' in locatable) {
-      return (locatable as RealNode).range;
-    } else if (locatable instanceof Base) {
+  getRange(locatable: Base | LocationData): [number, number] | null {
+    if (locatable instanceof Base) {
       return this.getRange(locatable.locationData);
     } else {
       let locationData = locatable as LocationData;


### PR DESCRIPTION
I think this may have been for compatibility and doesn't seem to be needed
anymore.