### PR TITLE
feat: add parent pointers to nodes and a traverse function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "decaffeinate-parser",
   "description": "A better AST for CoffeeScript, inspired by CoffeeScriptRedux.",
+  "version": "0.0.0-development",
   "main": "dist/parser.js",
   "module": "dist/parser.mjs",
   "types": "dist/parser.d.ts",

--- a/src/mappers/mapObj.ts
+++ b/src/mappers/mapObj.ts
@@ -21,7 +21,7 @@ export default function mapObj(context: ParseContext, node: Obj): ObjectInitiali
       members.push(new ObjectInitialiserMember(
         line, column, start, end, raw,
         value,
-        value
+        null
       ));
     } else if (property instanceof Assign && property.context === 'object') {
       let key = mapAny(context, property.variable);

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -4,7 +4,7 @@ import ParseContext from './util/ParseContext';
 export type ChildField = Node | Array<Node | null> | null;
 
 export abstract class Node {
-  readonly range: [number, number];
+  parentNode: Node | null = null;
 
   constructor(
     readonly type: string,
@@ -14,8 +14,6 @@ export abstract class Node {
     readonly end: number,
     readonly raw: string,
   ) {
-    this.range = [start, end];
-    this.raw = raw;
   }
 
   getChildren(): Array<Node> {
@@ -316,7 +314,8 @@ export class ObjectInitialiserMember extends Node {
     end: number,
     raw: string,
     readonly key: Node,
-    readonly expression: Node,
+    // If null, this is a shorthand initializer and the key and value are the same.
+    readonly expression: Node | null,
   ) {
     super('ObjectInitialiserMember', line, column, start, end, raw);
   }

--- a/test/examples/addition/output.json
+++ b/test/examples/addition/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "3 + 4",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": 3,
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "3",
+          "start": 0,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "3 + 4",
         "right": {
           "column": 5,
           "data": 4,
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "4",
+          "start": 4,
           "type": "Int"
         },
+        "start": 0,
         "type": "PlusOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "3 + 4",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/array-with-multiple-members/output.json
+++ b/test/examples/array-with-multiple-members/output.json
@@ -1,68 +1,56 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "[1, 2, 3]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 9,
         "line": 1,
         "members": [
           {
             "column": 2,
             "data": 1,
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "1",
+            "start": 1,
             "type": "Int"
           },
           {
             "column": 5,
             "data": 2,
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "2",
+            "start": 4,
             "type": "Int"
           },
           {
             "column": 8,
             "data": 3,
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "3",
+            "start": 7,
             "type": "Int"
           }
         ],
-        "range": [
-          0,
-          9
-        ],
         "raw": "[1, 2, 3]",
+        "start": 0,
         "type": "ArrayInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "[1, 2, 3]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/array-with-single-member/output.json
+++ b/test/examples/array-with-single-member/output.json
@@ -1,46 +1,38 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "[1]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "line": 1,
         "members": [
           {
             "column": 2,
             "data": 1,
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "1",
+            "start": 1,
             "type": "Int"
           }
         ],
-        "range": [
-          0,
-          3
-        ],
         "raw": "[1]",
+        "start": 0,
         "type": "ArrayInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "[1]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/assign/output.json
+++ b/test/examples/assign/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a = 1",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 5,
         "expression": {
           "column": 5,
           "data": 1,
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "1",
+          "start": 4,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a = 1",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a = 1",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/backticks-with-string-inside/output.json
+++ b/test/examples/backticks-with-string-inside/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 23,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      23
-    ],
     "raw": "`import foo from 'foo'`",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": "import foo from 'foo'",
+        "end": 23,
         "line": 1,
-        "range": [
-          0,
-          23
-        ],
         "raw": "`import foo from 'foo'`",
+        "start": 0,
         "type": "JavaScript"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 24,
   "line": 1,
-  "range": [
-    0,
-    24
-  ],
   "raw": "`import foo from 'foo'`\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/bitshift-left/output.json
+++ b/test/examples/bitshift-left/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a << b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a << b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "LeftShiftOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a << b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/bitshift-right-unsigned/output.json
+++ b/test/examples/bitshift-right-unsigned/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "a >>> b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          7
-        ],
         "raw": "a >>> b",
         "right": {
           "column": 7,
           "data": "b",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "b",
+          "start": 6,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "UnsignedRightShiftOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "a >>> b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/bitshift-right/output.json
+++ b/test/examples/bitshift-right/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a >> b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a >> b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "SignedRightShiftOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a >> b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/bitwise-and/output.json
+++ b/test/examples/bitwise-and/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a & b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a & b",
         "right": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "BitAndOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a & b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/bitwise-or/output.json
+++ b/test/examples/bitwise-or/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a | b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a | b",
         "right": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "BitOrOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a | b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/bitwise-xor/output.json
+++ b/test/examples/bitwise-xor/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a ^ b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a ^ b",
         "right": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "BitXorOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a ^ b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/block-comment-in-function/output.json
+++ b/test/examples/block-comment-in-function/output.json
@@ -1,48 +1,40 @@
 {
   "body": {
     "column": 1,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      18
-    ],
     "raw": "->\n  ###\n  a\n  ###",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 18,
           "inline": false,
           "line": 2,
-          "range": [
-            5,
-            18
-          ],
           "raw": "###\n  a\n  ###",
+          "start": 5,
           "statements": [
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 18,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          18
-        ],
         "raw": "->\n  ###\n  a\n  ###",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 19,
   "line": 1,
-  "range": [
-    0,
-    19
-  ],
   "raw": "->\n  ###\n  a\n  ###\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/block-comment-only-file/output.json
+++ b/test/examples/block-comment-only-file/output.json
@@ -1,23 +1,19 @@
 {
   "body": {
     "column": 1,
+    "end": 19,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      19
-    ],
     "raw": "###\n# hey there\n###",
+    "start": 0,
     "statements": [
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 20,
   "line": 1,
-  "range": [
-    0,
-    20
-  ],
   "raw": "###\n# hey there\n###\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/block-comment/output.json
+++ b/test/examples/block-comment/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 21,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      21
-    ],
     "raw": "###\n# hey there\n###\na",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": "a",
+        "end": 21,
         "line": 4,
-        "range": [
-          20,
-          21
-        ],
         "raw": "a",
+        "start": 20,
         "type": "Identifier"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 21,
   "line": 1,
-  "range": [
-    0,
-    21
-  ],
   "raw": "###\n# hey there\n###\na",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/bound-function-with-parameters/output.json
+++ b/test/examples/bound-function-with-parameters/output.json
@@ -1,58 +1,48 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "(a, b) =>",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 9,
         "line": 1,
         "parameters": [
           {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Identifier"
           },
           {
             "column": 5,
             "data": "b",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "b",
+            "start": 4,
             "type": "Identifier"
           }
         ],
-        "range": [
-          0,
-          9
-        ],
         "raw": "(a, b) =>",
+        "start": 0,
         "type": "BoundFunction"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "(a, b) =>",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/bound-generator-function/output.json
+++ b/test/examples/bound-generator-function/output.json
@@ -1,69 +1,57 @@
 {
   "body": {
     "column": 1,
+    "end": 10,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      10
-    ],
     "raw": "=> yield 3",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 4,
+          "end": 10,
           "inline": true,
           "line": 1,
-          "range": [
-            3,
-            10
-          ],
           "raw": "yield 3",
+          "start": 3,
           "statements": [
             {
               "column": 4,
+              "end": 10,
               "expression": {
                 "column": 10,
                 "data": 3,
+                "end": 10,
                 "line": 1,
-                "range": [
-                  9,
-                  10
-                ],
                 "raw": "3",
+                "start": 9,
                 "type": "Int"
               },
               "line": 1,
-              "range": [
-                3,
-                10
-              ],
               "raw": "yield 3",
+              "start": 3,
               "type": "Yield"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 10,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          10
-        ],
         "raw": "=> yield 3",
+        "start": 0,
         "type": "BoundGeneratorFunction"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "=> yield 3\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/break/output.json
+++ b/test/examples/break/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "loop\n  break",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 12,
           "inline": false,
           "line": 2,
-          "range": [
-            7,
-            12
-          ],
           "raw": "break",
+          "start": 7,
           "statements": [
             {
               "column": 3,
+              "end": 12,
               "line": 2,
-              "range": [
-                7,
-                12
-              ],
               "raw": "break",
+              "start": 7,
               "type": "Break"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 12,
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "loop\n  break",
+        "start": 0,
         "type": "Loop"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "loop\n  break\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/call-dynamic-member-access-result/output.json
+++ b/test/examples/call-dynamic-member-access-result/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a[b]()",
+    "start": 0,
     "statements": [
       {
         "arguments": [
         ],
         "column": 1,
+        "end": 6,
         "function": {
           "column": 1,
+          "end": 4,
           "expression": {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           "indexingExpr": {
             "column": 3,
             "data": "b",
+            "end": 3,
             "line": 1,
-            "range": [
-              2,
-              3
-            ],
             "raw": "b",
+            "start": 2,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            0,
-            4
-          ],
           "raw": "a[b]",
+          "start": 0,
           "type": "DynamicMemberAccessOp"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a[b]()",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "a[b]()\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chain-calls-with-parens/output.json
+++ b/test/examples/chain-calls-with-parens/output.json
@@ -1,18 +1,17 @@
 {
   "body": {
     "column": 1,
+    "end": 56,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      56
-    ],
     "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 15,
+            "end": 47,
             "expressions": [
             ],
             "line": 3,
@@ -20,41 +19,37 @@
               {
                 "column": 16,
                 "data": "MyCtrl",
+                "end": 46,
                 "line": 3,
-                "range": [
-                  40,
-                  46
-                ],
                 "raw": "MyCtrl",
+                "start": 40,
                 "type": "Quasi"
               }
             ],
-            "range": [
-              39,
-              47
-            ],
             "raw": "'MyCtrl'",
+            "start": 39,
             "type": "String"
           },
           {
             "column": 25,
             "data": "MyCtrl",
+            "end": 55,
             "line": 3,
-            "range": [
-              49,
-              55
-            ],
             "raw": "MyCtrl",
+            "start": 49,
             "type": "Identifier"
           }
         ],
         "column": 1,
+        "end": 56,
         "function": {
           "column": 1,
+          "end": 38,
           "expression": {
             "arguments": [
               {
                 "column": 11,
+                "end": 23,
                 "expressions": [
                 ],
                 "line": 2,
@@ -62,100 +57,77 @@
                   {
                     "column": 12,
                     "data": "app",
+                    "end": 22,
                     "line": 2,
-                    "range": [
-                      19,
-                      22
-                    ],
                     "raw": "app",
+                    "start": 19,
                     "type": "Quasi"
                   }
                 ],
-                "range": [
-                  18,
-                  23
-                ],
                 "raw": "'app'",
+                "start": 18,
                 "type": "String"
               }
             ],
             "column": 1,
+            "end": 24,
             "function": {
               "column": 1,
+              "end": 17,
               "expression": {
                 "column": 1,
                 "data": "angular",
+                "end": 7,
                 "line": 1,
-                "range": [
-                  0,
-                  7
-                ],
                 "raw": "angular",
+                "start": 0,
                 "type": "Identifier"
               },
               "line": 1,
               "member": {
                 "column": 4,
                 "data": "module",
+                "end": 17,
                 "line": 2,
-                "range": [
-                  11,
-                  17
-                ],
                 "raw": "module",
+                "start": 11,
                 "type": "Identifier"
               },
-              "range": [
-                0,
-                17
-              ],
               "raw": "angular\n  .module",
+              "start": 0,
               "type": "MemberAccessOp"
             },
             "line": 1,
-            "range": [
-              0,
-              24
-            ],
             "raw": "angular\n  .module('app')",
+            "start": 0,
             "type": "FunctionApplication"
           },
           "line": 1,
           "member": {
             "column": 4,
             "data": "controller",
+            "end": 38,
             "line": 3,
-            "range": [
-              28,
-              38
-            ],
             "raw": "controller",
+            "start": 28,
             "type": "Identifier"
           },
-          "range": [
-            0,
-            38
-          ],
           "raw": "angular\n  .module('app')\n  .controller",
+          "start": 0,
           "type": "MemberAccessOp"
         },
         "line": 1,
-        "range": [
-          0,
-          56
-        ],
         "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 56,
   "line": 1,
-  "range": [
-    0,
-    56
-  ],
   "raw": "angular\n  .module('app')\n  .controller('MyCtrl', MyCtrl)",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chain-calls-without-indent/output.json
+++ b/test/examples/chain-calls-without-indent/output.json
@@ -1,18 +1,17 @@
 {
   "body": {
     "column": 1,
+    "end": 40,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      40
-    ],
     "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 8,
+            "end": 40,
             "expressions": [
             ],
             "line": 3,
@@ -20,30 +19,28 @@
               {
                 "column": 9,
                 "data": "bar",
+                "end": 39,
                 "line": 3,
-                "range": [
-                  36,
-                  39
-                ],
                 "raw": "bar",
+                "start": 36,
                 "type": "Quasi"
               }
             ],
-            "range": [
-              35,
-              40
-            ],
             "raw": "'bar'",
+            "start": 35,
             "type": "String"
           }
         ],
         "column": 1,
+        "end": 40,
         "function": {
           "column": 1,
+          "end": 34,
           "expression": {
             "arguments": [
               {
                 "column": 8,
+                "end": 27,
                 "expressions": [
                 ],
                 "line": 2,
@@ -51,100 +48,77 @@
                   {
                     "column": 9,
                     "data": "foo",
+                    "end": 26,
                     "line": 2,
-                    "range": [
-                      23,
-                      26
-                    ],
                     "raw": "foo",
+                    "start": 23,
                     "type": "Quasi"
                   }
                 ],
-                "range": [
-                  22,
-                  27
-                ],
                 "raw": "'foo'",
+                "start": 22,
                 "type": "String"
               }
             ],
             "column": 1,
+            "end": 27,
             "function": {
               "column": 1,
+              "end": 21,
               "expression": {
                 "column": 1,
                 "data": "$stateProvider",
+                "end": 14,
                 "line": 1,
-                "range": [
-                  0,
-                  14
-                ],
                 "raw": "$stateProvider",
+                "start": 0,
                 "type": "Identifier"
               },
               "line": 1,
               "member": {
                 "column": 2,
                 "data": "state",
+                "end": 21,
                 "line": 2,
-                "range": [
-                  16,
-                  21
-                ],
                 "raw": "state",
+                "start": 16,
                 "type": "Identifier"
               },
-              "range": [
-                0,
-                21
-              ],
               "raw": "$stateProvider\n.state",
+              "start": 0,
               "type": "MemberAccessOp"
             },
             "line": 1,
-            "range": [
-              0,
-              27
-            ],
             "raw": "$stateProvider\n.state 'foo'",
+            "start": 0,
             "type": "FunctionApplication"
           },
           "line": 1,
           "member": {
             "column": 2,
             "data": "state",
+            "end": 34,
             "line": 3,
-            "range": [
-              29,
-              34
-            ],
             "raw": "state",
+            "start": 29,
             "type": "Identifier"
           },
-          "range": [
-            0,
-            34
-          ],
           "raw": "$stateProvider\n.state 'foo'\n.state",
+          "start": 0,
           "type": "MemberAccessOp"
         },
         "line": 1,
-        "range": [
-          0,
-          40
-        ],
         "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 40,
   "line": 1,
-  "range": [
-    0,
-    40
-  ],
   "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chain-calls-without-parens/output.json
+++ b/test/examples/chain-calls-without-parens/output.json
@@ -1,18 +1,17 @@
 {
   "body": {
     "column": 1,
+    "end": 40,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      40
-    ],
     "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 8,
+            "end": 40,
             "expressions": [
             ],
             "line": 3,
@@ -20,30 +19,28 @@
               {
                 "column": 9,
                 "data": "bar",
+                "end": 39,
                 "line": 3,
-                "range": [
-                  36,
-                  39
-                ],
                 "raw": "bar",
+                "start": 36,
                 "type": "Quasi"
               }
             ],
-            "range": [
-              35,
-              40
-            ],
             "raw": "'bar'",
+            "start": 35,
             "type": "String"
           }
         ],
         "column": 1,
+        "end": 40,
         "function": {
           "column": 1,
+          "end": 34,
           "expression": {
             "arguments": [
               {
                 "column": 8,
+                "end": 27,
                 "expressions": [
                 ],
                 "line": 2,
@@ -51,100 +48,77 @@
                   {
                     "column": 9,
                     "data": "foo",
+                    "end": 26,
                     "line": 2,
-                    "range": [
-                      23,
-                      26
-                    ],
                     "raw": "foo",
+                    "start": 23,
                     "type": "Quasi"
                   }
                 ],
-                "range": [
-                  22,
-                  27
-                ],
                 "raw": "'foo'",
+                "start": 22,
                 "type": "String"
               }
             ],
             "column": 1,
+            "end": 27,
             "function": {
               "column": 1,
+              "end": 21,
               "expression": {
                 "column": 1,
                 "data": "$stateProvider",
+                "end": 14,
                 "line": 1,
-                "range": [
-                  0,
-                  14
-                ],
                 "raw": "$stateProvider",
+                "start": 0,
                 "type": "Identifier"
               },
               "line": 1,
               "member": {
                 "column": 2,
                 "data": "state",
+                "end": 21,
                 "line": 2,
-                "range": [
-                  16,
-                  21
-                ],
                 "raw": "state",
+                "start": 16,
                 "type": "Identifier"
               },
-              "range": [
-                0,
-                21
-              ],
               "raw": "$stateProvider\n.state",
+              "start": 0,
               "type": "MemberAccessOp"
             },
             "line": 1,
-            "range": [
-              0,
-              27
-            ],
             "raw": "$stateProvider\n.state 'foo'",
+            "start": 0,
             "type": "FunctionApplication"
           },
           "line": 1,
           "member": {
             "column": 2,
             "data": "state",
+            "end": 34,
             "line": 3,
-            "range": [
-              29,
-              34
-            ],
             "raw": "state",
+            "start": 29,
             "type": "Identifier"
           },
-          "range": [
-            0,
-            34
-          ],
           "raw": "$stateProvider\n.state 'foo'\n.state",
+          "start": 0,
           "type": "MemberAccessOp"
         },
         "line": 1,
-        "range": [
-          0,
-          40
-        ],
         "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 40,
   "line": 1,
-  "range": [
-    0,
-    40
-  ],
   "raw": "$stateProvider\n.state 'foo'\n.state 'bar'",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-equals/output.json
+++ b/test/examples/chained-comparison-equals/output.json
@@ -1,49 +1,42 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "a == b == c",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "line": 1,
         "operands": [
           {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           {
             "column": 6,
             "data": "b",
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "b",
+            "start": 5,
             "type": "Identifier"
           },
           {
             "column": 11,
             "data": "c",
+            "end": 11,
             "line": 1,
-            "range": [
-              10,
-              11
-            ],
             "raw": "c",
+            "start": 10,
             "type": "Identifier"
           }
         ],
@@ -65,22 +58,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "a == b == c",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "a == b == c\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-extended/output.json
+++ b/test/examples/chained-comparison-extended/output.json
@@ -1,71 +1,60 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "a < b < c < d < e",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 17,
         "line": 1,
         "operands": [
           {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           {
             "column": 5,
             "data": "b",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "b",
+            "start": 4,
             "type": "Identifier"
           },
           {
             "column": 9,
             "data": "c",
+            "end": 9,
             "line": 1,
-            "range": [
-              8,
-              9
-            ],
             "raw": "c",
+            "start": 8,
             "type": "Identifier"
           },
           {
             "column": 13,
             "data": "d",
+            "end": 13,
             "line": 1,
-            "range": [
-              12,
-              13
-            ],
             "raw": "d",
+            "start": 12,
             "type": "Identifier"
           },
           {
             "column": 17,
             "data": "e",
+            "end": 17,
             "line": 1,
-            "range": [
-              16,
-              17
-            ],
             "raw": "e",
+            "start": 16,
             "type": "Identifier"
           }
         ],
@@ -103,22 +92,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          17
-        ],
         "raw": "a < b < c < d < e",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "a < b < c < d < e",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-greater-than/output.json
+++ b/test/examples/chained-comparison-greater-than/output.json
@@ -1,49 +1,42 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "a > b > c",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 9,
         "line": 1,
         "operands": [
           {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           {
             "column": 5,
             "data": "b",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "b",
+            "start": 4,
             "type": "Identifier"
           },
           {
             "column": 9,
             "data": "c",
+            "end": 9,
             "line": 1,
-            "range": [
-              8,
-              9
-            ],
             "raw": "c",
+            "start": 8,
             "type": "Identifier"
           }
         ],
@@ -65,22 +58,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          9
-        ],
         "raw": "a > b > c",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "a > b > c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-less-than/output.json
+++ b/test/examples/chained-comparison-less-than/output.json
@@ -1,49 +1,42 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "a < b < c",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 9,
         "line": 1,
         "operands": [
           {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           {
             "column": 5,
             "data": "b",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "b",
+            "start": 4,
             "type": "Identifier"
           },
           {
             "column": 9,
             "data": "c",
+            "end": 9,
             "line": 1,
-            "range": [
-              8,
-              9
-            ],
             "raw": "c",
+            "start": 8,
             "type": "Identifier"
           }
         ],
@@ -65,22 +58,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          9
-        ],
         "raw": "a < b < c",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "a < b < c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-mixed/output.json
+++ b/test/examples/chained-comparison-mixed/output.json
@@ -1,49 +1,42 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "a < b > c",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 9,
         "line": 1,
         "operands": [
           {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           {
             "column": 5,
             "data": "b",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "b",
+            "start": 4,
             "type": "Identifier"
           },
           {
             "column": 9,
             "data": "c",
+            "end": 9,
             "line": 1,
-            "range": [
-              8,
-              9
-            ],
             "raw": "c",
+            "start": 8,
             "type": "Identifier"
           }
         ],
@@ -65,22 +58,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          9
-        ],
         "raw": "a < b > c",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "a < b > c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-nested/output.json
+++ b/test/examples/chained-comparison-nested/output.json
@@ -1,53 +1,47 @@
 {
   "body": {
     "column": 1,
+    "end": 23,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      23
-    ],
     "raw": "(a == b == c) == d == e",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 23,
         "line": 1,
         "operands": [
           {
             "column": 2,
+            "end": 12,
             "line": 1,
             "operands": [
               {
                 "column": 2,
                 "data": "a",
+                "end": 2,
                 "line": 1,
-                "range": [
-                  1,
-                  2
-                ],
                 "raw": "a",
+                "start": 1,
                 "type": "Identifier"
               },
               {
                 "column": 7,
                 "data": "b",
+                "end": 7,
                 "line": 1,
-                "range": [
-                  6,
-                  7
-                ],
                 "raw": "b",
+                "start": 6,
                 "type": "Identifier"
               },
               {
                 "column": 12,
                 "data": "c",
+                "end": 12,
                 "line": 1,
-                "range": [
-                  11,
-                  12
-                ],
                 "raw": "c",
+                "start": 11,
                 "type": "Identifier"
               }
             ],
@@ -69,33 +63,26 @@
                 }
               }
             ],
-            "range": [
-              1,
-              12
-            ],
             "raw": "a == b == c",
+            "start": 1,
             "type": "ChainedComparisonOp"
           },
           {
             "column": 18,
             "data": "d",
+            "end": 18,
             "line": 1,
-            "range": [
-              17,
-              18
-            ],
             "raw": "d",
+            "start": 17,
             "type": "Identifier"
           },
           {
             "column": 23,
             "data": "e",
+            "end": 23,
             "line": 1,
-            "range": [
-              22,
-              23
-            ],
             "raw": "e",
+            "start": 22,
             "type": "Identifier"
           }
         ],
@@ -117,22 +104,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          23
-        ],
         "raw": "(a == b == c) == d == e",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 24,
   "line": 1,
-  "range": [
-    0,
-    24
-  ],
   "raw": "(a == b == c) == d == e\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-not-equal/output.json
+++ b/test/examples/chained-comparison-not-equal/output.json
@@ -1,49 +1,42 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "a != b != c",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "line": 1,
         "operands": [
           {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           {
             "column": 6,
             "data": "b",
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "b",
+            "start": 5,
             "type": "Identifier"
           },
           {
             "column": 11,
             "data": "c",
+            "end": 11,
             "line": 1,
-            "range": [
-              10,
-              11
-            ],
             "raw": "c",
+            "start": 10,
             "type": "Identifier"
           }
         ],
@@ -65,22 +58,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "a != b != c",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "a != b != c\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-three/output.json
+++ b/test/examples/chained-comparison-three/output.json
@@ -1,60 +1,51 @@
 {
   "body": {
     "column": 1,
+    "end": 16,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      16
-    ],
     "raw": "a == b == c == d",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 16,
         "line": 1,
         "operands": [
           {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           {
             "column": 6,
             "data": "b",
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "b",
+            "start": 5,
             "type": "Identifier"
           },
           {
             "column": 11,
             "data": "c",
+            "end": 11,
             "line": 1,
-            "range": [
-              10,
-              11
-            ],
             "raw": "c",
+            "start": 10,
             "type": "Identifier"
           },
           {
             "column": 16,
             "data": "d",
+            "end": 16,
             "line": 1,
-            "range": [
-              15,
-              16
-            ],
             "raw": "d",
+            "start": 15,
             "type": "Identifier"
           }
         ],
@@ -84,22 +75,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          16
-        ],
         "raw": "a == b == c == d",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "a == b == c == d\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-with-increment/output.json
+++ b/test/examples/chained-comparison-with-increment/output.json
@@ -1,59 +1,50 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "0<++c<2",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "line": 1,
         "operands": [
           {
             "column": 1,
             "data": 0,
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "0",
+            "start": 0,
             "type": "Int"
           },
           {
             "column": 3,
+            "end": 5,
             "expression": {
               "column": 5,
               "data": "c",
+              "end": 5,
               "line": 1,
-              "range": [
-                4,
-                5
-              ],
               "raw": "c",
+              "start": 4,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              2,
-              5
-            ],
             "raw": "++c",
+            "start": 2,
             "type": "PreIncrementOp"
           },
           {
             "column": 7,
             "data": 2,
+            "end": 7,
             "line": 1,
-            "range": [
-              6,
-              7
-            ],
             "raw": "2",
+            "start": 6,
             "type": "Int"
           }
         ],
@@ -75,22 +66,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          7
-        ],
         "raw": "0<++c<2",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "0<++c<2\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-with-other-operators/output.json
+++ b/test/examples/chained-comparison-with-other-operators/output.json
@@ -1,154 +1,127 @@
 {
   "body": {
     "column": 1,
+    "end": 31,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      31
-    ],
     "raw": "Math.PI/2 < angle < 3*Math.PI/2",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 31,
         "line": 1,
         "operands": [
           {
             "column": 1,
+            "end": 9,
             "left": {
               "column": 1,
+              "end": 7,
               "expression": {
                 "column": 1,
                 "data": "Math",
+                "end": 4,
                 "line": 1,
-                "range": [
-                  0,
-                  4
-                ],
                 "raw": "Math",
+                "start": 0,
                 "type": "Identifier"
               },
               "line": 1,
               "member": {
                 "column": 6,
                 "data": "PI",
+                "end": 7,
                 "line": 1,
-                "range": [
-                  5,
-                  7
-                ],
                 "raw": "PI",
+                "start": 5,
                 "type": "Identifier"
               },
-              "range": [
-                0,
-                7
-              ],
               "raw": "Math.PI",
+              "start": 0,
               "type": "MemberAccessOp"
             },
             "line": 1,
-            "range": [
-              0,
-              9
-            ],
             "raw": "Math.PI/2",
             "right": {
               "column": 9,
               "data": 2,
+              "end": 9,
               "line": 1,
-              "range": [
-                8,
-                9
-              ],
               "raw": "2",
+              "start": 8,
               "type": "Int"
             },
+            "start": 0,
             "type": "DivideOp"
           },
           {
             "column": 13,
             "data": "angle",
+            "end": 17,
             "line": 1,
-            "range": [
-              12,
-              17
-            ],
             "raw": "angle",
+            "start": 12,
             "type": "Identifier"
           },
           {
             "column": 21,
+            "end": 31,
             "left": {
               "column": 21,
+              "end": 29,
               "left": {
                 "column": 21,
                 "data": 3,
+                "end": 21,
                 "line": 1,
-                "range": [
-                  20,
-                  21
-                ],
                 "raw": "3",
+                "start": 20,
                 "type": "Int"
               },
               "line": 1,
-              "range": [
-                20,
-                29
-              ],
               "raw": "3*Math.PI",
               "right": {
                 "column": 23,
+                "end": 29,
                 "expression": {
                   "column": 23,
                   "data": "Math",
+                  "end": 26,
                   "line": 1,
-                  "range": [
-                    22,
-                    26
-                  ],
                   "raw": "Math",
+                  "start": 22,
                   "type": "Identifier"
                 },
                 "line": 1,
                 "member": {
                   "column": 28,
                   "data": "PI",
+                  "end": 29,
                   "line": 1,
-                  "range": [
-                    27,
-                    29
-                  ],
                   "raw": "PI",
+                  "start": 27,
                   "type": "Identifier"
                 },
-                "range": [
-                  22,
-                  29
-                ],
                 "raw": "Math.PI",
+                "start": 22,
                 "type": "MemberAccessOp"
               },
+              "start": 20,
               "type": "MultiplyOp"
             },
             "line": 1,
-            "range": [
-              20,
-              31
-            ],
             "raw": "3*Math.PI/2",
             "right": {
               "column": 31,
               "data": 2,
+              "end": 31,
               "line": 1,
-              "range": [
-                30,
-                31
-              ],
               "raw": "2",
+              "start": 30,
               "type": "Int"
             },
+            "start": 20,
             "type": "DivideOp"
           }
         ],
@@ -170,22 +143,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          31
-        ],
         "raw": "Math.PI/2 < angle < 3*Math.PI/2",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 32,
   "line": 1,
-  "range": [
-    0,
-    32
-  ],
   "raw": "Math.PI/2 < angle < 3*Math.PI/2\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-comparison-with-unary-negate/output.json
+++ b/test/examples/chained-comparison-with-unary-negate/output.json
@@ -1,59 +1,50 @@
 {
   "body": {
     "column": 1,
+    "end": 10,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      10
-    ],
     "raw": "-1 < 0 < 1",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 10,
         "line": 1,
         "operands": [
           {
             "column": 1,
+            "end": 2,
             "expression": {
               "column": 2,
               "data": 1,
+              "end": 2,
               "line": 1,
-              "range": [
-                1,
-                2
-              ],
               "raw": "1",
+              "start": 1,
               "type": "Int"
             },
             "line": 1,
-            "range": [
-              0,
-              2
-            ],
             "raw": "-1",
+            "start": 0,
             "type": "UnaryNegateOp"
           },
           {
             "column": 6,
             "data": 0,
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "0",
+            "start": 5,
             "type": "Int"
           },
           {
             "column": 10,
             "data": 1,
+            "end": 10,
             "line": 1,
-            "range": [
-              9,
-              10
-            ],
             "raw": "1",
+            "start": 9,
             "type": "Int"
           }
         ],
@@ -75,22 +66,17 @@
             }
           }
         ],
-        "range": [
-          0,
-          10
-        ],
         "raw": "-1 < 0 < 1",
+        "start": 0,
         "type": "ChainedComparisonOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "-1 < 0 < 1\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/chained-prototype-member-access/output.json
+++ b/test/examples/chained-prototype-member-access/output.json
@@ -1,117 +1,95 @@
 {
   "body": {
     "column": 1,
+    "end": 37,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      37
-    ],
     "raw": "Object::toString.constructor::valueOf",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 37,
         "expression": {
           "column": 1,
+          "end": 30,
           "expression": {
             "column": 1,
+            "end": 28,
             "expression": {
               "column": 1,
+              "end": 16,
               "expression": {
                 "column": 1,
+                "end": 8,
                 "expression": {
                   "column": 1,
                   "data": "Object",
+                  "end": 6,
                   "line": 1,
-                  "range": [
-                    0,
-                    6
-                  ],
                   "raw": "Object",
+                  "start": 0,
                   "type": "Identifier"
                 },
                 "line": 1,
-                "range": [
-                  0,
-                  8
-                ],
                 "raw": "Object::",
+                "start": 0,
                 "type": "ProtoMemberAccessOp"
               },
               "line": 1,
               "member": {
                 "column": 9,
                 "data": "toString",
+                "end": 16,
                 "line": 1,
-                "range": [
-                  8,
-                  16
-                ],
                 "raw": "toString",
+                "start": 8,
                 "type": "Identifier"
               },
-              "range": [
-                0,
-                16
-              ],
               "raw": "Object::toString",
+              "start": 0,
               "type": "MemberAccessOp"
             },
             "line": 1,
             "member": {
               "column": 18,
               "data": "constructor",
+              "end": 28,
               "line": 1,
-              "range": [
-                17,
-                28
-              ],
               "raw": "constructor",
+              "start": 17,
               "type": "Identifier"
             },
-            "range": [
-              0,
-              28
-            ],
             "raw": "Object::toString.constructor",
+            "start": 0,
             "type": "MemberAccessOp"
           },
           "line": 1,
-          "range": [
-            0,
-            30
-          ],
           "raw": "Object::toString.constructor::",
+          "start": 0,
           "type": "ProtoMemberAccessOp"
         },
         "line": 1,
         "member": {
           "column": 31,
           "data": "valueOf",
+          "end": 37,
           "line": 1,
-          "range": [
-            30,
-            37
-          ],
           "raw": "valueOf",
+          "start": 30,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          37
-        ],
         "raw": "Object::toString.constructor::valueOf",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 38,
   "line": 1,
-  "range": [
-    0,
-    38
-  ],
   "raw": "Object::toString.constructor::valueOf\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-extends/output.json
+++ b/test/examples/class-extends/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "A extends B",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "left": {
           "column": 1,
           "data": "A",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "A",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          11
-        ],
         "raw": "A extends B",
         "right": {
           "column": 11,
           "data": "B",
+          "end": 11,
           "line": 1,
-          "range": [
-            10,
-            11
-          ],
           "raw": "B",
+          "start": 10,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "ExtendsOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "A extends B",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-member-with-block-comment/output.json
+++ b/test/examples/class-member-with-block-comment/output.json
@@ -1,57 +1,47 @@
 {
   "body": {
     "column": 1,
+    "end": 39,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      39
-    ],
     "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 39,
           "inline": false,
           "line": 2,
-          "range": [
-            12,
-            39
-          ],
           "raw": "###\n  # foo\n  ###\n  foo: ->",
+          "start": 12,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "foo",
+                "end": 35,
                 "line": 5,
-                "range": [
-                  32,
-                  35
-                ],
                 "raw": "foo",
+                "start": 32,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 39,
               "expression": {
                 "body": null,
                 "column": 8,
+                "end": 39,
                 "line": 5,
                 "parameters": [
                 ],
-                "range": [
-                  37,
-                  39
-                ],
                 "raw": "->",
+                "start": 37,
                 "type": "Function"
               },
               "line": 5,
-              "range": [
-                32,
-                39
-              ],
               "raw": "foo: ->",
+              "start": 32,
               "type": "ClassProtoAssignOp"
             }
           ],
@@ -61,46 +51,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 39,
         "line": 1,
         "name": {
           "column": 7,
           "data": "Foo",
+          "end": 9,
           "line": 1,
-          "range": [
-            6,
-            9
-          ],
           "raw": "Foo",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "Foo",
+          "end": 9,
           "line": 1,
-          "range": [
-            6,
-            9
-          ],
           "raw": "Foo",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          39
-        ],
         "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 39,
   "line": 1,
-  "range": [
-    0,
-    39
-  ],
   "raw": "class Foo\n  ###\n  # foo\n  ###\n  foo: ->",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-super-call/output.json
+++ b/test/examples/class-super-call/output.json
@@ -1,169 +1,139 @@
 {
   "body": {
     "column": 1,
+    "end": 76,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      76
-    ],
     "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 76,
           "inline": false,
           "line": 2,
-          "range": [
-            24,
-            76
-          ],
           "raw": "constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
+          "start": 24,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "constructor",
+                "end": 35,
                 "line": 2,
-                "range": [
-                  24,
-                  35
-                ],
                 "raw": "constructor",
+                "start": 24,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 49,
               "expression": {
                 "body": {
                   "column": 5,
+                  "end": 49,
                   "inline": false,
                   "line": 3,
-                  "range": [
-                    44,
-                    49
-                  ],
                   "raw": "super",
+                  "start": 44,
                   "statements": [
                     {
                       "column": 5,
+                      "end": 49,
                       "line": 3,
-                      "range": [
-                        44,
-                        49
-                      ],
                       "raw": "super",
+                      "start": 44,
                       "type": "BareSuperFunctionApplication"
                     }
                   ],
                   "type": "Block"
                 },
                 "column": 16,
+                "end": 49,
                 "line": 2,
                 "parameters": [
                 ],
-                "range": [
-                  37,
-                  49
-                ],
                 "raw": "->\n    super",
+                "start": 37,
                 "type": "Function"
               },
               "line": 2,
-              "range": [
-                24,
-                49
-              ],
               "raw": "constructor: ->\n    super",
+              "start": 24,
               "type": "Constructor"
             },
             {
               "assignee": {
                 "column": 3,
                 "data": "foo",
+                "end": 56,
                 "line": 5,
-                "range": [
-                  53,
-                  56
-                ],
                 "raw": "foo",
+                "start": 53,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 76,
               "expression": {
                 "body": {
                   "column": 5,
+                  "end": 76,
                   "inline": false,
                   "line": 6,
-                  "range": [
-                    65,
-                    76
-                  ],
                   "raw": "super(1, 2)",
+                  "start": 65,
                   "statements": [
                     {
                       "arguments": [
                         {
                           "column": 11,
                           "data": 1,
+                          "end": 72,
                           "line": 6,
-                          "range": [
-                            71,
-                            72
-                          ],
                           "raw": "1",
+                          "start": 71,
                           "type": "Int"
                         },
                         {
                           "column": 14,
                           "data": 2,
+                          "end": 75,
                           "line": 6,
-                          "range": [
-                            74,
-                            75
-                          ],
                           "raw": "2",
+                          "start": 74,
                           "type": "Int"
                         }
                       ],
                       "column": 5,
+                      "end": 76,
                       "function": {
                         "column": 5,
+                        "end": 70,
                         "line": 6,
-                        "range": [
-                          65,
-                          70
-                        ],
                         "raw": "super",
+                        "start": 65,
                         "type": "Super"
                       },
                       "line": 6,
-                      "range": [
-                        65,
-                        76
-                      ],
                       "raw": "super(1, 2)",
+                      "start": 65,
                       "type": "FunctionApplication"
                     }
                   ],
                   "type": "Block"
                 },
                 "column": 8,
+                "end": 76,
                 "line": 5,
                 "parameters": [
                 ],
-                "range": [
-                  58,
-                  76
-                ],
                 "raw": "->\n    super(1, 2)",
+                "start": 58,
                 "type": "Function"
               },
               "line": 5,
-              "range": [
-                53,
-                76
-              ],
               "raw": "foo: ->\n    super(1, 2)",
+              "start": 53,
               "type": "ClassProtoAssignOp"
             }
           ],
@@ -176,108 +146,88 @@
           "assignee": {
             "column": 3,
             "data": "constructor",
+            "end": 35,
             "line": 2,
-            "range": [
-              24,
-              35
-            ],
             "raw": "constructor",
+            "start": 24,
             "type": "Identifier"
           },
           "column": 3,
+          "end": 49,
           "expression": {
             "body": {
               "column": 5,
+              "end": 49,
               "inline": false,
               "line": 3,
-              "range": [
-                44,
-                49
-              ],
               "raw": "super",
+              "start": 44,
               "statements": [
                 {
                   "column": 5,
+                  "end": 49,
                   "line": 3,
-                  "range": [
-                    44,
-                    49
-                  ],
                   "raw": "super",
+                  "start": 44,
                   "type": "BareSuperFunctionApplication"
                 }
               ],
               "type": "Block"
             },
             "column": 16,
+            "end": 49,
             "line": 2,
             "parameters": [
             ],
-            "range": [
-              37,
-              49
-            ],
             "raw": "->\n    super",
+            "start": 37,
             "type": "Function"
           },
           "line": 2,
-          "range": [
-            24,
-            49
-          ],
           "raw": "constructor: ->\n    super",
+          "start": 24,
           "type": "Constructor"
         },
+        "end": 76,
         "line": 1,
         "name": {
           "column": 7,
           "data": "Foo",
+          "end": 9,
           "line": 1,
-          "range": [
-            6,
-            9
-          ],
           "raw": "Foo",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "Foo",
+          "end": 9,
           "line": 1,
-          "range": [
-            6,
-            9
-          ],
           "raw": "Foo",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": {
           "column": 19,
           "data": "Bar",
+          "end": 21,
           "line": 1,
-          "range": [
-            18,
-            21
-          ],
           "raw": "Bar",
+          "start": 18,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          76
-        ],
         "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 76,
   "line": 1,
-  "range": [
-    0,
-    76
-  ],
   "raw": "class Foo extends Bar\n  constructor: ->\n    super\n\n  foo: ->\n    super(1, 2)",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-body-statements/output.json
+++ b/test/examples/class-with-body-statements/output.json
@@ -1,87 +1,71 @@
 {
   "body": {
     "column": 1,
+    "end": 22,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      22
-    ],
     "raw": "class A\n  a = 1\n  b: a",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 22,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            22
-          ],
           "raw": "a = 1\n  b: a",
+          "start": 10,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "a",
+                "end": 11,
                 "line": 2,
-                "range": [
-                  10,
-                  11
-                ],
                 "raw": "a",
+                "start": 10,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 15,
               "expression": {
                 "column": 7,
                 "data": 1,
+                "end": 15,
                 "line": 2,
-                "range": [
-                  14,
-                  15
-                ],
                 "raw": "1",
+                "start": 14,
                 "type": "Int"
               },
               "line": 2,
-              "range": [
-                10,
-                15
-              ],
               "raw": "a = 1",
+              "start": 10,
               "type": "AssignOp"
             },
             {
               "assignee": {
                 "column": 3,
                 "data": "b",
+                "end": 19,
                 "line": 3,
-                "range": [
-                  18,
-                  19
-                ],
                 "raw": "b",
+                "start": 18,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 22,
               "expression": {
                 "column": 6,
                 "data": "a",
+                "end": 22,
                 "line": 3,
-                "range": [
-                  21,
-                  22
-                ],
                 "raw": "a",
+                "start": 21,
                 "type": "Identifier"
               },
               "line": 3,
-              "range": [
-                18,
-                22
-              ],
               "raw": "b: a",
+              "start": 18,
               "type": "ClassProtoAssignOp"
             }
           ],
@@ -91,46 +75,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 22,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          22
-        ],
         "raw": "class A\n  a = 1\n  b: a",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 22,
   "line": 1,
-  "range": [
-    0,
-    22
-  ],
   "raw": "class A\n  a = 1\n  b: a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-bound-methods/output.json
+++ b/test/examples/class-with-bound-methods/output.json
@@ -1,80 +1,66 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "class A\n  a: => b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 17,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            17
-          ],
           "raw": "a: => b",
+          "start": 10,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "a",
+                "end": 11,
                 "line": 2,
-                "range": [
-                  10,
-                  11
-                ],
                 "raw": "a",
+                "start": 10,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 17,
               "expression": {
                 "body": {
                   "column": 9,
+                  "end": 17,
                   "inline": true,
                   "line": 2,
-                  "range": [
-                    16,
-                    17
-                  ],
                   "raw": "b",
+                  "start": 16,
                   "statements": [
                     {
                       "column": 9,
                       "data": "b",
+                      "end": 17,
                       "line": 2,
-                      "range": [
-                        16,
-                        17
-                      ],
                       "raw": "b",
+                      "start": 16,
                       "type": "Identifier"
                     }
                   ],
                   "type": "Block"
                 },
                 "column": 6,
+                "end": 17,
                 "line": 2,
                 "parameters": [
                 ],
-                "range": [
-                  13,
-                  17
-                ],
                 "raw": "=> b",
+                "start": 13,
                 "type": "BoundFunction"
               },
               "line": 2,
-              "range": [
-                10,
-                17
-              ],
               "raw": "a: => b",
+              "start": 10,
               "type": "ClassProtoAssignOp"
             }
           ],
@@ -85,102 +71,84 @@
             "assignee": {
               "column": 3,
               "data": "a",
+              "end": 11,
               "line": 2,
-              "range": [
-                10,
-                11
-              ],
               "raw": "a",
+              "start": 10,
               "type": "Identifier"
             },
             "column": 3,
+            "end": 17,
             "expression": {
               "body": {
                 "column": 9,
+                "end": 17,
                 "inline": true,
                 "line": 2,
-                "range": [
-                  16,
-                  17
-                ],
                 "raw": "b",
+                "start": 16,
                 "statements": [
                   {
                     "column": 9,
                     "data": "b",
+                    "end": 17,
                     "line": 2,
-                    "range": [
-                      16,
-                      17
-                    ],
                     "raw": "b",
+                    "start": 16,
                     "type": "Identifier"
                   }
                 ],
                 "type": "Block"
               },
               "column": 6,
+              "end": 17,
               "line": 2,
               "parameters": [
               ],
-              "range": [
-                13,
-                17
-              ],
               "raw": "=> b",
+              "start": 13,
               "type": "BoundFunction"
             },
             "line": 2,
-            "range": [
-              10,
-              17
-            ],
             "raw": "a: => b",
+            "start": 10,
             "type": "ClassProtoAssignOp"
           }
         ],
         "column": 1,
         "ctor": null,
+        "end": 17,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          17
-        ],
         "raw": "class A\n  a: => b",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "class A\n  a: => b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-conditional-bound-method/output.json
+++ b/test/examples/class-with-conditional-bound-method/output.json
@@ -1,24 +1,20 @@
 {
   "body": {
     "column": 1,
+    "end": 26,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      26
-    ],
     "raw": "class A\n  if b\n    c: => d",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 26,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            26
-          ],
           "raw": "if b\n    c: => d",
+          "start": 10,
           "statements": [
             {
               "alternate": null,
@@ -26,91 +22,75 @@
               "condition": {
                 "column": 6,
                 "data": "b",
+                "end": 14,
                 "line": 2,
-                "range": [
-                  13,
-                  14
-                ],
                 "raw": "b",
+                "start": 13,
                 "type": "Identifier"
               },
               "consequent": {
                 "column": 5,
+                "end": 26,
                 "inline": false,
                 "line": 3,
-                "range": [
-                  19,
-                  26
-                ],
                 "raw": "c: => d",
+                "start": 19,
                 "statements": [
                   {
                     "assignee": {
                       "column": 5,
                       "data": "c",
+                      "end": 20,
                       "line": 3,
-                      "range": [
-                        19,
-                        20
-                      ],
                       "raw": "c",
+                      "start": 19,
                       "type": "Identifier"
                     },
                     "column": 5,
+                    "end": 26,
                     "expression": {
                       "body": {
                         "column": 11,
+                        "end": 26,
                         "inline": true,
                         "line": 3,
-                        "range": [
-                          25,
-                          26
-                        ],
                         "raw": "d",
+                        "start": 25,
                         "statements": [
                           {
                             "column": 11,
                             "data": "d",
+                            "end": 26,
                             "line": 3,
-                            "range": [
-                              25,
-                              26
-                            ],
                             "raw": "d",
+                            "start": 25,
                             "type": "Identifier"
                           }
                         ],
                         "type": "Block"
                       },
                       "column": 8,
+                      "end": 26,
                       "line": 3,
                       "parameters": [
                       ],
-                      "range": [
-                        22,
-                        26
-                      ],
                       "raw": "=> d",
+                      "start": 22,
                       "type": "BoundFunction"
                     },
                     "line": 3,
-                    "range": [
-                      19,
-                      26
-                    ],
                     "raw": "c: => d",
+                    "start": 19,
                     "type": "ClassProtoAssignOp"
                   }
                 ],
                 "type": "Block"
               },
+              "end": 26,
               "isUnless": false,
               "line": 2,
-              "range": [
-                10,
-                26
-              ],
               "raw": "if b\n    c: => d",
+              "start": 10,
               "type": "Conditional"
             }
           ],
@@ -121,102 +101,84 @@
             "assignee": {
               "column": 5,
               "data": "c",
+              "end": 20,
               "line": 3,
-              "range": [
-                19,
-                20
-              ],
               "raw": "c",
+              "start": 19,
               "type": "Identifier"
             },
             "column": 5,
+            "end": 26,
             "expression": {
               "body": {
                 "column": 11,
+                "end": 26,
                 "inline": true,
                 "line": 3,
-                "range": [
-                  25,
-                  26
-                ],
                 "raw": "d",
+                "start": 25,
                 "statements": [
                   {
                     "column": 11,
                     "data": "d",
+                    "end": 26,
                     "line": 3,
-                    "range": [
-                      25,
-                      26
-                    ],
                     "raw": "d",
+                    "start": 25,
                     "type": "Identifier"
                   }
                 ],
                 "type": "Block"
               },
               "column": 8,
+              "end": 26,
               "line": 3,
               "parameters": [
               ],
-              "range": [
-                22,
-                26
-              ],
               "raw": "=> d",
+              "start": 22,
               "type": "BoundFunction"
             },
             "line": 3,
-            "range": [
-              19,
-              26
-            ],
             "raw": "c: => d",
+            "start": 19,
             "type": "ClassProtoAssignOp"
           }
         ],
         "column": 1,
         "ctor": null,
+        "end": 26,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          26
-        ],
         "raw": "class A\n  if b\n    c: => d",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 27,
   "line": 1,
-  "range": [
-    0,
-    27
-  ],
   "raw": "class A\n  if b\n    c: => d\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-conditional-method/output.json
+++ b/test/examples/class-with-conditional-method/output.json
@@ -1,24 +1,20 @@
 {
   "body": {
     "column": 1,
+    "end": 26,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      26
-    ],
     "raw": "class A\n  if b\n    c: -> d",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 26,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            26
-          ],
           "raw": "if b\n    c: -> d",
+          "start": 10,
           "statements": [
             {
               "alternate": null,
@@ -26,91 +22,75 @@
               "condition": {
                 "column": 6,
                 "data": "b",
+                "end": 14,
                 "line": 2,
-                "range": [
-                  13,
-                  14
-                ],
                 "raw": "b",
+                "start": 13,
                 "type": "Identifier"
               },
               "consequent": {
                 "column": 5,
+                "end": 26,
                 "inline": false,
                 "line": 3,
-                "range": [
-                  19,
-                  26
-                ],
                 "raw": "c: -> d",
+                "start": 19,
                 "statements": [
                   {
                     "assignee": {
                       "column": 5,
                       "data": "c",
+                      "end": 20,
                       "line": 3,
-                      "range": [
-                        19,
-                        20
-                      ],
                       "raw": "c",
+                      "start": 19,
                       "type": "Identifier"
                     },
                     "column": 5,
+                    "end": 26,
                     "expression": {
                       "body": {
                         "column": 11,
+                        "end": 26,
                         "inline": true,
                         "line": 3,
-                        "range": [
-                          25,
-                          26
-                        ],
                         "raw": "d",
+                        "start": 25,
                         "statements": [
                           {
                             "column": 11,
                             "data": "d",
+                            "end": 26,
                             "line": 3,
-                            "range": [
-                              25,
-                              26
-                            ],
                             "raw": "d",
+                            "start": 25,
                             "type": "Identifier"
                           }
                         ],
                         "type": "Block"
                       },
                       "column": 8,
+                      "end": 26,
                       "line": 3,
                       "parameters": [
                       ],
-                      "range": [
-                        22,
-                        26
-                      ],
                       "raw": "-> d",
+                      "start": 22,
                       "type": "Function"
                     },
                     "line": 3,
-                    "range": [
-                      19,
-                      26
-                    ],
                     "raw": "c: -> d",
+                    "start": 19,
                     "type": "ClassProtoAssignOp"
                   }
                 ],
                 "type": "Block"
               },
+              "end": 26,
               "isUnless": false,
               "line": 2,
-              "range": [
-                10,
-                26
-              ],
               "raw": "if b\n    c: -> d",
+              "start": 10,
               "type": "Conditional"
             }
           ],
@@ -120,46 +100,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 26,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          26
-        ],
         "raw": "class A\n  if b\n    c: -> d",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 27,
   "line": 1,
-  "range": [
-    0,
-    27
-  ],
   "raw": "class A\n  if b\n    c: -> d\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-constructor/output.json
+++ b/test/examples/class-with-constructor/output.json
@@ -1,119 +1,97 @@
 {
   "body": {
     "column": 1,
+    "end": 38,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      38
-    ],
     "raw": "class Point\n  constructor: (@x, @y) ->",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 38,
           "inline": false,
           "line": 2,
-          "range": [
-            14,
-            38
-          ],
           "raw": "constructor: (@x, @y) ->",
+          "start": 14,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "constructor",
+                "end": 25,
                 "line": 2,
-                "range": [
-                  14,
-                  25
-                ],
                 "raw": "constructor",
+                "start": 14,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 38,
               "expression": {
                 "body": null,
                 "column": 16,
+                "end": 38,
                 "line": 2,
                 "parameters": [
                   {
                     "column": 17,
+                    "end": 30,
                     "expression": {
                       "column": 17,
+                      "end": 29,
                       "line": 2,
-                      "range": [
-                        28,
-                        29
-                      ],
                       "raw": "@",
+                      "start": 28,
                       "type": "This"
                     },
                     "line": 2,
                     "member": {
                       "column": 18,
                       "data": "x",
+                      "end": 30,
                       "line": 2,
-                      "range": [
-                        29,
-                        30
-                      ],
                       "raw": "x",
+                      "start": 29,
                       "type": "Identifier"
                     },
-                    "range": [
-                      28,
-                      30
-                    ],
                     "raw": "@x",
+                    "start": 28,
                     "type": "MemberAccessOp"
                   },
                   {
                     "column": 21,
+                    "end": 34,
                     "expression": {
                       "column": 21,
+                      "end": 33,
                       "line": 2,
-                      "range": [
-                        32,
-                        33
-                      ],
                       "raw": "@",
+                      "start": 32,
                       "type": "This"
                     },
                     "line": 2,
                     "member": {
                       "column": 22,
                       "data": "y",
+                      "end": 34,
                       "line": 2,
-                      "range": [
-                        33,
-                        34
-                      ],
                       "raw": "y",
+                      "start": 33,
                       "type": "Identifier"
                     },
-                    "range": [
-                      32,
-                      34
-                    ],
                     "raw": "@y",
+                    "start": 32,
                     "type": "MemberAccessOp"
                   }
                 ],
-                "range": [
-                  27,
-                  38
-                ],
                 "raw": "(@x, @y) ->",
+                "start": 27,
                 "type": "Function"
               },
               "line": 2,
-              "range": [
-                14,
-                38
-              ],
               "raw": "constructor: (@x, @y) ->",
+              "start": 14,
               "type": "Constructor"
             }
           ],
@@ -126,138 +104,112 @@
           "assignee": {
             "column": 3,
             "data": "constructor",
+            "end": 25,
             "line": 2,
-            "range": [
-              14,
-              25
-            ],
             "raw": "constructor",
+            "start": 14,
             "type": "Identifier"
           },
           "column": 3,
+          "end": 38,
           "expression": {
             "body": null,
             "column": 16,
+            "end": 38,
             "line": 2,
             "parameters": [
               {
                 "column": 17,
+                "end": 30,
                 "expression": {
                   "column": 17,
+                  "end": 29,
                   "line": 2,
-                  "range": [
-                    28,
-                    29
-                  ],
                   "raw": "@",
+                  "start": 28,
                   "type": "This"
                 },
                 "line": 2,
                 "member": {
                   "column": 18,
                   "data": "x",
+                  "end": 30,
                   "line": 2,
-                  "range": [
-                    29,
-                    30
-                  ],
                   "raw": "x",
+                  "start": 29,
                   "type": "Identifier"
                 },
-                "range": [
-                  28,
-                  30
-                ],
                 "raw": "@x",
+                "start": 28,
                 "type": "MemberAccessOp"
               },
               {
                 "column": 21,
+                "end": 34,
                 "expression": {
                   "column": 21,
+                  "end": 33,
                   "line": 2,
-                  "range": [
-                    32,
-                    33
-                  ],
                   "raw": "@",
+                  "start": 32,
                   "type": "This"
                 },
                 "line": 2,
                 "member": {
                   "column": 22,
                   "data": "y",
+                  "end": 34,
                   "line": 2,
-                  "range": [
-                    33,
-                    34
-                  ],
                   "raw": "y",
+                  "start": 33,
                   "type": "Identifier"
                 },
-                "range": [
-                  32,
-                  34
-                ],
                 "raw": "@y",
+                "start": 32,
                 "type": "MemberAccessOp"
               }
             ],
-            "range": [
-              27,
-              38
-            ],
             "raw": "(@x, @y) ->",
+            "start": 27,
             "type": "Function"
           },
           "line": 2,
-          "range": [
-            14,
-            38
-          ],
           "raw": "constructor: (@x, @y) ->",
+          "start": 14,
           "type": "Constructor"
         },
+        "end": 38,
         "line": 1,
         "name": {
           "column": 7,
           "data": "Point",
+          "end": 11,
           "line": 1,
-          "range": [
-            6,
-            11
-          ],
           "raw": "Point",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "Point",
+          "end": 11,
           "line": 1,
-          "range": [
-            6,
-            11
-          ],
           "raw": "Point",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          38
-        ],
         "raw": "class Point\n  constructor: (@x, @y) ->",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 39,
   "line": 1,
-  "range": [
-    0,
-    39
-  ],
   "raw": "class Point\n  constructor: (@x, @y) ->\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-explicit-object-literal/output.json
+++ b/test/examples/class-with-explicit-object-literal/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 16,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      16
-    ],
     "raw": "class A\n  {b: c}",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 16,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            16
-          ],
           "raw": "{b: c}",
+          "start": 10,
           "statements": [
             {
               "column": 3,
+              "end": 16,
               "line": 2,
               "members": [
                 {
                   "column": 4,
+                  "end": 15,
                   "expression": {
                     "column": 7,
                     "data": "c",
+                    "end": 15,
                     "line": 2,
-                    "range": [
-                      14,
-                      15
-                    ],
                     "raw": "c",
+                    "start": 14,
                     "type": "Identifier"
                   },
                   "key": {
                     "column": 4,
                     "data": "b",
+                    "end": 12,
                     "line": 2,
-                    "range": [
-                      11,
-                      12
-                    ],
                     "raw": "b",
+                    "start": 11,
                     "type": "Identifier"
                   },
                   "line": 2,
-                  "range": [
-                    11,
-                    15
-                  ],
                   "raw": "b: c",
+                  "start": 11,
                   "type": "ObjectInitialiserMember"
                 }
               ],
-              "range": [
-                10,
-                16
-              ],
               "raw": "{b: c}",
+              "start": 10,
               "type": "ObjectInitialiser"
             }
           ],
@@ -71,46 +59,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 16,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          16
-        ],
         "raw": "class A\n  {b: c}",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "class A\n  {b: c}\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-implicit-object-literal-within-function/output.json
+++ b/test/examples/class-with-implicit-object-literal-within-function/output.json
@@ -1,134 +1,110 @@
 {
   "body": {
     "column": 1,
+    "end": 38,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      38
-    ],
     "raw": "class A\n  b = ->\n    c: d\n    return 1",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 38,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            38
-          ],
           "raw": "b = ->\n    c: d\n    return 1",
+          "start": 10,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "b",
+                "end": 11,
                 "line": 2,
-                "range": [
-                  10,
-                  11
-                ],
                 "raw": "b",
+                "start": 10,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 38,
               "expression": {
                 "body": {
                   "column": 5,
+                  "end": 38,
                   "inline": false,
                   "line": 3,
-                  "range": [
-                    21,
-                    38
-                  ],
                   "raw": "c: d\n    return 1",
+                  "start": 21,
                   "statements": [
                     {
                       "column": 5,
+                      "end": 25,
                       "line": 3,
                       "members": [
                         {
                           "column": 5,
+                          "end": 25,
                           "expression": {
                             "column": 8,
                             "data": "d",
+                            "end": 25,
                             "line": 3,
-                            "range": [
-                              24,
-                              25
-                            ],
                             "raw": "d",
+                            "start": 24,
                             "type": "Identifier"
                           },
                           "key": {
                             "column": 5,
                             "data": "c",
+                            "end": 22,
                             "line": 3,
-                            "range": [
-                              21,
-                              22
-                            ],
                             "raw": "c",
+                            "start": 21,
                             "type": "Identifier"
                           },
                           "line": 3,
-                          "range": [
-                            21,
-                            25
-                          ],
                           "raw": "c: d",
+                          "start": 21,
                           "type": "ObjectInitialiserMember"
                         }
                       ],
-                      "range": [
-                        21,
-                        25
-                      ],
                       "raw": "c: d",
+                      "start": 21,
                       "type": "ObjectInitialiser"
                     },
                     {
                       "column": 5,
+                      "end": 38,
                       "expression": {
                         "column": 12,
                         "data": 1,
+                        "end": 38,
                         "line": 4,
-                        "range": [
-                          37,
-                          38
-                        ],
                         "raw": "1",
+                        "start": 37,
                         "type": "Int"
                       },
                       "line": 4,
-                      "range": [
-                        30,
-                        38
-                      ],
                       "raw": "return 1",
+                      "start": 30,
                       "type": "Return"
                     }
                   ],
                   "type": "Block"
                 },
                 "column": 7,
+                "end": 38,
                 "line": 2,
                 "parameters": [
                 ],
-                "range": [
-                  14,
-                  38
-                ],
                 "raw": "->\n    c: d\n    return 1",
+                "start": 14,
                 "type": "Function"
               },
               "line": 2,
-              "range": [
-                10,
-                38
-              ],
               "raw": "b = ->\n    c: d\n    return 1",
+              "start": 10,
               "type": "AssignOp"
             }
           ],
@@ -138,46 +114,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 38,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          38
-        ],
         "raw": "class A\n  b = ->\n    c: d\n    return 1",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 39,
   "line": 1,
-  "range": [
-    0,
-    39
-  ],
   "raw": "class A\n  b = ->\n    c: d\n    return 1\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-members/output.json
+++ b/test/examples/class-with-members/output.json
@@ -1,112 +1,92 @@
 {
   "body": {
     "column": 1,
+    "end": 24,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      24
-    ],
     "raw": "class A\n  a: 1\n  b: -> 2",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 24,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            24
-          ],
           "raw": "a: 1\n  b: -> 2",
+          "start": 10,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "a",
+                "end": 11,
                 "line": 2,
-                "range": [
-                  10,
-                  11
-                ],
                 "raw": "a",
+                "start": 10,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 14,
               "expression": {
                 "column": 6,
                 "data": 1,
+                "end": 14,
                 "line": 2,
-                "range": [
-                  13,
-                  14
-                ],
                 "raw": "1",
+                "start": 13,
                 "type": "Int"
               },
               "line": 2,
-              "range": [
-                10,
-                14
-              ],
               "raw": "a: 1",
+              "start": 10,
               "type": "ClassProtoAssignOp"
             },
             {
               "assignee": {
                 "column": 3,
                 "data": "b",
+                "end": 18,
                 "line": 3,
-                "range": [
-                  17,
-                  18
-                ],
                 "raw": "b",
+                "start": 17,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 24,
               "expression": {
                 "body": {
                   "column": 9,
+                  "end": 24,
                   "inline": true,
                   "line": 3,
-                  "range": [
-                    23,
-                    24
-                  ],
                   "raw": "2",
+                  "start": 23,
                   "statements": [
                     {
                       "column": 9,
                       "data": 2,
+                      "end": 24,
                       "line": 3,
-                      "range": [
-                        23,
-                        24
-                      ],
                       "raw": "2",
+                      "start": 23,
                       "type": "Int"
                     }
                   ],
                   "type": "Block"
                 },
                 "column": 6,
+                "end": 24,
                 "line": 3,
                 "parameters": [
                 ],
-                "range": [
-                  20,
-                  24
-                ],
                 "raw": "-> 2",
+                "start": 20,
                 "type": "Function"
               },
               "line": 3,
-              "range": [
-                17,
-                24
-              ],
               "raw": "b: -> 2",
+              "start": 17,
               "type": "ClassProtoAssignOp"
             }
           ],
@@ -116,46 +96,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 24,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          24
-        ],
         "raw": "class A\n  a: 1\n  b: -> 2",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 24,
   "line": 1,
-  "range": [
-    0,
-    24
-  ],
   "raw": "class A\n  a: 1\n  b: -> 2",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-outer-assign-blocking-conditional-assign/output.json
+++ b/test/examples/class-with-outer-assign-blocking-conditional-assign/output.json
@@ -1,24 +1,20 @@
 {
   "body": {
     "column": 1,
+    "end": 30,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      30
-    ],
     "raw": "class A\n  if b\n    c: d\n  e: f",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 30,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            30
-          ],
           "raw": "if b\n    c: d\n  e: f",
+          "start": 10,
           "statements": [
             {
               "alternate": null,
@@ -26,110 +22,90 @@
               "condition": {
                 "column": 6,
                 "data": "b",
+                "end": 14,
                 "line": 2,
-                "range": [
-                  13,
-                  14
-                ],
                 "raw": "b",
+                "start": 13,
                 "type": "Identifier"
               },
               "consequent": {
                 "column": 5,
+                "end": 23,
                 "inline": false,
                 "line": 3,
-                "range": [
-                  19,
-                  23
-                ],
                 "raw": "c: d",
+                "start": 19,
                 "statements": [
                   {
                     "column": 5,
+                    "end": 23,
                     "line": 3,
                     "members": [
                       {
                         "column": 5,
+                        "end": 23,
                         "expression": {
                           "column": 8,
                           "data": "d",
+                          "end": 23,
                           "line": 3,
-                          "range": [
-                            22,
-                            23
-                          ],
                           "raw": "d",
+                          "start": 22,
                           "type": "Identifier"
                         },
                         "key": {
                           "column": 5,
                           "data": "c",
+                          "end": 20,
                           "line": 3,
-                          "range": [
-                            19,
-                            20
-                          ],
                           "raw": "c",
+                          "start": 19,
                           "type": "Identifier"
                         },
                         "line": 3,
-                        "range": [
-                          19,
-                          23
-                        ],
                         "raw": "c: d",
+                        "start": 19,
                         "type": "ObjectInitialiserMember"
                       }
                     ],
-                    "range": [
-                      19,
-                      23
-                    ],
                     "raw": "c: d",
+                    "start": 19,
                     "type": "ObjectInitialiser"
                   }
                 ],
                 "type": "Block"
               },
+              "end": 23,
               "isUnless": false,
               "line": 2,
-              "range": [
-                10,
-                23
-              ],
               "raw": "if b\n    c: d",
+              "start": 10,
               "type": "Conditional"
             },
             {
               "assignee": {
                 "column": 3,
                 "data": "e",
+                "end": 27,
                 "line": 4,
-                "range": [
-                  26,
-                  27
-                ],
                 "raw": "e",
+                "start": 26,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 30,
               "expression": {
                 "column": 6,
                 "data": "f",
+                "end": 30,
                 "line": 4,
-                "range": [
-                  29,
-                  30
-                ],
                 "raw": "f",
+                "start": 29,
                 "type": "Identifier"
               },
               "line": 4,
-              "range": [
-                26,
-                30
-              ],
               "raw": "e: f",
+              "start": 26,
               "type": "ClassProtoAssignOp"
             }
           ],
@@ -139,46 +115,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 30,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          30
-        ],
         "raw": "class A\n  if b\n    c: d\n  e: f",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 31,
   "line": 1,
-  "range": [
-    0,
-    31
-  ],
   "raw": "class A\n  if b\n    c: d\n  e: f\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-parenthesized-value/output.json
+++ b/test/examples/class-with-parenthesized-value/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 16,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      16
-    ],
     "raw": "class A\n  b: (c)",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 16,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            16
-          ],
           "raw": "b: (c)",
+          "start": 10,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "b",
+                "end": 11,
                 "line": 2,
-                "range": [
-                  10,
-                  11
-                ],
                 "raw": "b",
+                "start": 10,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 16,
               "expression": {
                 "column": 7,
                 "data": "c",
+                "end": 15,
                 "line": 2,
-                "range": [
-                  14,
-                  15
-                ],
                 "raw": "c",
+                "start": 14,
                 "type": "Identifier"
               },
               "line": 2,
-              "range": [
-                10,
-                16
-              ],
               "raw": "b: (c)",
+              "start": 10,
               "type": "ClassProtoAssignOp"
             }
           ],
@@ -59,46 +49,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 16,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          16
-        ],
         "raw": "class A\n  b: (c)",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "class A\n  b: (c)\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-proto-access-name/output.json
+++ b/test/examples/class-with-proto-access-name/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "class A::",
+    "start": 0,
     "statements": [
       {
         "body": null,
@@ -15,66 +13,54 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 9,
         "line": 1,
         "name": {
           "column": 7,
+          "end": 9,
           "expression": {
             "column": 7,
             "data": "A",
+            "end": 7,
             "line": 1,
-            "range": [
-              6,
-              7
-            ],
             "raw": "A",
+            "start": 6,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            6,
-            9
-          ],
           "raw": "A::",
+          "start": 6,
           "type": "ProtoMemberAccessOp"
         },
         "nameAssignee": {
           "column": 7,
+          "end": 9,
           "expression": {
             "column": 7,
             "data": "A",
+            "end": 7,
             "line": 1,
-            "range": [
-              6,
-              7
-            ],
             "raw": "A",
+            "start": 6,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            6,
-            9
-          ],
           "raw": "A::",
+          "start": 6,
           "type": "ProtoMemberAccessOp"
         },
         "parent": null,
-        "range": [
-          0,
-          9
-        ],
         "raw": "class A::",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "class A::\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/class-with-static-members/output.json
+++ b/test/examples/class-with-static-members/output.json
@@ -1,75 +1,61 @@
 {
   "body": {
     "column": 1,
+    "end": 15,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      15
-    ],
     "raw": "class A\n  @b: c",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 15,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            15
-          ],
           "raw": "@b: c",
+          "start": 10,
           "statements": [
             {
               "assignee": {
                 "column": 3,
+                "end": 12,
                 "expression": {
                   "column": 3,
+                  "end": 11,
                   "line": 2,
-                  "range": [
-                    10,
-                    11
-                  ],
                   "raw": "@",
+                  "start": 10,
                   "type": "This"
                 },
                 "line": 2,
                 "member": {
                   "column": 4,
                   "data": "b",
+                  "end": 12,
                   "line": 2,
-                  "range": [
-                    11,
-                    12
-                  ],
                   "raw": "b",
+                  "start": 11,
                   "type": "Identifier"
                 },
-                "range": [
-                  10,
-                  12
-                ],
                 "raw": "@b",
+                "start": 10,
                 "type": "MemberAccessOp"
               },
               "column": 3,
+              "end": 15,
               "expression": {
                 "column": 7,
                 "data": "c",
+                "end": 15,
                 "line": 2,
-                "range": [
-                  14,
-                  15
-                ],
                 "raw": "c",
+                "start": 14,
                 "type": "Identifier"
               },
               "line": 2,
-              "range": [
-                10,
-                15
-              ],
               "raw": "@b: c",
+              "start": 10,
               "type": "AssignOp"
             }
           ],
@@ -79,46 +65,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 15,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          15
-        ],
         "raw": "class A\n  @b: c",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 15,
   "line": 1,
-  "range": [
-    0,
-    15
-  ],
   "raw": "class A\n  @b: c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/comment-only-file/output.json
+++ b/test/examples/comment-only-file/output.json
@@ -1,11 +1,9 @@
 {
   "body": null,
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "# Testing\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/complex-template-literal/output.json
+++ b/test/examples/complex-template-literal/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 21,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      21
-    ],
     "raw": "\"#{}A#{} #{} #{}B#{}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 21,
         "expressions": [
           null,
           null,
@@ -23,86 +22,69 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 5,
             "data": "A",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "A",
+            "start": 4,
             "type": "Quasi"
           },
           {
             "column": 9,
             "data": " ",
+            "end": 9,
             "line": 1,
-            "range": [
-              8,
-              9
-            ],
             "raw": " ",
+            "start": 8,
             "type": "Quasi"
           },
           {
             "column": 13,
             "data": " ",
+            "end": 13,
             "line": 1,
-            "range": [
-              12,
-              13
-            ],
             "raw": " ",
+            "start": 12,
             "type": "Quasi"
           },
           {
             "column": 17,
             "data": "B",
+            "end": 17,
             "line": 1,
-            "range": [
-              16,
-              17
-            ],
             "raw": "B",
+            "start": 16,
             "type": "Quasi"
           },
           {
             "column": 21,
             "data": "",
+            "end": 20,
             "line": 1,
-            "range": [
-              20,
-              20
-            ],
             "raw": "",
+            "start": 20,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          21
-        ],
         "raw": "\"#{}A#{} #{} #{}B#{}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 22,
   "line": 1,
-  "range": [
-    0,
-    22
-  ],
   "raw": "\"#{}A#{} #{} #{}B#{}\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/compound-assignment-addition/output.json
+++ b/test/examples/compound-assignment-addition/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a += 1",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 6,
         "expression": {
           "column": 6,
           "data": 1,
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "1",
+          "start": 5,
           "type": "Int"
         },
         "line": 1,
         "op": "PlusOp",
-        "range": [
-          0,
-          6
-        ],
         "raw": "a += 1",
+        "start": 0,
         "type": "CompoundAssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a += 1",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/compound-assignment-subtraction/output.json
+++ b/test/examples/compound-assignment-subtraction/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a -= b",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 6,
         "expression": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
         "line": 1,
         "op": "SubtractOp",
-        "range": [
-          0,
-          6
-        ],
         "raw": "a -= b",
+        "start": 0,
         "type": "CompoundAssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a -= b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-empty-consequent-alternate/output.json
+++ b/test/examples/conditional-empty-consequent-alternate/output.json
@@ -1,24 +1,20 @@
 {
   "body": {
     "column": 1,
+    "end": 27,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      27
-    ],
     "raw": "if false\nelse if false\nelse",
+    "start": 0,
     "statements": [
       {
         "alternate": {
           "column": 6,
+          "end": 27,
           "inline": true,
           "line": 2,
-          "range": [
-            14,
-            27
-          ],
           "raw": "if false\nelse",
+          "start": 14,
           "statements": [
             {
               "alternate": null,
@@ -26,22 +22,18 @@
               "condition": {
                 "column": 9,
                 "data": false,
+                "end": 22,
                 "line": 2,
-                "range": [
-                  17,
-                  22
-                ],
                 "raw": "false",
+                "start": 17,
                 "type": "Bool"
               },
               "consequent": null,
+              "end": 27,
               "isUnless": false,
               "line": 2,
-              "range": [
-                14,
-                27
-              ],
               "raw": "if false\nelse",
+              "start": 14,
               "type": "Conditional"
             }
           ],
@@ -51,33 +43,27 @@
         "condition": {
           "column": 4,
           "data": false,
+          "end": 8,
           "line": 1,
-          "range": [
-            3,
-            8
-          ],
           "raw": "false",
+          "start": 3,
           "type": "Bool"
         },
         "consequent": null,
+        "end": 27,
         "isUnless": false,
         "line": 1,
-        "range": [
-          0,
-          27
-        ],
         "raw": "if false\nelse if false\nelse",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 27,
   "line": 1,
-  "range": [
-    0,
-    27
-  ],
   "raw": "if false\nelse if false\nelse",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-ending-in-semicolon/output.json
+++ b/test/examples/conditional-ending-in-semicolon/output.json
@@ -1,80 +1,66 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "x = if a\n  ;",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "x",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "x",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 12,
         "expression": {
           "alternate": null,
           "column": 5,
           "condition": {
             "column": 8,
             "data": "a",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "a",
+            "start": 7,
             "type": "Identifier"
           },
           "consequent": {
             "column": 1,
+            "end": 12,
             "inline": false,
             "line": 2,
-            "range": [
-              11,
-              12
-            ],
             "raw": ";",
+            "start": 11,
             "statements": [
             ],
             "type": "Block"
           },
+          "end": 12,
           "isUnless": false,
           "line": 1,
-          "range": [
-            4,
-            12
-          ],
           "raw": "if a\n  ;",
+          "start": 4,
           "type": "Conditional"
         },
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "x = if a\n  ;",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "x = if a\n  ;\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-on-one-line/output.json
+++ b/test/examples/conditional-on-one-line/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      18
-    ],
     "raw": "if a then b else c",
+    "start": 0,
     "statements": [
       {
         "alternate": {
           "column": 18,
+          "end": 18,
           "inline": true,
           "line": 1,
-          "range": [
-            17,
-            18
-          ],
           "raw": "c",
+          "start": 17,
           "statements": [
             {
               "column": 18,
               "data": "c",
+              "end": 18,
               "line": 1,
-              "range": [
-                17,
-                18
-              ],
               "raw": "c",
+              "start": 17,
               "type": "Identifier"
             }
           ],
@@ -38,56 +32,46 @@
         "condition": {
           "column": 4,
           "data": "a",
+          "end": 4,
           "line": 1,
-          "range": [
-            3,
-            4
-          ],
           "raw": "a",
+          "start": 3,
           "type": "Identifier"
         },
         "consequent": {
           "column": 11,
+          "end": 11,
           "inline": true,
           "line": 1,
-          "range": [
-            10,
-            11
-          ],
           "raw": "b",
+          "start": 10,
           "statements": [
             {
               "column": 11,
               "data": "b",
+              "end": 11,
               "line": 1,
-              "range": [
-                10,
-                11
-              ],
               "raw": "b",
+              "start": 10,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 18,
         "isUnless": false,
         "line": 1,
-        "range": [
-          0,
-          18
-        ],
         "raw": "if a then b else c",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "if a then b else c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-unless-equal-condition/output.json
+++ b/test/examples/conditional-unless-equal-condition/output.json
@@ -1,91 +1,75 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "unless a == b\n  c",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
         "column": 1,
         "condition": {
           "column": 8,
+          "end": 13,
           "left": {
             "column": 8,
             "data": "a",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "a",
+            "start": 7,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            7,
-            13
-          ],
           "raw": "a == b",
           "right": {
             "column": 13,
             "data": "b",
+            "end": 13,
             "line": 1,
-            "range": [
-              12,
-              13
-            ],
             "raw": "b",
+            "start": 12,
             "type": "Identifier"
           },
+          "start": 7,
           "type": "EQOp"
         },
         "consequent": {
           "column": 3,
+          "end": 17,
           "inline": false,
           "line": 2,
-          "range": [
-            16,
-            17
-          ],
           "raw": "c",
+          "start": 16,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 17,
               "line": 2,
-              "range": [
-                16,
-                17
-              ],
               "raw": "c",
+              "start": 16,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 17,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          17
-        ],
         "raw": "unless a == b\n  c",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "unless a == b\n  c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-unless-exists-op/output.json
+++ b/test/examples/conditional-unless-exists-op/output.json
@@ -1,80 +1,66 @@
 {
   "body": {
     "column": 1,
+    "end": 13,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      13
-    ],
     "raw": "unless a?\n  b",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
         "column": 1,
         "condition": {
           "column": 8,
+          "end": 9,
           "expression": {
             "column": 8,
             "data": "a",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "a",
+            "start": 7,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            7,
-            9
-          ],
           "raw": "a?",
+          "start": 7,
           "type": "UnaryExistsOp"
         },
         "consequent": {
           "column": 3,
+          "end": 13,
           "inline": false,
           "line": 2,
-          "range": [
-            12,
-            13
-          ],
           "raw": "b",
+          "start": 12,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 13,
               "line": 2,
-              "range": [
-                12,
-                13
-              ],
               "raw": "b",
+              "start": 12,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 13,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          13
-        ],
         "raw": "unless a?\n  b",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "unless a?\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-unless-virtual-parens/output.json
+++ b/test/examples/conditional-unless-virtual-parens/output.json
@@ -1,91 +1,75 @@
 {
   "body": {
     "column": 1,
+    "end": 16,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      16
-    ],
     "raw": "unless a + b\n  c",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
         "column": 1,
         "condition": {
           "column": 8,
+          "end": 12,
           "left": {
             "column": 8,
             "data": "a",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "a",
+            "start": 7,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            7,
-            12
-          ],
           "raw": "a + b",
           "right": {
             "column": 12,
             "data": "b",
+            "end": 12,
             "line": 1,
-            "range": [
-              11,
-              12
-            ],
             "raw": "b",
+            "start": 11,
             "type": "Identifier"
           },
+          "start": 7,
           "type": "PlusOp"
         },
         "consequent": {
           "column": 3,
+          "end": 16,
           "inline": false,
           "line": 2,
-          "range": [
-            15,
-            16
-          ],
           "raw": "c",
+          "start": 15,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 16,
               "line": 2,
-              "range": [
-                15,
-                16
-              ],
               "raw": "c",
+              "start": 15,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 16,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          16
-        ],
         "raw": "unless a + b\n  c",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 16,
   "line": 1,
-  "range": [
-    0,
-    16
-  ],
   "raw": "unless a + b\n  c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-using-unless/output.json
+++ b/test/examples/conditional-using-unless/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "unless a\n  b",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
@@ -15,56 +13,46 @@
         "condition": {
           "column": 8,
           "data": "a",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "a",
+          "start": 7,
           "type": "Identifier"
         },
         "consequent": {
           "column": 3,
+          "end": 12,
           "inline": false,
           "line": 2,
-          "range": [
-            11,
-            12
-          ],
           "raw": "b",
+          "start": 11,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 12,
               "line": 2,
-              "range": [
-                11,
-                12
-              ],
               "raw": "b",
+              "start": 11,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 12,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "unless a\n  b",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "unless a\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-with-alternate/output.json
+++ b/test/examples/conditional-with-alternate/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "if a\n  b\nelse\n  c",
+    "start": 0,
     "statements": [
       {
         "alternate": {
           "column": 3,
+          "end": 17,
           "inline": false,
           "line": 4,
-          "range": [
-            16,
-            17
-          ],
           "raw": "c",
+          "start": 16,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 17,
               "line": 4,
-              "range": [
-                16,
-                17
-              ],
               "raw": "c",
+              "start": 16,
               "type": "Identifier"
             }
           ],
@@ -38,56 +32,46 @@
         "condition": {
           "column": 4,
           "data": "a",
+          "end": 4,
           "line": 1,
-          "range": [
-            3,
-            4
-          ],
           "raw": "a",
+          "start": 3,
           "type": "Identifier"
         },
         "consequent": {
           "column": 3,
+          "end": 8,
           "inline": false,
           "line": 2,
-          "range": [
-            7,
-            8
-          ],
           "raw": "b",
+          "start": 7,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 8,
               "line": 2,
-              "range": [
-                7,
-                8
-              ],
               "raw": "b",
+              "start": 7,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 17,
         "isUnless": false,
         "line": 1,
-        "range": [
-          0,
-          17
-        ],
         "raw": "if a\n  b\nelse\n  c",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "if a\n  b\nelse\n  c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-with-braces-on-one-line/output.json
+++ b/test/examples/conditional-with-braces-on-one-line/output.json
@@ -1,91 +1,75 @@
 {
   "body": {
     "column": 1,
+    "end": 14,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      14
-    ],
     "raw": "a if (b and c)",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
         "column": 1,
         "condition": {
           "column": 7,
+          "end": 13,
           "left": {
             "column": 7,
             "data": "b",
+            "end": 7,
             "line": 1,
-            "range": [
-              6,
-              7
-            ],
             "raw": "b",
+            "start": 6,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            6,
-            13
-          ],
           "raw": "b and c",
           "right": {
             "column": 13,
             "data": "c",
+            "end": 13,
             "line": 1,
-            "range": [
-              12,
-              13
-            ],
             "raw": "c",
+            "start": 12,
             "type": "Identifier"
           },
+          "start": 6,
           "type": "LogicalAndOp"
         },
         "consequent": {
           "column": 1,
+          "end": 1,
           "inline": true,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "statements": [
             {
               "column": 1,
               "data": "a",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "a",
+              "start": 0,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 14,
         "isUnless": false,
         "line": 1,
-        "range": [
-          0,
-          14
-        ],
         "raw": "a if (b and c)",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 15,
   "line": 1,
-  "range": [
-    0,
-    15
-  ],
   "raw": "a if (b and c)\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-with-post-if/output.json
+++ b/test/examples/conditional-with-post-if/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a if b",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
@@ -15,56 +13,46 @@
         "condition": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
         "consequent": {
           "column": 1,
+          "end": 1,
           "inline": true,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "statements": [
             {
               "column": 1,
               "data": "a",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "a",
+              "start": 0,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 6,
         "isUnless": false,
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a if b",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a if b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-with-post-unless/output.json
+++ b/test/examples/conditional-with-post-unless/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 10,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      10
-    ],
     "raw": "a unless b",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
@@ -15,56 +13,46 @@
         "condition": {
           "column": 10,
           "data": "b",
+          "end": 10,
           "line": 1,
-          "range": [
-            9,
-            10
-          ],
           "raw": "b",
+          "start": 9,
           "type": "Identifier"
         },
         "consequent": {
           "column": 1,
+          "end": 1,
           "inline": true,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "statements": [
             {
               "column": 1,
               "data": "a",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "a",
+              "start": 0,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 10,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          10
-        ],
         "raw": "a unless b",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "a unless b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/conditional-without-alternate/output.json
+++ b/test/examples/conditional-without-alternate/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "if a\n  b",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
@@ -15,56 +13,46 @@
         "condition": {
           "column": 4,
           "data": "a",
+          "end": 4,
           "line": 1,
-          "range": [
-            3,
-            4
-          ],
           "raw": "a",
+          "start": 3,
           "type": "Identifier"
         },
         "consequent": {
           "column": 3,
+          "end": 8,
           "inline": false,
           "line": 2,
-          "range": [
-            7,
-            8
-          ],
           "raw": "b",
+          "start": 7,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 8,
               "line": 2,
-              "range": [
-                7,
-                8
-              ],
               "raw": "b",
+              "start": 7,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 8,
         "isUnless": false,
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "if a\n  b",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "if a\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/continue/output.json
+++ b/test/examples/continue/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 15,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      15
-    ],
     "raw": "loop\n  continue",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 15,
           "inline": false,
           "line": 2,
-          "range": [
-            7,
-            15
-          ],
           "raw": "continue",
+          "start": 7,
           "statements": [
             {
               "column": 3,
+              "end": 15,
               "line": 2,
-              "range": [
-                7,
-                15
-              ],
               "raw": "continue",
+              "start": 7,
               "type": "Continue"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 15,
         "line": 1,
-        "range": [
-          0,
-          15
-        ],
         "raw": "loop\n  continue",
+        "start": 0,
         "type": "Loop"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 16,
   "line": 1,
-  "range": [
-    0,
-    16
-  ],
   "raw": "loop\n  continue\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/dangling-prototype-access-of-call/output.json
+++ b/test/examples/dangling-prototype-access-of-call/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a()::",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expression": {
           "arguments": [
           ],
           "column": 1,
+          "end": 3,
           "function": {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            0,
-            3
-          ],
           "raw": "a()",
+          "start": 0,
           "type": "FunctionApplication"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a()::",
+        "start": 0,
         "type": "ProtoMemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a()::\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/dangling-prototype-access/output.json
+++ b/test/examples/dangling-prototype-access/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "Object::",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 8,
         "expression": {
           "column": 1,
           "data": "Object",
+          "end": 6,
           "line": 1,
-          "range": [
-            0,
-            6
-          ],
           "raw": "Object",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "Object::",
+        "start": 0,
         "type": "ProtoMemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "Object::\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/delete/output.json
+++ b/test/examples/delete/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "delete a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 8,
         "expression": {
           "column": 8,
           "data": "a",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "a",
+          "start": 7,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "delete a",
+        "start": 0,
         "type": "DeleteOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "delete a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/destructure-this-assignment/output.json
+++ b/test/examples/destructure-this-assignment/output.json
@@ -1,120 +1,74 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "({@a}) ->",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 9,
         "line": 1,
         "parameters": [
           {
             "column": 2,
+            "end": 5,
             "line": 1,
             "members": [
               {
                 "column": 3,
-                "expression": {
-                  "column": 3,
-                  "expression": {
-                    "column": 3,
-                    "line": 1,
-                    "range": [
-                      2,
-                      3
-                    ],
-                    "raw": "@",
-                    "type": "This"
-                  },
-                  "line": 1,
-                  "member": {
-                    "column": 4,
-                    "data": "a",
-                    "line": 1,
-                    "range": [
-                      3,
-                      4
-                    ],
-                    "raw": "a",
-                    "type": "Identifier"
-                  },
-                  "range": [
-                    2,
-                    4
-                  ],
-                  "raw": "@a",
-                  "type": "MemberAccessOp"
-                },
+                "end": 4,
+                "expression": null,
                 "key": {
                   "column": 3,
+                  "end": 4,
                   "expression": {
                     "column": 3,
+                    "end": 3,
                     "line": 1,
-                    "range": [
-                      2,
-                      3
-                    ],
                     "raw": "@",
+                    "start": 2,
                     "type": "This"
                   },
                   "line": 1,
                   "member": {
                     "column": 4,
                     "data": "a",
+                    "end": 4,
                     "line": 1,
-                    "range": [
-                      3,
-                      4
-                    ],
                     "raw": "a",
+                    "start": 3,
                     "type": "Identifier"
                   },
-                  "range": [
-                    2,
-                    4
-                  ],
                   "raw": "@a",
+                  "start": 2,
                   "type": "MemberAccessOp"
                 },
                 "line": 1,
-                "range": [
-                  2,
-                  4
-                ],
                 "raw": "@a",
+                "start": 2,
                 "type": "ObjectInitialiserMember"
               }
             ],
-            "range": [
-              1,
-              5
-            ],
             "raw": "{@a}",
+            "start": 1,
             "type": "ObjectInitialiser"
           }
         ],
-        "range": [
-          0,
-          9
-        ],
         "raw": "({@a}) ->",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "({@a}) ->\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/division/output.json
+++ b/test/examples/division/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "3 / 4",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": 3,
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "3",
+          "start": 0,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "3 / 4",
         "right": {
           "column": 5,
           "data": 4,
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "4",
+          "start": 4,
           "type": "Int"
         },
+        "start": 0,
         "type": "DivideOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "3 / 4",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/do-expression/output.json
+++ b/test/examples/do-expression/output.json
@@ -1,92 +1,76 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "a(do =>\n  b)",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 3,
+            "end": 11,
             "expression": {
               "body": {
                 "column": 3,
+                "end": 11,
                 "inline": false,
                 "line": 2,
-                "range": [
-                  10,
-                  11
-                ],
                 "raw": "b",
+                "start": 10,
                 "statements": [
                   {
                     "column": 3,
                     "data": "b",
+                    "end": 11,
                     "line": 2,
-                    "range": [
-                      10,
-                      11
-                    ],
                     "raw": "b",
+                    "start": 10,
                     "type": "Identifier"
                   }
                 ],
                 "type": "Block"
               },
               "column": 6,
+              "end": 11,
               "line": 1,
               "parameters": [
               ],
-              "range": [
-                5,
-                11
-              ],
               "raw": "=>\n  b",
+              "start": 5,
               "type": "BoundFunction"
             },
             "line": 1,
-            "range": [
-              2,
-              11
-            ],
             "raw": "do =>\n  b",
+            "start": 2,
             "type": "DoOp"
           }
         ],
         "column": 1,
+        "end": 12,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "a(do =>\n  b)",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "a(do =>\n  b)",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/do-with-assign-and-defaults/output.json
+++ b/test/examples/do-with-assign-and-defaults/output.json
@@ -1,55 +1,50 @@
 {
   "body": {
     "column": 1,
+    "end": 24,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      24
-    ],
     "raw": "do a = (b = c, d) ->\n  e",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 24,
         "expression": {
           "assignee": {
             "column": 4,
             "data": "a",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "a",
+            "start": 3,
             "type": "Identifier"
           },
           "column": 4,
+          "end": 24,
           "expression": {
             "body": {
               "column": 3,
+              "end": 24,
               "inline": false,
               "line": 2,
-              "range": [
-                23,
-                24
-              ],
               "raw": "e",
+              "start": 23,
               "statements": [
                 {
                   "column": 3,
                   "data": "e",
+                  "end": 24,
                   "line": 2,
-                  "range": [
-                    23,
-                    24
-                  ],
                   "raw": "e",
+                  "start": 23,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
             "column": 8,
+            "end": 24,
             "line": 1,
             "parameters": [
               {
@@ -57,77 +52,58 @@
                 "default": {
                   "column": 13,
                   "data": "c",
+                  "end": 13,
                   "line": 1,
-                  "range": [
-                    12,
-                    13
-                  ],
                   "raw": "c",
+                  "start": 12,
                   "type": "Identifier"
                 },
+                "end": 13,
                 "line": 1,
                 "param": {
                   "column": 9,
                   "data": "b",
+                  "end": 9,
                   "line": 1,
-                  "range": [
-                    8,
-                    9
-                  ],
                   "raw": "b",
+                  "start": 8,
                   "type": "Identifier"
                 },
-                "range": [
-                  8,
-                  13
-                ],
                 "raw": "b = c",
+                "start": 8,
                 "type": "DefaultParam"
               },
               {
                 "column": 16,
                 "data": "d",
+                "end": 16,
                 "line": 1,
-                "range": [
-                  15,
-                  16
-                ],
                 "raw": "d",
+                "start": 15,
                 "type": "Identifier"
               }
             ],
-            "range": [
-              7,
-              24
-            ],
             "raw": "(b = c, d) ->\n  e",
+            "start": 7,
             "type": "Function"
           },
           "line": 1,
-          "range": [
-            3,
-            24
-          ],
           "raw": "a = (b = c, d) ->\n  e",
+          "start": 3,
           "type": "AssignOp"
         },
         "line": 1,
-        "range": [
-          0,
-          24
-        ],
         "raw": "do a = (b = c, d) ->\n  e",
+        "start": 0,
         "type": "DoOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 25,
   "line": 1,
-  "range": [
-    0,
-    25
-  ],
   "raw": "do a = (b = c, d) ->\n  e\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/do-with-assign-expression/output.json
+++ b/test/examples/do-with-assign-expression/output.json
@@ -1,102 +1,84 @@
 {
   "body": {
     "column": 1,
+    "end": 21,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      21
-    ],
     "raw": "do wait = ->\n  wait()",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 21,
         "expression": {
           "assignee": {
             "column": 4,
             "data": "wait",
+            "end": 7,
             "line": 1,
-            "range": [
-              3,
-              7
-            ],
             "raw": "wait",
+            "start": 3,
             "type": "Identifier"
           },
           "column": 4,
+          "end": 21,
           "expression": {
             "body": {
               "column": 3,
+              "end": 21,
               "inline": false,
               "line": 2,
-              "range": [
-                15,
-                21
-              ],
               "raw": "wait()",
+              "start": 15,
               "statements": [
                 {
                   "arguments": [
                   ],
                   "column": 3,
+                  "end": 21,
                   "function": {
                     "column": 3,
                     "data": "wait",
+                    "end": 19,
                     "line": 2,
-                    "range": [
-                      15,
-                      19
-                    ],
                     "raw": "wait",
+                    "start": 15,
                     "type": "Identifier"
                   },
                   "line": 2,
-                  "range": [
-                    15,
-                    21
-                  ],
                   "raw": "wait()",
+                  "start": 15,
                   "type": "FunctionApplication"
                 }
               ],
               "type": "Block"
             },
             "column": 11,
+            "end": 21,
             "line": 1,
             "parameters": [
             ],
-            "range": [
-              10,
-              21
-            ],
             "raw": "->\n  wait()",
+            "start": 10,
             "type": "Function"
           },
           "line": 1,
-          "range": [
-            3,
-            21
-          ],
           "raw": "wait = ->\n  wait()",
+          "start": 3,
           "type": "AssignOp"
         },
         "line": 1,
-        "range": [
-          0,
-          21
-        ],
         "raw": "do wait = ->\n  wait()",
+        "start": 0,
         "type": "DoOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 22,
   "line": 1,
-  "range": [
-    0,
-    22
-  ],
   "raw": "do wait = ->\n  wait()\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/do-with-bound-function/output.json
+++ b/test/examples/do-with-bound-function/output.json
@@ -1,69 +1,57 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "do =>\n  a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 9,
         "expression": {
           "body": {
             "column": 3,
+            "end": 9,
             "inline": false,
             "line": 2,
-            "range": [
-              8,
-              9
-            ],
             "raw": "a",
+            "start": 8,
             "statements": [
               {
                 "column": 3,
                 "data": "a",
+                "end": 9,
                 "line": 2,
-                "range": [
-                  8,
-                  9
-                ],
                 "raw": "a",
+                "start": 8,
                 "type": "Identifier"
               }
             ],
             "type": "Block"
           },
           "column": 4,
+          "end": 9,
           "line": 1,
           "parameters": [
           ],
-          "range": [
-            3,
-            9
-          ],
           "raw": "=>\n  a",
+          "start": 3,
           "type": "BoundFunction"
         },
         "line": 1,
-        "range": [
-          0,
-          9
-        ],
         "raw": "do =>\n  a",
+        "start": 0,
         "type": "DoOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "do =>\n  a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/do-with-default-parameters/output.json
+++ b/test/examples/do-with-default-parameters/output.json
@@ -1,63 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 25,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      25
-    ],
     "raw": "do (a=1, b=@b) ->\n  a + b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 25,
         "expression": {
           "body": {
             "column": 3,
+            "end": 25,
             "inline": false,
             "line": 2,
-            "range": [
-              20,
-              25
-            ],
             "raw": "a + b",
+            "start": 20,
             "statements": [
               {
                 "column": 3,
+                "end": 25,
                 "left": {
                   "column": 3,
                   "data": "a",
+                  "end": 21,
                   "line": 2,
-                  "range": [
-                    20,
-                    21
-                  ],
                   "raw": "a",
+                  "start": 20,
                   "type": "Identifier"
                 },
                 "line": 2,
-                "range": [
-                  20,
-                  25
-                ],
                 "raw": "a + b",
                 "right": {
                   "column": 7,
                   "data": "b",
+                  "end": 25,
                   "line": 2,
-                  "range": [
-                    24,
-                    25
-                  ],
                   "raw": "b",
+                  "start": 24,
                   "type": "Identifier"
                 },
+                "start": 20,
                 "type": "PlusOp"
               }
             ],
             "type": "Block"
           },
           "column": 4,
+          "end": 25,
           "line": 1,
           "parameters": [
             {
@@ -65,110 +57,86 @@
               "default": {
                 "column": 7,
                 "data": 1,
+                "end": 7,
                 "line": 1,
-                "range": [
-                  6,
-                  7
-                ],
                 "raw": "1",
+                "start": 6,
                 "type": "Int"
               },
+              "end": 7,
               "line": 1,
               "param": {
                 "column": 5,
                 "data": "a",
+                "end": 5,
                 "line": 1,
-                "range": [
-                  4,
-                  5
-                ],
                 "raw": "a",
+                "start": 4,
                 "type": "Identifier"
               },
-              "range": [
-                4,
-                7
-              ],
               "raw": "a=1",
+              "start": 4,
               "type": "DefaultParam"
             },
             {
               "column": 10,
               "default": {
                 "column": 12,
+                "end": 13,
                 "expression": {
                   "column": 12,
+                  "end": 12,
                   "line": 1,
-                  "range": [
-                    11,
-                    12
-                  ],
                   "raw": "@",
+                  "start": 11,
                   "type": "This"
                 },
                 "line": 1,
                 "member": {
                   "column": 13,
                   "data": "b",
+                  "end": 13,
                   "line": 1,
-                  "range": [
-                    12,
-                    13
-                  ],
                   "raw": "b",
+                  "start": 12,
                   "type": "Identifier"
                 },
-                "range": [
-                  11,
-                  13
-                ],
                 "raw": "@b",
+                "start": 11,
                 "type": "MemberAccessOp"
               },
+              "end": 13,
               "line": 1,
               "param": {
                 "column": 10,
                 "data": "b",
+                "end": 10,
                 "line": 1,
-                "range": [
-                  9,
-                  10
-                ],
                 "raw": "b",
+                "start": 9,
                 "type": "Identifier"
               },
-              "range": [
-                9,
-                13
-              ],
               "raw": "b=@b",
+              "start": 9,
               "type": "DefaultParam"
             }
           ],
-          "range": [
-            3,
-            25
-          ],
           "raw": "(a=1, b=@b) ->\n  a + b",
+          "start": 3,
           "type": "Function"
         },
         "line": 1,
-        "range": [
-          0,
-          25
-        ],
         "raw": "do (a=1, b=@b) ->\n  a + b",
+        "start": 0,
         "type": "DoOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 25,
   "line": 1,
-  "range": [
-    0,
-    25
-  ],
   "raw": "do (a=1, b=@b) ->\n  a + b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/do-with-defaults-with-same-name/output.json
+++ b/test/examples/do-with-defaults-with-same-name/output.json
@@ -1,63 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 24,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      24
-    ],
     "raw": "do (a=a, b=b) ->\n  a + b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 24,
         "expression": {
           "body": {
             "column": 3,
+            "end": 24,
             "inline": false,
             "line": 2,
-            "range": [
-              19,
-              24
-            ],
             "raw": "a + b",
+            "start": 19,
             "statements": [
               {
                 "column": 3,
+                "end": 24,
                 "left": {
                   "column": 3,
                   "data": "a",
+                  "end": 20,
                   "line": 2,
-                  "range": [
-                    19,
-                    20
-                  ],
                   "raw": "a",
+                  "start": 19,
                   "type": "Identifier"
                 },
                 "line": 2,
-                "range": [
-                  19,
-                  24
-                ],
                 "raw": "a + b",
                 "right": {
                   "column": 7,
                   "data": "b",
+                  "end": 24,
                   "line": 2,
-                  "range": [
-                    23,
-                    24
-                  ],
                   "raw": "b",
+                  "start": 23,
                   "type": "Identifier"
                 },
+                "start": 19,
                 "type": "PlusOp"
               }
             ],
             "type": "Block"
           },
           "column": 4,
+          "end": 24,
           "line": 1,
           "parameters": [
             {
@@ -65,31 +57,25 @@
               "default": {
                 "column": 7,
                 "data": "a",
+                "end": 7,
                 "line": 1,
-                "range": [
-                  6,
-                  7
-                ],
                 "raw": "a",
+                "start": 6,
                 "type": "Identifier"
               },
+              "end": 7,
               "line": 1,
               "param": {
                 "column": 5,
                 "data": "a",
+                "end": 5,
                 "line": 1,
-                "range": [
-                  4,
-                  5
-                ],
                 "raw": "a",
+                "start": 4,
                 "type": "Identifier"
               },
-              "range": [
-                4,
-                7
-              ],
               "raw": "a=a",
+              "start": 4,
               "type": "DefaultParam"
             },
             {
@@ -97,58 +83,44 @@
               "default": {
                 "column": 12,
                 "data": "b",
+                "end": 12,
                 "line": 1,
-                "range": [
-                  11,
-                  12
-                ],
                 "raw": "b",
+                "start": 11,
                 "type": "Identifier"
               },
+              "end": 12,
               "line": 1,
               "param": {
                 "column": 10,
                 "data": "b",
+                "end": 10,
                 "line": 1,
-                "range": [
-                  9,
-                  10
-                ],
                 "raw": "b",
+                "start": 9,
                 "type": "Identifier"
               },
-              "range": [
-                9,
-                12
-              ],
               "raw": "b=b",
+              "start": 9,
               "type": "DefaultParam"
             }
           ],
-          "range": [
-            3,
-            24
-          ],
           "raw": "(a=a, b=b) ->\n  a + b",
+          "start": 3,
           "type": "Function"
         },
         "line": 1,
-        "range": [
-          0,
-          24
-        ],
         "raw": "do (a=a, b=b) ->\n  a + b",
+        "start": 0,
         "type": "DoOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 25,
   "line": 1,
-  "range": [
-    0,
-    25
-  ],
   "raw": "do (a=a, b=b) ->\n  a + b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/do-with-simple-parameters/output.json
+++ b/test/examples/do-with-simple-parameters/output.json
@@ -1,112 +1,92 @@
 {
   "body": {
     "column": 1,
+    "end": 20,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      20
-    ],
     "raw": "do (a, b) ->\n  a + b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 20,
         "expression": {
           "body": {
             "column": 3,
+            "end": 20,
             "inline": false,
             "line": 2,
-            "range": [
-              15,
-              20
-            ],
             "raw": "a + b",
+            "start": 15,
             "statements": [
               {
                 "column": 3,
+                "end": 20,
                 "left": {
                   "column": 3,
                   "data": "a",
+                  "end": 16,
                   "line": 2,
-                  "range": [
-                    15,
-                    16
-                  ],
                   "raw": "a",
+                  "start": 15,
                   "type": "Identifier"
                 },
                 "line": 2,
-                "range": [
-                  15,
-                  20
-                ],
                 "raw": "a + b",
                 "right": {
                   "column": 7,
                   "data": "b",
+                  "end": 20,
                   "line": 2,
-                  "range": [
-                    19,
-                    20
-                  ],
                   "raw": "b",
+                  "start": 19,
                   "type": "Identifier"
                 },
+                "start": 15,
                 "type": "PlusOp"
               }
             ],
             "type": "Block"
           },
           "column": 4,
+          "end": 20,
           "line": 1,
           "parameters": [
             {
               "column": 5,
               "data": "a",
+              "end": 5,
               "line": 1,
-              "range": [
-                4,
-                5
-              ],
               "raw": "a",
+              "start": 4,
               "type": "Identifier"
             },
             {
               "column": 8,
               "data": "b",
+              "end": 8,
               "line": 1,
-              "range": [
-                7,
-                8
-              ],
               "raw": "b",
+              "start": 7,
               "type": "Identifier"
             }
           ],
-          "range": [
-            3,
-            20
-          ],
           "raw": "(a, b) ->\n  a + b",
+          "start": 3,
           "type": "Function"
         },
         "line": 1,
-        "range": [
-          0,
-          20
-        ],
         "raw": "do (a, b) ->\n  a + b",
+        "start": 0,
         "type": "DoOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 20,
   "line": 1,
-  "range": [
-    0,
-    20
-  ],
   "raw": "do (a, b) ->\n  a + b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/do/output.json
+++ b/test/examples/do/output.json
@@ -1,69 +1,57 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "do ->\n  a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 9,
         "expression": {
           "body": {
             "column": 3,
+            "end": 9,
             "inline": false,
             "line": 2,
-            "range": [
-              8,
-              9
-            ],
             "raw": "a",
+            "start": 8,
             "statements": [
               {
                 "column": 3,
                 "data": "a",
+                "end": 9,
                 "line": 2,
-                "range": [
-                  8,
-                  9
-                ],
                 "raw": "a",
+                "start": 8,
                 "type": "Identifier"
               }
             ],
             "type": "Block"
           },
           "column": 4,
+          "end": 9,
           "line": 1,
           "parameters": [
           ],
-          "range": [
-            3,
-            9
-          ],
           "raw": "->\n  a",
+          "start": 3,
           "type": "Function"
         },
         "line": 1,
-        "range": [
-          0,
-          9
-        ],
         "raw": "do ->\n  a",
+        "start": 0,
         "type": "DoOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "do ->\n  a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/double-negation/output.json
+++ b/test/examples/double-negation/output.json
@@ -1,54 +1,44 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "!!a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "expression": {
           "column": 2,
+          "end": 3,
           "expression": {
             "column": 3,
             "data": "a",
+            "end": 3,
             "line": 1,
-            "range": [
-              2,
-              3
-            ],
             "raw": "a",
+            "start": 2,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            1,
-            3
-          ],
           "raw": "!a",
+          "start": 1,
           "type": "LogicalNotOp"
         },
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": "!!a",
+        "start": 0,
         "type": "LogicalNotOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "!!a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/dynamic-member-expressions/output.json
+++ b/test/examples/dynamic-member-expressions/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "a[b]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 4,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "indexingExpr": {
           "column": 3,
           "data": "b",
+          "end": 3,
           "line": 1,
-          "range": [
-            2,
-            3
-          ],
           "raw": "b",
+          "start": 2,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          4
-        ],
         "raw": "a[b]",
+        "start": 0,
         "type": "DynamicMemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": "a[b]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-anonymous-class/output.json
+++ b/test/examples/empty-anonymous-class/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "class",
+    "start": 0,
     "statements": [
       {
         "body": null,
@@ -15,26 +13,22 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 5,
         "line": 1,
         "name": null,
         "nameAssignee": null,
         "parent": null,
-        "range": [
-          0,
-          5
-        ],
         "raw": "class",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "class",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-array/output.json
+++ b/test/examples/empty-array/output.json
@@ -1,35 +1,29 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "[]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 2,
         "line": 1,
         "members": [
         ],
-        "range": [
-          0,
-          2
-        ],
         "raw": "[]",
+        "start": 0,
         "type": "ArrayInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "[]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-bound-function-without-body/output.json
+++ b/test/examples/empty-bound-function-without-body/output.json
@@ -1,36 +1,30 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "=>",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 2,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          2
-        ],
         "raw": "=>",
+        "start": 0,
         "type": "BoundFunction"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "=>",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-class-with-superclass/output.json
+++ b/test/examples/empty-class-with-superclass/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "class A extends B",
+    "start": 0,
     "statements": [
       {
         "body": null,
@@ -15,56 +13,46 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 17,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": {
           "column": 17,
           "data": "B",
+          "end": 17,
           "line": 1,
-          "range": [
-            16,
-            17
-          ],
           "raw": "B",
+          "start": 16,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          17
-        ],
         "raw": "class A extends B",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "class A extends B",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-class/output.json
+++ b/test/examples/empty-class/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "class A",
+    "start": 0,
     "statements": [
       {
         "body": null,
@@ -15,46 +13,38 @@
         ],
         "column": 1,
         "ctor": null,
+        "end": 7,
         "line": 1,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "A",
+          "start": 6,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          0,
-          7
-        ],
         "raw": "class A",
+        "start": 0,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "class A",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-function-without-parameters/output.json
+++ b/test/examples/empty-function-without-parameters/output.json
@@ -1,36 +1,30 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "->",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 2,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          2
-        ],
         "raw": "->",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "->\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-heregex-interpolation/output.json
+++ b/test/examples/empty-heregex-interpolation/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "///a#{}b///",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "expressions": [
           null
         ],
@@ -29,42 +28,33 @@
           {
             "column": 4,
             "data": "a",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "a",
+            "start": 3,
             "type": "Quasi"
           },
           {
             "column": 8,
             "data": "b",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "b",
+            "start": 7,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "///a#{}b///",
+        "start": 0,
         "type": "Heregex"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "///a#{}b///\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-loop/output.json
+++ b/test/examples/empty-loop/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "loop",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 4,
         "line": 1,
-        "range": [
-          0,
-          4
-        ],
         "raw": "loop",
+        "start": 0,
         "type": "Loop"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "loop then\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-object/output.json
+++ b/test/examples/empty-object/output.json
@@ -1,35 +1,29 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "{}",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 2,
         "line": 1,
         "members": [
         ],
-        "range": [
-          0,
-          2
-        ],
         "raw": "{}",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "{}",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-program/output.json
+++ b/test/examples/empty-program/output.json
@@ -1,11 +1,9 @@
 {
   "body": null,
   "column": 1,
+  "end": 0,
   "line": 1,
-  "range": [
-    0,
-    0
-  ],
   "raw": "",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/empty-string-interpolation/output.json
+++ b/test/examples/empty-string-interpolation/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "\"a#{}b\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "expressions": [
           null
         ],
@@ -19,42 +18,33 @@
           {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 6,
             "data": "b",
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "b",
+            "start": 5,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          7
-        ],
         "raw": "\"a#{}b\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "\"a#{}b\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/equality-longhand/output.json
+++ b/test/examples/equality-longhand/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a is b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a is b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "EQOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a is b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/equality/output.json
+++ b/test/examples/equality/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a == b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a == b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "EQOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a == b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/existential-binary/output.json
+++ b/test/examples/existential-binary/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a ? b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a ? b",
         "right": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "ExistsOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a ? b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/existential-unary/output.json
+++ b/test/examples/existential-unary/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "a?",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 2,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          2
-        ],
         "raw": "a?",
+        "start": 0,
         "type": "UnaryExistsOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "a?",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/expansion/output.json
+++ b/test/examples/expansion/output.json
@@ -1,88 +1,72 @@
 {
   "body": {
     "column": 1,
+    "end": 15,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      15
-    ],
     "raw": "[a, ..., b] = c",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
+          "end": 11,
           "line": 1,
           "members": [
             {
               "column": 2,
               "data": "a",
+              "end": 2,
               "line": 1,
-              "range": [
-                1,
-                2
-              ],
               "raw": "a",
+              "start": 1,
               "type": "Identifier"
             },
             {
               "column": 5,
+              "end": 7,
               "line": 1,
-              "range": [
-                4,
-                7
-              ],
               "raw": "...",
+              "start": 4,
               "type": "Expansion"
             },
             {
               "column": 10,
               "data": "b",
+              "end": 10,
               "line": 1,
-              "range": [
-                9,
-                10
-              ],
               "raw": "b",
+              "start": 9,
               "type": "Identifier"
             }
           ],
-          "range": [
-            0,
-            11
-          ],
           "raw": "[a, ..., b]",
+          "start": 0,
           "type": "ArrayInitialiser"
         },
         "column": 1,
+        "end": 15,
         "expression": {
           "column": 15,
           "data": "c",
+          "end": 15,
           "line": 1,
-          "range": [
-            14,
-            15
-          ],
           "raw": "c",
+          "start": 14,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          15
-        ],
         "raw": "[a, ..., b] = c",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 15,
   "line": 1,
-  "range": [
-    0,
-    15
-  ],
   "raw": "[a, ..., b] = c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/external-constructor/output.json
+++ b/test/examples/external-constructor/output.json
@@ -1,89 +1,73 @@
 {
   "body": {
     "column": 1,
+    "end": 31,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      31
-    ],
     "raw": "f = ->\nclass A\n  constructor: f",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "f",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "f",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 6,
         "expression": {
           "body": null,
           "column": 5,
+          "end": 6,
           "line": 1,
           "parameters": [
           ],
-          "range": [
-            4,
-            6
-          ],
           "raw": "->",
+          "start": 4,
           "type": "Function"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "f = ->",
+        "start": 0,
         "type": "AssignOp"
       },
       {
         "body": {
           "column": 3,
+          "end": 31,
           "inline": false,
           "line": 3,
-          "range": [
-            17,
-            31
-          ],
           "raw": "constructor: f",
+          "start": 17,
           "statements": [
             {
               "assignee": {
                 "column": 3,
                 "data": "constructor",
+                "end": 28,
                 "line": 3,
-                "range": [
-                  17,
-                  28
-                ],
                 "raw": "constructor",
+                "start": 17,
                 "type": "Identifier"
               },
               "column": 3,
+              "end": 31,
               "expression": {
                 "column": 16,
                 "data": "f",
+                "end": 31,
                 "line": 3,
-                "range": [
-                  30,
-                  31
-                ],
                 "raw": "f",
+                "start": 30,
                 "type": "Identifier"
               },
               "line": 3,
-              "range": [
-                17,
-                31
-              ],
               "raw": "constructor: f",
+              "start": 17,
               "type": "Constructor"
             }
           ],
@@ -96,74 +80,60 @@
           "assignee": {
             "column": 3,
             "data": "constructor",
+            "end": 28,
             "line": 3,
-            "range": [
-              17,
-              28
-            ],
             "raw": "constructor",
+            "start": 17,
             "type": "Identifier"
           },
           "column": 3,
+          "end": 31,
           "expression": {
             "column": 16,
             "data": "f",
+            "end": 31,
             "line": 3,
-            "range": [
-              30,
-              31
-            ],
             "raw": "f",
+            "start": 30,
             "type": "Identifier"
           },
           "line": 3,
-          "range": [
-            17,
-            31
-          ],
           "raw": "constructor: f",
+          "start": 17,
           "type": "Constructor"
         },
+        "end": 31,
         "line": 2,
         "name": {
           "column": 7,
           "data": "A",
+          "end": 14,
           "line": 2,
-          "range": [
-            13,
-            14
-          ],
           "raw": "A",
+          "start": 13,
           "type": "Identifier"
         },
         "nameAssignee": {
           "column": 7,
           "data": "A",
+          "end": 14,
           "line": 2,
-          "range": [
-            13,
-            14
-          ],
           "raw": "A",
+          "start": 13,
           "type": "Identifier"
         },
         "parent": null,
-        "range": [
-          7,
-          31
-        ],
         "raw": "class A\n  constructor: f",
+        "start": 7,
         "type": "Class"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 32,
   "line": 1,
-  "range": [
-    0,
-    32
-  ],
   "raw": "f = ->\nclass A\n  constructor: f\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/false/output.json
+++ b/test/examples/false/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "false",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": false,
+        "end": 5,
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "false",
+        "start": 0,
         "type": "Bool"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "false",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/float-int-value/output.json
+++ b/test/examples/float-int-value/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "1.0",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": 1,
+        "end": 3,
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": "1.0",
+        "start": 0,
         "type": "Float"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "1.0",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/float-leading-period/output.json
+++ b/test/examples/float-leading-period/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": ".25",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": 0.25,
+        "end": 3,
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": ".25",
+        "start": 0,
         "type": "Float"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": ".25\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/float/output.json
+++ b/test/examples/float/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "1.2",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": 1.2,
+        "end": 3,
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": "1.2",
+        "start": 0,
         "type": "Float"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "1.2",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/floor-division/output.json
+++ b/test/examples/floor-division/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "7 // 3",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": 7,
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "7",
+          "start": 0,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "7 // 3",
         "right": {
           "column": 6,
           "data": 3,
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "3",
+          "start": 5,
           "type": "Int"
         },
+        "start": 0,
         "type": "FloorDivideOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "7 // 3",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-comprehension/output.json
+++ b/test/examples/for-comprehension/output.json
@@ -1,70 +1,58 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "a for b in c",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 1,
+          "end": 1,
           "inline": true,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "statements": [
             {
               "column": 1,
               "data": "a",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "a",
+              "start": 0,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 12,
         "filter": null,
         "keyAssignee": null,
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "a for b in c",
+        "start": 0,
         "step": null,
         "target": {
           "column": 12,
           "data": "c",
+          "end": 12,
           "line": 1,
-          "range": [
-            11,
-            12
-          ],
           "raw": "c",
+          "start": 11,
           "type": "Identifier"
         },
         "type": "ForIn",
         "valAssignee": {
           "column": 7,
           "data": "b",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "b",
+          "start": 6,
           "type": "Identifier"
         }
       }
@@ -72,11 +60,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "a for b in c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-in-by/output.json
+++ b/test/examples/for-in-by/output.json
@@ -1,80 +1,66 @@
 {
   "body": {
     "column": 1,
+    "end": 19,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      19
-    ],
     "raw": "for a in b by c\n  d",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 19,
           "inline": false,
           "line": 2,
-          "range": [
-            18,
-            19
-          ],
           "raw": "d",
+          "start": 18,
           "statements": [
             {
               "column": 3,
               "data": "d",
+              "end": 19,
               "line": 2,
-              "range": [
-                18,
-                19
-              ],
               "raw": "d",
+              "start": 18,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 19,
         "filter": null,
         "keyAssignee": null,
         "line": 1,
-        "range": [
-          0,
-          19
-        ],
         "raw": "for a in b by c\n  d",
+        "start": 0,
         "step": {
           "column": 15,
           "data": "c",
+          "end": 15,
           "line": 1,
-          "range": [
-            14,
-            15
-          ],
           "raw": "c",
+          "start": 14,
           "type": "Identifier"
         },
         "target": {
           "column": 10,
           "data": "b",
+          "end": 10,
           "line": 1,
-          "range": [
-            9,
-            10
-          ],
           "raw": "b",
+          "start": 9,
           "type": "Identifier"
         },
         "type": "ForIn",
         "valAssignee": {
           "column": 5,
           "data": "a",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "type": "Identifier"
         }
       }
@@ -82,11 +68,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 19,
   "line": 1,
-  "range": [
-    0,
-    19
-  ],
   "raw": "for a in b by c\n  d",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-in-when/output.json
+++ b/test/examples/for-in-when/output.json
@@ -1,80 +1,66 @@
 {
   "body": {
     "column": 1,
+    "end": 21,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      21
-    ],
     "raw": "for a in b when c\n  d",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 21,
           "inline": false,
           "line": 2,
-          "range": [
-            20,
-            21
-          ],
           "raw": "d",
+          "start": 20,
           "statements": [
             {
               "column": 3,
               "data": "d",
+              "end": 21,
               "line": 2,
-              "range": [
-                20,
-                21
-              ],
               "raw": "d",
+              "start": 20,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 21,
         "filter": {
           "column": 17,
           "data": "c",
+          "end": 17,
           "line": 1,
-          "range": [
-            16,
-            17
-          ],
           "raw": "c",
+          "start": 16,
           "type": "Identifier"
         },
         "keyAssignee": null,
         "line": 1,
-        "range": [
-          0,
-          21
-        ],
         "raw": "for a in b when c\n  d",
+        "start": 0,
         "step": null,
         "target": {
           "column": 10,
           "data": "b",
+          "end": 10,
           "line": 1,
-          "range": [
-            9,
-            10
-          ],
           "raw": "b",
+          "start": 9,
           "type": "Identifier"
         },
         "type": "ForIn",
         "valAssignee": {
           "column": 5,
           "data": "a",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "type": "Identifier"
         }
       }
@@ -82,11 +68,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 21,
   "line": 1,
-  "range": [
-    0,
-    21
-  ],
   "raw": "for a in b when c\n  d",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-in-with-key-and-value-assignees/output.json
+++ b/test/examples/for-in-with-key-and-value-assignees/output.json
@@ -1,80 +1,66 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "for a, i in b\n  c",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 17,
           "inline": false,
           "line": 2,
-          "range": [
-            16,
-            17
-          ],
           "raw": "c",
+          "start": 16,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 17,
               "line": 2,
-              "range": [
-                16,
-                17
-              ],
               "raw": "c",
+              "start": 16,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 17,
         "filter": null,
         "keyAssignee": {
           "column": 8,
           "data": "i",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "i",
+          "start": 7,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          17
-        ],
         "raw": "for a, i in b\n  c",
+        "start": 0,
         "step": null,
         "target": {
           "column": 13,
           "data": "b",
+          "end": 13,
           "line": 1,
-          "range": [
-            12,
-            13
-          ],
           "raw": "b",
+          "start": 12,
           "type": "Identifier"
         },
         "type": "ForIn",
         "valAssignee": {
           "column": 5,
           "data": "a",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "type": "Identifier"
         }
       }
@@ -82,11 +68,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "for a, i in b\n  c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-in/output.json
+++ b/test/examples/for-in/output.json
@@ -1,70 +1,58 @@
 {
   "body": {
     "column": 1,
+    "end": 14,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      14
-    ],
     "raw": "for a in b\n  c",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 14,
           "inline": false,
           "line": 2,
-          "range": [
-            13,
-            14
-          ],
           "raw": "c",
+          "start": 13,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 14,
               "line": 2,
-              "range": [
-                13,
-                14
-              ],
               "raw": "c",
+              "start": 13,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 14,
         "filter": null,
         "keyAssignee": null,
         "line": 1,
-        "range": [
-          0,
-          14
-        ],
         "raw": "for a in b\n  c",
+        "start": 0,
         "step": null,
         "target": {
           "column": 10,
           "data": "b",
+          "end": 10,
           "line": 1,
-          "range": [
-            9,
-            10
-          ],
           "raw": "b",
+          "start": 9,
           "type": "Identifier"
         },
         "type": "ForIn",
         "valAssignee": {
           "column": 5,
           "data": "a",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "type": "Identifier"
         }
       }
@@ -72,11 +60,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 14,
   "line": 1,
-  "range": [
-    0,
-    14
-  ],
   "raw": "for a in b\n  c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-of-expression/output.json
+++ b/test/examples/for-of-expression/output.json
@@ -1,70 +1,58 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "a(for b of c\n  b)",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "body": {
               "column": 3,
+              "end": 16,
               "inline": false,
               "line": 2,
-              "range": [
-                15,
-                16
-              ],
               "raw": "b",
+              "start": 15,
               "statements": [
                 {
                   "column": 3,
                   "data": "b",
+                  "end": 16,
                   "line": 2,
-                  "range": [
-                    15,
-                    16
-                  ],
                   "raw": "b",
+                  "start": 15,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
             "column": 3,
+            "end": 16,
             "filter": null,
             "isOwn": false,
             "keyAssignee": {
               "column": 7,
               "data": "b",
+              "end": 7,
               "line": 1,
-              "range": [
-                6,
-                7
-              ],
               "raw": "b",
+              "start": 6,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              2,
-              16
-            ],
             "raw": "for b of c\n  b",
+            "start": 2,
             "target": {
               "column": 12,
               "data": "c",
+              "end": 12,
               "line": 1,
-              "range": [
-                11,
-                12
-              ],
               "raw": "c",
+              "start": 11,
               "type": "Identifier"
             },
             "type": "ForOf",
@@ -72,34 +60,28 @@
           }
         ],
         "column": 1,
+        "end": 17,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          17
-        ],
         "raw": "a(for b of c\n  b)",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "a(for b of c\n  b)\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-of-when/output.json
+++ b/test/examples/for-of-when/output.json
@@ -1,78 +1,64 @@
 {
   "body": {
     "column": 1,
+    "end": 21,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      21
-    ],
     "raw": "for a of b when c\n  d",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 21,
           "inline": false,
           "line": 2,
-          "range": [
-            20,
-            21
-          ],
           "raw": "d",
+          "start": 20,
           "statements": [
             {
               "column": 3,
               "data": "d",
+              "end": 21,
               "line": 2,
-              "range": [
-                20,
-                21
-              ],
               "raw": "d",
+              "start": 20,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 21,
         "filter": {
           "column": 17,
           "data": "c",
+          "end": 17,
           "line": 1,
-          "range": [
-            16,
-            17
-          ],
           "raw": "c",
+          "start": 16,
           "type": "Identifier"
         },
         "isOwn": false,
         "keyAssignee": {
           "column": 5,
           "data": "a",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          21
-        ],
         "raw": "for a of b when c\n  d",
+        "start": 0,
         "target": {
           "column": 10,
           "data": "b",
+          "end": 10,
           "line": 1,
-          "range": [
-            9,
-            10
-          ],
           "raw": "b",
+          "start": 9,
           "type": "Identifier"
         },
         "type": "ForOf",
@@ -82,11 +68,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 21,
   "line": 1,
-  "range": [
-    0,
-    21
-  ],
   "raw": "for a of b when c\n  d",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-of-with-key-and-value-assignees/output.json
+++ b/test/examples/for-of-with-key-and-value-assignees/output.json
@@ -1,80 +1,66 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "for k, v of a\n  b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 17,
           "inline": false,
           "line": 2,
-          "range": [
-            16,
-            17
-          ],
           "raw": "b",
+          "start": 16,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 17,
               "line": 2,
-              "range": [
-                16,
-                17
-              ],
               "raw": "b",
+              "start": 16,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 17,
         "filter": null,
         "isOwn": false,
         "keyAssignee": {
           "column": 5,
           "data": "k",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "k",
+          "start": 4,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          17
-        ],
         "raw": "for k, v of a\n  b",
+        "start": 0,
         "target": {
           "column": 13,
           "data": "a",
+          "end": 13,
           "line": 1,
-          "range": [
-            12,
-            13
-          ],
           "raw": "a",
+          "start": 12,
           "type": "Identifier"
         },
         "type": "ForOf",
         "valAssignee": {
           "column": 8,
           "data": "v",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "v",
+          "start": 7,
           "type": "Identifier"
         }
       }
@@ -82,11 +68,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "for k, v of a\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-of/output.json
+++ b/test/examples/for-of/output.json
@@ -1,68 +1,56 @@
 {
   "body": {
     "column": 1,
+    "end": 14,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      14
-    ],
     "raw": "for a of b\n  c",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 14,
           "inline": false,
           "line": 2,
-          "range": [
-            13,
-            14
-          ],
           "raw": "c",
+          "start": 13,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 14,
               "line": 2,
-              "range": [
-                13,
-                14
-              ],
               "raw": "c",
+              "start": 13,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 14,
         "filter": null,
         "isOwn": false,
         "keyAssignee": {
           "column": 5,
           "data": "a",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          14
-        ],
         "raw": "for a of b\n  c",
+        "start": 0,
         "target": {
           "column": 10,
           "data": "b",
+          "end": 10,
           "line": 1,
-          "range": [
-            9,
-            10
-          ],
           "raw": "b",
+          "start": 9,
           "type": "Identifier"
         },
         "type": "ForOf",
@@ -72,11 +60,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 14,
   "line": 1,
-  "range": [
-    0,
-    14
-  ],
   "raw": "for a of b\n  c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-own-of/output.json
+++ b/test/examples/for-own-of/output.json
@@ -1,68 +1,56 @@
 {
   "body": {
     "column": 1,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      18
-    ],
     "raw": "for own a of b\n  c",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 18,
           "inline": false,
           "line": 2,
-          "range": [
-            17,
-            18
-          ],
           "raw": "c",
+          "start": 17,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 18,
               "line": 2,
-              "range": [
-                17,
-                18
-              ],
               "raw": "c",
+              "start": 17,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 18,
         "filter": null,
         "isOwn": true,
         "keyAssignee": {
           "column": 9,
           "data": "a",
+          "end": 9,
           "line": 1,
-          "range": [
-            8,
-            9
-          ],
           "raw": "a",
+          "start": 8,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          18
-        ],
         "raw": "for own a of b\n  c",
+        "start": 0,
         "target": {
           "column": 14,
           "data": "b",
+          "end": 14,
           "line": 1,
-          "range": [
-            13,
-            14
-          ],
           "raw": "b",
+          "start": 13,
           "type": "Identifier"
         },
         "type": "ForOf",
@@ -72,11 +60,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "for own a of b\n  c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/for-repeater/output.json
+++ b/test/examples/for-repeater/output.json
@@ -1,80 +1,66 @@
 {
   "body": {
     "column": 1,
+    "end": 14,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      14
-    ],
     "raw": "for [0..1]\n  2",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 14,
           "inline": false,
           "line": 2,
-          "range": [
-            13,
-            14
-          ],
           "raw": "2",
+          "start": 13,
           "statements": [
             {
               "column": 3,
               "data": 2,
+              "end": 14,
               "line": 2,
-              "range": [
-                13,
-                14
-              ],
               "raw": "2",
+              "start": 13,
               "type": "Int"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 14,
         "filter": null,
         "keyAssignee": null,
         "line": 1,
-        "range": [
-          0,
-          14
-        ],
         "raw": "for [0..1]\n  2",
+        "start": 0,
         "step": null,
         "target": {
           "column": 5,
+          "end": 10,
           "isInclusive": true,
           "left": {
             "column": 6,
             "data": 0,
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "0",
+            "start": 5,
             "type": "Int"
           },
           "line": 1,
-          "range": [
-            4,
-            10
-          ],
           "raw": "[0..1]",
           "right": {
             "column": 9,
             "data": 1,
+            "end": 9,
             "line": 1,
-            "range": [
-              8,
-              9
-            ],
             "raw": "1",
+            "start": 8,
             "type": "Int"
           },
+          "start": 4,
           "type": "Range"
         },
         "type": "ForIn",
@@ -84,11 +70,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 15,
   "line": 1,
-  "range": [
-    0,
-    15
-  ],
   "raw": "for [0..1]\n  2\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/function-ending-in-block-comment/output.json
+++ b/test/examples/function-ending-in-block-comment/output.json
@@ -1,82 +1,68 @@
 {
   "body": {
     "column": 1,
+    "end": 20,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      20
-    ],
     "raw": "a ->\n  b\n  ### c ###",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "body": {
               "column": 3,
+              "end": 20,
               "inline": false,
               "line": 2,
-              "range": [
-                7,
-                20
-              ],
               "raw": "b\n  ### c ###",
+              "start": 7,
               "statements": [
                 {
                   "column": 3,
                   "data": "b",
+                  "end": 8,
                   "line": 2,
-                  "range": [
-                    7,
-                    8
-                  ],
                   "raw": "b",
+                  "start": 7,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
             "column": 3,
+            "end": 20,
             "line": 1,
             "parameters": [
             ],
-            "range": [
-              2,
-              20
-            ],
             "raw": "->\n  b\n  ### c ###",
+            "start": 2,
             "type": "Function"
           }
         ],
         "column": 1,
+        "end": 20,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          20
-        ],
         "raw": "a ->\n  b\n  ### c ###",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 21,
   "line": 1,
-  "range": [
-    0,
-    21
-  ],
   "raw": "a ->\n  b\n  ### c ###\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/function-ending-in-semicolon/output.json
+++ b/test/examples/function-ending-in-semicolon/output.json
@@ -1,48 +1,40 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "->\n  ;",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 1,
+          "end": 6,
           "inline": false,
           "line": 2,
-          "range": [
-            5,
-            6
-          ],
           "raw": ";",
+          "start": 5,
           "statements": [
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 6,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          6
-        ],
         "raw": "->\n  ;",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "->\n  ;\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/function-followed-by-block-comment/output.json
+++ b/test/examples/function-followed-by-block-comment/output.json
@@ -1,82 +1,68 @@
 {
   "body": {
     "column": 1,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      18
-    ],
     "raw": "a ->\n  b\n### c ###",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "body": {
               "column": 3,
+              "end": 8,
               "inline": false,
               "line": 2,
-              "range": [
-                7,
-                8
-              ],
               "raw": "b",
+              "start": 7,
               "statements": [
                 {
                   "column": 3,
                   "data": "b",
+                  "end": 8,
                   "line": 2,
-                  "range": [
-                    7,
-                    8
-                  ],
                   "raw": "b",
+                  "start": 7,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
             "column": 3,
+            "end": 8,
             "line": 1,
             "parameters": [
             ],
-            "range": [
-              2,
-              8
-            ],
             "raw": "->\n  b",
+            "start": 2,
             "type": "Function"
           }
         ],
         "column": 1,
+        "end": 8,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "a ->\n  b",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 19,
   "line": 1,
-  "range": [
-    0,
-    19
-  ],
   "raw": "a ->\n  b\n### c ###\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/function-trailing-spaces/output.json
+++ b/test/examples/function-trailing-spaces/output.json
@@ -1,102 +1,84 @@
 {
   "body": {
     "column": 1,
+    "end": 26,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      26
-    ],
     "raw": "main = ->\n  foo\n  bar\n\nbaz",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "main",
+          "end": 4,
           "line": 1,
-          "range": [
-            0,
-            4
-          ],
           "raw": "main",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 21,
         "expression": {
           "body": {
             "column": 3,
+            "end": 21,
             "inline": false,
             "line": 2,
-            "range": [
-              12,
-              21
-            ],
             "raw": "foo\n  bar",
+            "start": 12,
             "statements": [
               {
                 "column": 3,
                 "data": "foo",
+                "end": 15,
                 "line": 2,
-                "range": [
-                  12,
-                  15
-                ],
                 "raw": "foo",
+                "start": 12,
                 "type": "Identifier"
               },
               {
                 "column": 3,
                 "data": "bar",
+                "end": 21,
                 "line": 3,
-                "range": [
-                  18,
-                  21
-                ],
                 "raw": "bar",
+                "start": 18,
                 "type": "Identifier"
               }
             ],
             "type": "Block"
           },
           "column": 8,
+          "end": 21,
           "line": 1,
           "parameters": [
           ],
-          "range": [
-            7,
-            21
-          ],
           "raw": "->\n  foo\n  bar",
+          "start": 7,
           "type": "Function"
         },
         "line": 1,
-        "range": [
-          0,
-          21
-        ],
         "raw": "main = ->\n  foo\n  bar",
+        "start": 0,
         "type": "AssignOp"
       },
       {
         "column": 1,
         "data": "baz",
+        "end": 26,
         "line": 5,
-        "range": [
-          23,
-          26
-        ],
         "raw": "baz",
+        "start": 23,
         "type": "Identifier"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 26,
   "line": 1,
-  "range": [
-    0,
-    26
-  ],
   "raw": "main = ->\n  foo\n  bar\n\nbaz",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/function-with-body/output.json
+++ b/test/examples/function-with-body/output.json
@@ -1,59 +1,49 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "->\n  a",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 6,
           "inline": false,
           "line": 2,
-          "range": [
-            5,
-            6
-          ],
           "raw": "a",
+          "start": 5,
           "statements": [
             {
               "column": 3,
               "data": "a",
+              "end": 6,
               "line": 2,
-              "range": [
-                5,
-                6
-              ],
               "raw": "a",
+              "start": 5,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 6,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          6
-        ],
         "raw": "->\n  a",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "->\n  a\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/function-with-default-parameter/output.json
+++ b/test/examples/function-with-default-parameter/output.json
@@ -1,17 +1,16 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "(a=1) ->",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 8,
         "line": 1,
         "parameters": [
           {
@@ -19,50 +18,39 @@
             "default": {
               "column": 4,
               "data": 1,
+              "end": 4,
               "line": 1,
-              "range": [
-                3,
-                4
-              ],
               "raw": "1",
+              "start": 3,
               "type": "Int"
             },
+            "end": 4,
             "line": 1,
             "param": {
               "column": 2,
               "data": "a",
+              "end": 2,
               "line": 1,
-              "range": [
-                1,
-                2
-              ],
               "raw": "a",
+              "start": 1,
               "type": "Identifier"
             },
-            "range": [
-              1,
-              4
-            ],
             "raw": "a=1",
+            "start": 1,
             "type": "DefaultParam"
           }
         ],
-        "range": [
-          0,
-          8
-        ],
         "raw": "(a=1) ->",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "(a=1) ->\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/function-with-parameters/output.json
+++ b/test/examples/function-with-parameters/output.json
@@ -1,58 +1,48 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "(a, b) ->",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 9,
         "line": 1,
         "parameters": [
           {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Identifier"
           },
           {
             "column": 5,
             "data": "b",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "b",
+            "start": 4,
             "type": "Identifier"
           }
         ],
-        "range": [
-          0,
-          9
-        ],
         "raw": "(a, b) ->",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "(a, b) ->",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/function-with-statement-after-block-and-comments/output.json
+++ b/test/examples/function-with-statement-after-block-and-comments/output.json
@@ -1,70 +1,58 @@
 {
   "body": {
     "column": 1,
+    "end": 26,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      26
-    ],
     "raw": "->\n  a\n\n# hey\n## foo ###\nb",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 6,
           "inline": false,
           "line": 2,
-          "range": [
-            5,
-            6
-          ],
           "raw": "a",
+          "start": 5,
           "statements": [
             {
               "column": 3,
               "data": "a",
+              "end": 6,
               "line": 2,
-              "range": [
-                5,
-                6
-              ],
               "raw": "a",
+              "start": 5,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 6,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          6
-        ],
         "raw": "->\n  a",
+        "start": 0,
         "type": "Function"
       },
       {
         "column": 1,
         "data": "b",
+        "end": 26,
         "line": 6,
-        "range": [
-          25,
-          26
-        ],
         "raw": "b",
+        "start": 25,
         "type": "Identifier"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 27,
   "line": 1,
-  "range": [
-    0,
-    27
-  ],
   "raw": "->\n  a\n\n# hey\n## foo ###\nb\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/greater-than-equal/output.json
+++ b/test/examples/greater-than-equal/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a >= b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a >= b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "GTEOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a >= b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/greater-than/output.json
+++ b/test/examples/greater-than/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a > b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a > b",
         "right": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "GTOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a > b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/heregex-in-method-call/output.json
+++ b/test/examples/heregex-in-method-call/output.json
@@ -1,18 +1,17 @@
 {
   "body": {
     "column": 1,
+    "end": 19,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      19
-    ],
     "raw": "///foo///.test('a')",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 16,
+            "end": 18,
             "expressions": [
             ],
             "line": 1,
@@ -20,28 +19,26 @@
               {
                 "column": 17,
                 "data": "a",
+                "end": 17,
                 "line": 1,
-                "range": [
-                  16,
-                  17
-                ],
                 "raw": "a",
+                "start": 16,
                 "type": "Quasi"
               }
             ],
-            "range": [
-              15,
-              18
-            ],
             "raw": "'a'",
+            "start": 15,
             "type": "String"
           }
         ],
         "column": 1,
+        "end": 19,
         "function": {
           "column": 1,
+          "end": 14,
           "expression": {
             "column": 1,
+            "end": 9,
             "expressions": [
             ],
             "flags": {
@@ -59,58 +56,43 @@
               {
                 "column": 4,
                 "data": "/foo/",
+                "end": 6,
                 "line": 1,
-                "range": [
-                  3,
-                  6
-                ],
                 "raw": "foo",
+                "start": 3,
                 "type": "Quasi"
               }
             ],
-            "range": [
-              0,
-              9
-            ],
             "raw": "///foo///",
+            "start": 0,
             "type": "Heregex"
           },
           "line": 1,
           "member": {
             "column": 11,
             "data": "test",
+            "end": 14,
             "line": 1,
-            "range": [
-              10,
-              14
-            ],
             "raw": "test",
+            "start": 10,
             "type": "Identifier"
           },
-          "range": [
-            0,
-            14
-          ],
           "raw": "///foo///.test",
+          "start": 0,
           "type": "MemberAccessOp"
         },
         "line": 1,
-        "range": [
-          0,
-          19
-        ],
         "raw": "///foo///.test('a')",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 20,
   "line": 1,
-  "range": [
-    0,
-    20
-  ],
   "raw": "///foo///.test('a')\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/heregex-with-flags/output.json
+++ b/test/examples/heregex-with-flags/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 15,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      15
-    ],
     "raw": "///a/b/c///gimy",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 15,
         "expressions": [
         ],
         "flags": {
@@ -28,31 +27,24 @@
           {
             "column": 4,
             "data": "/a\\/b\\/c/gimy",
+            "end": 8,
             "line": 1,
-            "range": [
-              3,
-              8
-            ],
             "raw": "a/b/c",
+            "start": 3,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          15
-        ],
         "raw": "///a/b/c///gimy",
+        "start": 0,
         "type": "Heregex"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 15,
   "line": 1,
-  "range": [
-    0,
-    15
-  ],
   "raw": "///a/b/c///gimy",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/heregex-with-interpolations-and-flags/output.json
+++ b/test/examples/heregex-with-interpolations-and-flags/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 30,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      30
-    ],
     "raw": "///\n  abc # def #{ghi} j\n///gi",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 30,
         "expressions": [
           {
             "column": 15,
             "data": "ghi",
+            "end": 21,
             "line": 2,
-            "range": [
-              18,
-              21
-            ],
             "raw": "ghi",
+            "start": 18,
             "type": "Identifier"
           }
         ],
@@ -39,42 +36,33 @@
           {
             "column": 4,
             "data": "abc",
+            "end": 16,
             "line": 1,
-            "range": [
-              3,
-              16
-            ],
             "raw": "\n  abc # def ",
+            "start": 3,
             "type": "Quasi"
           },
           {
             "column": 19,
             "data": "j",
+            "end": 25,
             "line": 2,
-            "range": [
-              22,
-              25
-            ],
             "raw": " j\n",
+            "start": 22,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          30
-        ],
         "raw": "///\n  abc # def #{ghi} j\n///gi",
+        "start": 0,
         "type": "Heregex"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 31,
   "line": 1,
-  "range": [
-    0,
-    31
-  ],
   "raw": "///\n  abc # def #{ghi} j\n///gi\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/heregex-with-interpolations/output.json
+++ b/test/examples/heregex-with-interpolations/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 29,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      29
-    ],
     "raw": "///\n  foo\n  #{bar}  # baz\n///",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 29,
         "expressions": [
           {
             "column": 5,
             "data": "bar",
+            "end": 17,
             "line": 3,
-            "range": [
-              14,
-              17
-            ],
             "raw": "bar",
+            "start": 14,
             "type": "Identifier"
           }
         ],
@@ -39,42 +36,33 @@
           {
             "column": 4,
             "data": "foo",
+            "end": 12,
             "line": 1,
-            "range": [
-              3,
-              12
-            ],
             "raw": "\n  foo\n  ",
+            "start": 3,
             "type": "Quasi"
           },
           {
             "column": 9,
             "data": "",
+            "end": 26,
             "line": 3,
-            "range": [
-              18,
-              26
-            ],
             "raw": "  # baz\n",
+            "start": 18,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          29
-        ],
         "raw": "///\n  foo\n  #{bar}  # baz\n///",
+        "start": 0,
         "type": "Heregex"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 30,
   "line": 1,
-  "range": [
-    0,
-    30
-  ],
   "raw": "///\n  foo\n  #{bar}  # baz\n///\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/heregex-with-spaces-and-comments/output.json
+++ b/test/examples/heregex-with-spaces-and-comments/output.json
@@ -1,29 +1,27 @@
 {
   "body": {
     "column": 1,
+    "end": 305,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      305
-    ],
     "raw": "OPERATOR = /// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "OPERATOR",
+          "end": 8,
           "line": 1,
-          "range": [
-            0,
-            8
-          ],
           "raw": "OPERATOR",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 305,
         "expression": {
           "column": 12,
+          "end": 305,
           "expressions": [
           ],
           "flags": {
@@ -41,39 +39,29 @@
             {
               "column": 15,
               "data": "/^(?:[-=]>|[-+*\\/%<>&|^!?=]=|>>>=?|([-+:])\\1|([&|<>])\\2=?|\\?\\.|\\.{2,3})/",
+              "end": 302,
               "line": 1,
-              "range": [
-                14,
-                302
-              ],
               "raw": " ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ",
+              "start": 14,
               "type": "Quasi"
             }
           ],
-          "range": [
-            11,
-            305
-          ],
           "raw": "/// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///",
+          "start": 11,
           "type": "Heregex"
         },
         "line": 1,
-        "range": [
-          0,
-          305
-        ],
         "raw": "OPERATOR = /// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 306,
   "line": 1,
-  "range": [
-    0,
-    306
-  ],
   "raw": "OPERATOR = /// ^ (\n  ?: [-=]>             # function\n   | [-+*/%<>&|^!?=]=  # compound assign / compare\n   | >>>=?             # zero-fill right shift\n   | ([-+:])\\1         # doubles\n   | ([&|<>])\\2=?      # logic / shift\n   | \\?\\.              # soak access\n   | \\.{2,3}           # range or splat\n) ///\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/heregex-with-strange-whitespace/output.json
+++ b/test/examples/heregex-with-strange-whitespace/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 44,
     "inline": false,
     "line": 2,
-    "range": [
-      37,
-      44
-    ],
     "raw": "/// ///",
+    "start": 37,
     "statements": [
       {
         "column": 1,
+        "end": 44,
         "expressions": [
         ],
         "flags": {
@@ -28,31 +27,24 @@
           {
             "column": 4,
             "data": "/(?:)/",
+            "end": 41,
             "line": 2,
-            "range": [
-              40,
-              41
-            ],
             "raw": " ",
+            "start": 40,
             "type": "Quasi"
           }
         ],
-        "range": [
-          37,
-          44
-        ],
         "raw": "/// ///",
+        "start": 37,
         "type": "Heregex"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 45,
   "line": 1,
-  "range": [
-    0,
-    45
-  ],
   "raw": "# This has a \\u2028 character in it.\n/// ///\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/heregex/output.json
+++ b/test/examples/heregex/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "///a/b/c///",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "expressions": [
         ],
         "flags": {
@@ -28,31 +27,24 @@
           {
             "column": 4,
             "data": "/a\\/b\\/c/",
+            "end": 8,
             "line": 1,
-            "range": [
-              3,
-              8
-            ],
             "raw": "a/b/c",
+            "start": 3,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "///a/b/c///",
+        "start": 0,
         "type": "Heregex"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "///a/b/c///",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/hexidecimal-number/output.json
+++ b/test/examples/hexidecimal-number/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "0x1B000",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": 110592,
+        "end": 7,
         "line": 1,
-        "range": [
-          0,
-          7
-        ],
         "raw": "0x1B000",
+        "start": 0,
         "type": "Int"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "0x1B000",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/iife-in-function-call/output.json
+++ b/test/examples/iife-in-function-call/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 13,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      13
-    ],
     "raw": "a((=>\n  0)())",
+    "start": 0,
     "statements": [
       {
         "arguments": [
@@ -15,80 +13,66 @@
             "arguments": [
             ],
             "column": 3,
+            "end": 12,
             "function": {
               "body": {
                 "column": 3,
+                "end": 9,
                 "inline": false,
                 "line": 2,
-                "range": [
-                  8,
-                  9
-                ],
                 "raw": "0",
+                "start": 8,
                 "statements": [
                   {
                     "column": 3,
                     "data": 0,
+                    "end": 9,
                     "line": 2,
-                    "range": [
-                      8,
-                      9
-                    ],
                     "raw": "0",
+                    "start": 8,
                     "type": "Int"
                   }
                 ],
                 "type": "Block"
               },
               "column": 4,
+              "end": 9,
               "line": 1,
               "parameters": [
               ],
-              "range": [
-                3,
-                9
-              ],
               "raw": "=>\n  0",
+              "start": 3,
               "type": "BoundFunction"
             },
             "line": 1,
-            "range": [
-              2,
-              12
-            ],
             "raw": "(=>\n  0)()",
+            "start": 2,
             "type": "FunctionApplication"
           }
         ],
         "column": 1,
+        "end": 13,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          13
-        ],
         "raw": "a((=>\n  0)())",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "a((=>\n  0)())",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/in-not/output.json
+++ b/test/examples/in-not/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 10,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      10
-    ],
     "raw": "a not in b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 10,
         "isNot": true,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          10
-        ],
         "raw": "a not in b",
         "right": {
           "column": 10,
           "data": "b",
+          "end": 10,
           "line": 1,
-          "range": [
-            9,
-            10
-          ],
           "raw": "b",
+          "start": 9,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "InOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "a not in b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/in/output.json
+++ b/test/examples/in/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a in b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "isNot": false,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a in b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "InOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a in b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/instanceof-not/output.json
+++ b/test/examples/instanceof-not/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      18
-    ],
     "raw": "a not instanceof b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 18,
         "isNot": true,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          18
-        ],
         "raw": "a not instanceof b",
         "right": {
           "column": 18,
           "data": "b",
+          "end": 18,
           "line": 1,
-          "range": [
-            17,
-            18
-          ],
           "raw": "b",
+          "start": 17,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "InstanceofOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "a not instanceof b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/instanceof/output.json
+++ b/test/examples/instanceof/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 14,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      14
-    ],
     "raw": "a instanceof b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 14,
         "isNot": false,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          14
-        ],
         "raw": "a instanceof b",
         "right": {
           "column": 14,
           "data": "b",
+          "end": 14,
           "line": 1,
-          "range": [
-            13,
-            14
-          ],
           "raw": "b",
+          "start": 13,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "InstanceofOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 14,
   "line": 1,
-  "range": [
-    0,
-    14
-  ],
   "raw": "a instanceof b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/integer/output.json
+++ b/test/examples/integer/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 1,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      1
-    ],
     "raw": "1",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": 1,
+        "end": 1,
         "line": 1,
-        "range": [
-          0,
-          1
-        ],
         "raw": "1",
+        "start": 0,
         "type": "Int"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 1,
   "line": 1,
-  "range": [
-    0,
-    1
-  ],
   "raw": "1",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/js/output.json
+++ b/test/examples/js/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "a = `void 0`",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 12,
         "expression": {
           "column": 5,
           "data": "void 0",
+          "end": 12,
           "line": 1,
-          "range": [
-            4,
-            12
-          ],
           "raw": "`void 0`",
+          "start": 4,
           "type": "JavaScript"
         },
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "a = `void 0`",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "a = `void 0`",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/keyword-member-access/output.json
+++ b/test/examples/keyword-member-access/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "a.break",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
         "member": {
           "column": 3,
           "data": "break",
+          "end": 7,
           "line": 1,
-          "range": [
-            2,
-            7
-          ],
           "raw": "break",
+          "start": 2,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          7
-        ],
         "raw": "a.break",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "a.break\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/less-than-equal/output.json
+++ b/test/examples/less-than-equal/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a <= b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a <= b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "LTEOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a <= b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/less-than/output.json
+++ b/test/examples/less-than/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a < b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a < b",
         "right": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "LTOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a < b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/logical-and-longform/output.json
+++ b/test/examples/logical-and-longform/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "a and b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          7
-        ],
         "raw": "a and b",
         "right": {
           "column": 7,
           "data": "b",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "b",
+          "start": 6,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "LogicalAndOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "a and b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/logical-and/output.json
+++ b/test/examples/logical-and/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a && b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a && b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "LogicalAndOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a && b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/logical-or-longform/output.json
+++ b/test/examples/logical-or-longform/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a or b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a or b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "LogicalOrOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a or b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/logical-or/output.json
+++ b/test/examples/logical-or/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a || b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a || b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "LogicalOrOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a || b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/loop/output.json
+++ b/test/examples/loop/output.json
@@ -1,57 +1,47 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "loop\n  a",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 8,
           "inline": false,
           "line": 2,
-          "range": [
-            7,
-            8
-          ],
           "raw": "a",
+          "start": 7,
           "statements": [
             {
               "column": 3,
               "data": "a",
+              "end": 8,
               "line": 2,
-              "range": [
-                7,
-                8
-              ],
               "raw": "a",
+              "start": 7,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 8,
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "loop\n  a",
+        "start": 0,
         "type": "Loop"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "loop\n  a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/many-expressions-in-parens/output.json
+++ b/test/examples/many-expressions-in-parens/output.json
@@ -1,139 +1,113 @@
 {
   "body": {
     "column": 1,
+    "end": 19,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      19
-    ],
     "raw": "(a; b; c; d; e) + f",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 19,
         "left": {
           "column": 2,
+          "end": 14,
           "left": {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            1,
-            14
-          ],
           "raw": "a; b; c; d; e",
           "right": {
             "column": 5,
+            "end": 14,
             "left": {
               "column": 5,
               "data": "b",
+              "end": 5,
               "line": 1,
-              "range": [
-                4,
-                5
-              ],
               "raw": "b",
+              "start": 4,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              4,
-              14
-            ],
             "raw": "b; c; d; e",
             "right": {
               "column": 8,
+              "end": 14,
               "left": {
                 "column": 8,
                 "data": "c",
+                "end": 8,
                 "line": 1,
-                "range": [
-                  7,
-                  8
-                ],
                 "raw": "c",
+                "start": 7,
                 "type": "Identifier"
               },
               "line": 1,
-              "range": [
-                7,
-                14
-              ],
               "raw": "c; d; e",
               "right": {
                 "column": 11,
+                "end": 14,
                 "left": {
                   "column": 11,
                   "data": "d",
+                  "end": 11,
                   "line": 1,
-                  "range": [
-                    10,
-                    11
-                  ],
                   "raw": "d",
+                  "start": 10,
                   "type": "Identifier"
                 },
                 "line": 1,
-                "range": [
-                  10,
-                  14
-                ],
                 "raw": "d; e",
                 "right": {
                   "column": 14,
                   "data": "e",
+                  "end": 14,
                   "line": 1,
-                  "range": [
-                    13,
-                    14
-                  ],
                   "raw": "e",
+                  "start": 13,
                   "type": "Identifier"
                 },
+                "start": 10,
                 "type": "SeqOp"
               },
+              "start": 7,
               "type": "SeqOp"
             },
+            "start": 4,
             "type": "SeqOp"
           },
+          "start": 1,
           "type": "SeqOp"
         },
         "line": 1,
-        "range": [
-          0,
-          19
-        ],
         "raw": "(a; b; c; d; e) + f",
         "right": {
           "column": 19,
           "data": "f",
+          "end": 19,
           "line": 1,
-          "range": [
-            18,
-            19
-          ],
           "raw": "f",
+          "start": 18,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "PlusOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 19,
   "line": 1,
-  "range": [
-    0,
-    19
-  ],
   "raw": "(a; b; c; d; e) + f",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/modulo/output.json
+++ b/test/examples/modulo/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a %% b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a %% b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "ModuloOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "a %% b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/multiline-interpolated-string-with-escaped-newline/output.json
+++ b/test/examples/multiline-interpolated-string-with-escaped-newline/output.json
@@ -1,37 +1,32 @@
 {
   "body": {
     "column": 1,
+    "end": 13,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      13
-    ],
     "raw": "\"#{a}\\\n #{b}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 13,
         "expressions": [
           {
             "column": 4,
             "data": "a",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "a",
+            "start": 3,
             "type": "Identifier"
           },
           {
             "column": 4,
             "data": "b",
+            "end": 11,
             "line": 2,
-            "range": [
-              10,
-              11
-            ],
             "raw": "b",
+            "start": 10,
             "type": "Identifier"
           }
         ],
@@ -40,53 +35,42 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 6,
             "data": "",
+            "end": 8,
             "line": 1,
-            "range": [
-              5,
-              8
-            ],
             "raw": "\\\n ",
+            "start": 5,
             "type": "Quasi"
           },
           {
             "column": 6,
             "data": "",
+            "end": 12,
             "line": 2,
-            "range": [
-              12,
-              12
-            ],
             "raw": "",
+            "start": 12,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          13
-        ],
         "raw": "\"#{a}\\\n #{b}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 14,
   "line": 1,
-  "range": [
-    0,
-    14
-  ],
   "raw": "\"#{a}\\\n #{b}\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/multiline-string-with-interpolations-and-quotes/output.json
+++ b/test/examples/multiline-string-with-interpolations-and-quotes/output.json
@@ -1,37 +1,32 @@
 {
   "body": {
     "column": 1,
+    "end": 39,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      39
-    ],
     "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 39,
         "expressions": [
           {
             "column": 9,
             "data": "c",
+            "end": 17,
             "line": 3,
-            "range": [
-              16,
-              17
-            ],
             "raw": "c",
+            "start": 16,
             "type": "Identifier"
           },
           {
             "column": 9,
             "data": "e",
+            "end": 29,
             "line": 4,
-            "range": [
-              28,
-              29
-            ],
             "raw": "e",
+            "start": 28,
             "type": "Identifier"
           }
         ],
@@ -40,53 +35,42 @@
           {
             "column": 4,
             "data": "a\n  b\"",
+            "end": 14,
             "line": 1,
-            "range": [
-              3,
-              14
-            ],
             "raw": "\n  a\n    b\"",
+            "start": 3,
             "type": "Quasi"
           },
           {
             "column": 11,
             "data": "\"\n  d\"",
+            "end": 26,
             "line": 3,
-            "range": [
-              18,
-              26
-            ],
             "raw": "\"\n    d\"",
+            "start": 18,
             "type": "Quasi"
           },
           {
             "column": 11,
             "data": "\"\nf",
+            "end": 36,
             "line": 4,
-            "range": [
-              30,
-              36
-            ],
             "raw": "\"\n  f\n",
+            "start": 30,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          39
-        ],
         "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 40,
   "line": 1,
-  "range": [
-    0,
-    40
-  ],
   "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"#{e}\"\n  f\n\"\"\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/multiline-string-with-quoted-interpolations-and-non-interpolations/output.json
+++ b/test/examples/multiline-string-with-quoted-interpolations-and-non-interpolations/output.json
@@ -1,37 +1,32 @@
 {
   "body": {
     "column": 1,
+    "end": 48,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      48
-    ],
     "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 48,
         "expressions": [
           {
             "column": 9,
             "data": "c",
+            "end": 17,
             "line": 3,
-            "range": [
-              16,
-              17
-            ],
             "raw": "c",
+            "start": 16,
             "type": "Identifier"
           },
           {
             "column": 9,
             "data": "g",
+            "end": 38,
             "line": 5,
-            "range": [
-              37,
-              38
-            ],
             "raw": "g",
+            "start": 37,
             "type": "Identifier"
           }
         ],
@@ -40,53 +35,42 @@
           {
             "column": 4,
             "data": "a\n  b\"",
+            "end": 14,
             "line": 1,
-            "range": [
-              3,
-              14
-            ],
             "raw": "\n  a\n    b\"",
+            "start": 3,
             "type": "Quasi"
           },
           {
             "column": 11,
             "data": "\"\n  d\"e\"\n  f\"",
+            "end": 35,
             "line": 3,
-            "range": [
-              18,
-              35
-            ],
             "raw": "\"\n    d\"e\"\n    f\"",
+            "start": 18,
             "type": "Quasi"
           },
           {
             "column": 11,
             "data": "\"\nh",
+            "end": 45,
             "line": 5,
-            "range": [
-              39,
-              45
-            ],
             "raw": "\"\n  h\n",
+            "start": 39,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          48
-        ],
         "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 49,
   "line": 1,
-  "range": [
-    0,
-    49
-  ],
   "raw": "\"\"\"\n  a\n    b\"#{c}\"\n    d\"e\"\n    f\"#{g}\"\n  h\n\"\"\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/multiple-expressions-in-parens/output.json
+++ b/test/examples/multiple-expressions-in-parens/output.json
@@ -1,76 +1,62 @@
 {
   "body": {
     "column": 1,
+    "end": 10,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      10
-    ],
     "raw": "a + (b; c)",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 10,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          10
-        ],
         "raw": "a + (b; c)",
         "right": {
           "column": 6,
+          "end": 9,
           "left": {
             "column": 6,
             "data": "b",
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "b",
+            "start": 5,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            5,
-            9
-          ],
           "raw": "b; c",
           "right": {
             "column": 9,
             "data": "c",
+            "end": 9,
             "line": 1,
-            "range": [
-              8,
-              9
-            ],
             "raw": "c",
+            "start": 8,
             "type": "Identifier"
           },
+          "start": 5,
           "type": "SeqOp"
         },
+        "start": 0,
         "type": "PlusOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "a + (b; c)",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/multiplication/output.json
+++ b/test/examples/multiplication/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "3 * 4",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": 3,
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "3",
+          "start": 0,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "3 * 4",
         "right": {
           "column": 5,
           "data": 4,
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "4",
+          "start": 4,
           "type": "Int"
         },
+        "start": 0,
         "type": "MultiplyOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "3 * 4",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/negated-equality-longhand/output.json
+++ b/test/examples/negated-equality-longhand/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "a isnt b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 8,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "a isnt b",
         "right": {
           "column": 8,
           "data": "b",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "b",
+          "start": 7,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "NEQOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "a isnt b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/negated-equality/output.json
+++ b/test/examples/negated-equality/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a != b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a != b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "NEQOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a != b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/negation-with-not/output.json
+++ b/test/examples/negation-with-not/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "not a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expression": {
           "column": 5,
           "data": "a",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "not a",
+        "start": 0,
         "type": "LogicalNotOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "not a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/negation/output.json
+++ b/test/examples/negation/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "!a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 2,
         "expression": {
           "column": 2,
           "data": "a",
+          "end": 2,
           "line": 1,
-          "range": [
-            1,
-            2
-          ],
           "raw": "a",
+          "start": 1,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          2
-        ],
         "raw": "!a",
+        "start": 0,
         "type": "LogicalNotOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "!a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/nested-code-with-outdent/output.json
+++ b/test/examples/nested-code-with-outdent/output.json
@@ -1,46 +1,43 @@
 {
   "body": {
     "column": 1,
+    "end": 52,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      52
-    ],
     "raw": "a {\n  b: ->\n    return c d,\n      if e\n        f\n}\ng",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 3,
+            "end": 50,
             "line": 1,
             "members": [
               {
                 "column": 3,
+                "end": 48,
                 "expression": {
                   "body": {
                     "column": 5,
+                    "end": 48,
                     "inline": false,
                     "line": 3,
-                    "range": [
-                      16,
-                      48
-                    ],
                     "raw": "return c d,\n      if e\n        f",
+                    "start": 16,
                     "statements": [
                       {
                         "column": 5,
+                        "end": 48,
                         "expression": {
                           "arguments": [
                             {
                               "column": 14,
                               "data": "d",
+                              "end": 26,
                               "line": 3,
-                              "range": [
-                                25,
-                                26
-                              ],
                               "raw": "d",
+                              "start": 25,
                               "type": "Identifier"
                             },
                             {
@@ -49,158 +46,125 @@
                               "condition": {
                                 "column": 10,
                                 "data": "e",
+                                "end": 38,
                                 "line": 4,
-                                "range": [
-                                  37,
-                                  38
-                                ],
                                 "raw": "e",
+                                "start": 37,
                                 "type": "Identifier"
                               },
                               "consequent": {
                                 "column": 9,
+                                "end": 48,
                                 "inline": false,
                                 "line": 5,
-                                "range": [
-                                  47,
-                                  48
-                                ],
                                 "raw": "f",
+                                "start": 47,
                                 "statements": [
                                   {
                                     "column": 9,
                                     "data": "f",
+                                    "end": 48,
                                     "line": 5,
-                                    "range": [
-                                      47,
-                                      48
-                                    ],
                                     "raw": "f",
+                                    "start": 47,
                                     "type": "Identifier"
                                   }
                                 ],
                                 "type": "Block"
                               },
+                              "end": 48,
                               "isUnless": false,
                               "line": 4,
-                              "range": [
-                                34,
-                                48
-                              ],
                               "raw": "if e\n        f",
+                              "start": 34,
                               "type": "Conditional"
                             }
                           ],
                           "column": 12,
+                          "end": 48,
                           "function": {
                             "column": 12,
                             "data": "c",
+                            "end": 24,
                             "line": 3,
-                            "range": [
-                              23,
-                              24
-                            ],
                             "raw": "c",
+                            "start": 23,
                             "type": "Identifier"
                           },
                           "line": 3,
-                          "range": [
-                            23,
-                            48
-                          ],
                           "raw": "c d,\n      if e\n        f",
+                          "start": 23,
                           "type": "FunctionApplication"
                         },
                         "line": 3,
-                        "range": [
-                          16,
-                          48
-                        ],
                         "raw": "return c d,\n      if e\n        f",
+                        "start": 16,
                         "type": "Return"
                       }
                     ],
                     "type": "Block"
                   },
                   "column": 6,
+                  "end": 48,
                   "line": 2,
                   "parameters": [
                   ],
-                  "range": [
-                    9,
-                    48
-                  ],
                   "raw": "->\n    return c d,\n      if e\n        f",
+                  "start": 9,
                   "type": "Function"
                 },
                 "key": {
                   "column": 3,
                   "data": "b",
+                  "end": 7,
                   "line": 2,
-                  "range": [
-                    6,
-                    7
-                  ],
                   "raw": "b",
+                  "start": 6,
                   "type": "Identifier"
                 },
                 "line": 2,
-                "range": [
-                  6,
-                  48
-                ],
                 "raw": "b: ->\n    return c d,\n      if e\n        f",
+                "start": 6,
                 "type": "ObjectInitialiserMember"
               }
             ],
-            "range": [
-              2,
-              50
-            ],
             "raw": "{\n  b: ->\n    return c d,\n      if e\n        f\n}",
+            "start": 2,
             "type": "ObjectInitialiser"
           }
         ],
         "column": 1,
+        "end": 50,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          50
-        ],
         "raw": "a {\n  b: ->\n    return c d,\n      if e\n        f\n}",
+        "start": 0,
         "type": "FunctionApplication"
       },
       {
         "column": 1,
         "data": "g",
+        "end": 52,
         "line": 7,
-        "range": [
-          51,
-          52
-        ],
         "raw": "g",
+        "start": 51,
         "type": "Identifier"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 53,
   "line": 1,
-  "range": [
-    0,
-    53
-  ],
   "raw": "a {\n  b: ->\n    return c d,\n      if e\n        f\n}\ng\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/nested-conditionals/output.json
+++ b/test/examples/nested-conditionals/output.json
@@ -1,45 +1,37 @@
 {
   "body": {
     "column": 1,
+    "end": 31,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      31
-    ],
     "raw": "if a\n  b\nelse if c\n  d\nelse\n  e",
+    "start": 0,
     "statements": [
       {
         "alternate": {
           "column": 6,
+          "end": 31,
           "inline": true,
           "line": 3,
-          "range": [
-            14,
-            31
-          ],
           "raw": "if c\n  d\nelse\n  e",
+          "start": 14,
           "statements": [
             {
               "alternate": {
                 "column": 3,
+                "end": 31,
                 "inline": false,
                 "line": 6,
-                "range": [
-                  30,
-                  31
-                ],
                 "raw": "e",
+                "start": 30,
                 "statements": [
                   {
                     "column": 3,
                     "data": "e",
+                    "end": 31,
                     "line": 6,
-                    "range": [
-                      30,
-                      31
-                    ],
                     "raw": "e",
+                    "start": 30,
                     "type": "Identifier"
                   }
                 ],
@@ -49,45 +41,37 @@
               "condition": {
                 "column": 9,
                 "data": "c",
+                "end": 18,
                 "line": 3,
-                "range": [
-                  17,
-                  18
-                ],
                 "raw": "c",
+                "start": 17,
                 "type": "Identifier"
               },
               "consequent": {
                 "column": 3,
+                "end": 22,
                 "inline": false,
                 "line": 4,
-                "range": [
-                  21,
-                  22
-                ],
                 "raw": "d",
+                "start": 21,
                 "statements": [
                   {
                     "column": 3,
                     "data": "d",
+                    "end": 22,
                     "line": 4,
-                    "range": [
-                      21,
-                      22
-                    ],
                     "raw": "d",
+                    "start": 21,
                     "type": "Identifier"
                   }
                 ],
                 "type": "Block"
               },
+              "end": 31,
               "isUnless": false,
               "line": 3,
-              "range": [
-                14,
-                31
-              ],
               "raw": "if c\n  d\nelse\n  e",
+              "start": 14,
               "type": "Conditional"
             }
           ],
@@ -97,56 +81,46 @@
         "condition": {
           "column": 4,
           "data": "a",
+          "end": 4,
           "line": 1,
-          "range": [
-            3,
-            4
-          ],
           "raw": "a",
+          "start": 3,
           "type": "Identifier"
         },
         "consequent": {
           "column": 3,
+          "end": 8,
           "inline": false,
           "line": 2,
-          "range": [
-            7,
-            8
-          ],
           "raw": "b",
+          "start": 7,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 8,
               "line": 2,
-              "range": [
-                7,
-                8
-              ],
               "raw": "b",
+              "start": 7,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 31,
         "isUnless": false,
         "line": 1,
-        "range": [
-          0,
-          31
-        ],
         "raw": "if a\n  b\nelse if c\n  d\nelse\n  e",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 31,
   "line": 1,
-  "range": [
-    0,
-    31
-  ],
   "raw": "if a\n  b\nelse if c\n  d\nelse\n  e",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/nested-member-expressions/output.json
+++ b/test/examples/nested-member-expressions/output.json
@@ -1,76 +1,62 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a.b.c",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expression": {
           "column": 1,
+          "end": 3,
           "expression": {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           "line": 1,
           "member": {
             "column": 3,
             "data": "b",
+            "end": 3,
             "line": 1,
-            "range": [
-              2,
-              3
-            ],
             "raw": "b",
+            "start": 2,
             "type": "Identifier"
           },
-          "range": [
-            0,
-            3
-          ],
           "raw": "a.b",
+          "start": 0,
           "type": "MemberAccessOp"
         },
         "line": 1,
         "member": {
           "column": 5,
           "data": "c",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "c",
+          "start": 4,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          5
-        ],
         "raw": "a.b.c",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a.b.c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/nested-object-literals/output.json
+++ b/test/examples/nested-object-literals/output.json
@@ -1,100 +1,82 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "a:\n  b: c",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 9,
         "line": 1,
         "members": [
           {
             "column": 1,
+            "end": 9,
             "expression": {
               "column": 3,
+              "end": 9,
               "line": 2,
               "members": [
                 {
                   "column": 3,
+                  "end": 9,
                   "expression": {
                     "column": 6,
                     "data": "c",
+                    "end": 9,
                     "line": 2,
-                    "range": [
-                      8,
-                      9
-                    ],
                     "raw": "c",
+                    "start": 8,
                     "type": "Identifier"
                   },
                   "key": {
                     "column": 3,
                     "data": "b",
+                    "end": 6,
                     "line": 2,
-                    "range": [
-                      5,
-                      6
-                    ],
                     "raw": "b",
+                    "start": 5,
                     "type": "Identifier"
                   },
                   "line": 2,
-                  "range": [
-                    5,
-                    9
-                  ],
                   "raw": "b: c",
+                  "start": 5,
                   "type": "ObjectInitialiserMember"
                 }
               ],
-              "range": [
-                5,
-                9
-              ],
               "raw": "b: c",
+              "start": 5,
               "type": "ObjectInitialiser"
             },
             "key": {
               "column": 1,
               "data": "a",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "a",
+              "start": 0,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              0,
-              9
-            ],
             "raw": "a:\n  b: c",
+            "start": 0,
             "type": "ObjectInitialiserMember"
           }
         ],
-        "range": [
-          0,
-          9
-        ],
         "raw": "a:\n  b: c",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "a:\n  b: c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/nested-string-interpolation/output.json
+++ b/test/examples/nested-string-interpolation/output.json
@@ -1,29 +1,27 @@
 {
   "body": {
     "column": 1,
+    "end": 13,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      13
-    ],
     "raw": "\"a#{\"b#{c}\"}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 13,
         "expressions": [
           {
             "column": 5,
+            "end": 11,
             "expressions": [
               {
                 "column": 9,
                 "data": "c",
+                "end": 9,
                 "line": 1,
-                "range": [
-                  8,
-                  9
-                ],
                 "raw": "c",
+                "start": 8,
                 "type": "Identifier"
               }
             ],
@@ -32,31 +30,24 @@
               {
                 "column": 6,
                 "data": "b",
+                "end": 6,
                 "line": 1,
-                "range": [
-                  5,
-                  6
-                ],
                 "raw": "b",
+                "start": 5,
                 "type": "Quasi"
               },
               {
                 "column": 11,
                 "data": "",
+                "end": 10,
                 "line": 1,
-                "range": [
-                  10,
-                  10
-                ],
                 "raw": "",
+                "start": 10,
                 "type": "Quasi"
               }
             ],
-            "range": [
-              4,
-              11
-            ],
             "raw": "\"b#{c}\"",
+            "start": 4,
             "type": "String"
           }
         ],
@@ -65,42 +56,33 @@
           {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 13,
             "data": "",
+            "end": 12,
             "line": 1,
-            "range": [
-              12,
-              12
-            ],
             "raw": "",
+            "start": 12,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          13
-        ],
         "raw": "\"a#{\"b#{c}\"}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "\"a#{\"b#{c}\"}\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/new-with-method-call/output.json
+++ b/test/examples/new-with-method-call/output.json
@@ -1,42 +1,38 @@
 {
   "body": {
     "column": 1,
+    "end": 15,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      15
-    ],
     "raw": "-> new A().b(c)",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 4,
+          "end": 15,
           "inline": true,
           "line": 1,
-          "range": [
-            3,
-            15
-          ],
           "raw": "new A().b(c)",
+          "start": 3,
           "statements": [
             {
               "arguments": [
                 {
                   "column": 14,
                   "data": "c",
+                  "end": 14,
                   "line": 1,
-                  "range": [
-                    13,
-                    14
-                  ],
                   "raw": "c",
+                  "start": 13,
                   "type": "Identifier"
                 }
               ],
               "column": 4,
+              "end": 15,
               "function": {
                 "column": 4,
+                "end": 12,
                 "expression": {
                   "arguments": [
                   ],
@@ -44,72 +40,56 @@
                   "ctor": {
                     "column": 8,
                     "data": "A",
+                    "end": 8,
                     "line": 1,
-                    "range": [
-                      7,
-                      8
-                    ],
                     "raw": "A",
+                    "start": 7,
                     "type": "Identifier"
                   },
+                  "end": 10,
                   "line": 1,
-                  "range": [
-                    3,
-                    10
-                  ],
                   "raw": "new A()",
+                  "start": 3,
                   "type": "NewOp"
                 },
                 "line": 1,
                 "member": {
                   "column": 12,
                   "data": "b",
+                  "end": 12,
                   "line": 1,
-                  "range": [
-                    11,
-                    12
-                  ],
                   "raw": "b",
+                  "start": 11,
                   "type": "Identifier"
                 },
-                "range": [
-                  3,
-                  12
-                ],
                 "raw": "new A().b",
+                "start": 3,
                 "type": "MemberAccessOp"
               },
               "line": 1,
-              "range": [
-                3,
-                15
-              ],
               "raw": "new A().b(c)",
+              "start": 3,
               "type": "FunctionApplication"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 15,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          15
-        ],
         "raw": "-> new A().b(c)",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 16,
   "line": 1,
-  "range": [
-    0,
-    16
-  ],
   "raw": "-> new A().b(c)\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/new-without-parens/output.json
+++ b/test/examples/new-without-parens/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "new A",
+    "start": 0,
     "statements": [
       {
         "arguments": [
@@ -16,31 +14,25 @@
         "ctor": {
           "column": 5,
           "data": "A",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "A",
+          "start": 4,
           "type": "Identifier"
         },
+        "end": 5,
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "new A",
+        "start": 0,
         "type": "NewOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "new A",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/new/output.json
+++ b/test/examples/new/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "new a.B()",
+    "start": 0,
     "statements": [
       {
         "arguments": [
@@ -15,53 +13,43 @@
         "column": 1,
         "ctor": {
           "column": 5,
+          "end": 7,
           "expression": {
             "column": 5,
             "data": "a",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "a",
+            "start": 4,
             "type": "Identifier"
           },
           "line": 1,
           "member": {
             "column": 7,
             "data": "B",
+            "end": 7,
             "line": 1,
-            "range": [
-              6,
-              7
-            ],
             "raw": "B",
+            "start": 6,
             "type": "Identifier"
           },
-          "range": [
-            4,
-            7
-          ],
           "raw": "a.B",
+          "start": 4,
           "type": "MemberAccessOp"
         },
+        "end": 9,
         "line": 1,
-        "range": [
-          0,
-          9
-        ],
         "raw": "new a.B()",
+        "start": 0,
         "type": "NewOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "new a.B()",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/null/output.json
+++ b/test/examples/null/output.json
@@ -1,33 +1,27 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "null",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 4,
         "line": 1,
-        "range": [
-          0,
-          4
-        ],
         "raw": "null",
+        "start": 0,
         "type": "Null"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": "null",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/number-object-key/output.json
+++ b/test/examples/number-object-key/output.json
@@ -1,67 +1,61 @@
 {
   "body": {
     "column": 1,
+    "end": 38,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      38
-    ],
     "raw": "arr = {length: 1, 0: 'Hello', 3.14: 0}",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "arr",
+          "end": 3,
           "line": 1,
-          "range": [
-            0,
-            3
-          ],
           "raw": "arr",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 38,
         "expression": {
           "column": 7,
+          "end": 38,
           "line": 1,
           "members": [
             {
               "column": 8,
+              "end": 16,
               "expression": {
                 "column": 16,
                 "data": 1,
+                "end": 16,
                 "line": 1,
-                "range": [
-                  15,
-                  16
-                ],
                 "raw": "1",
+                "start": 15,
                 "type": "Int"
               },
               "key": {
                 "column": 8,
                 "data": "length",
+                "end": 13,
                 "line": 1,
-                "range": [
-                  7,
-                  13
-                ],
                 "raw": "length",
+                "start": 7,
                 "type": "Identifier"
               },
               "line": 1,
-              "range": [
-                7,
-                16
-              ],
               "raw": "length: 1",
+              "start": 7,
               "type": "ObjectInitialiserMember"
             },
             {
               "column": 19,
+              "end": 28,
               "expression": {
                 "column": 22,
+                "end": 28,
                 "expressions": [
                 ],
                 "line": 1,
@@ -69,98 +63,74 @@
                   {
                     "column": 23,
                     "data": "Hello",
+                    "end": 27,
                     "line": 1,
-                    "range": [
-                      22,
-                      27
-                    ],
                     "raw": "Hello",
+                    "start": 22,
                     "type": "Quasi"
                   }
                 ],
-                "range": [
-                  21,
-                  28
-                ],
                 "raw": "'Hello'",
+                "start": 21,
                 "type": "String"
               },
               "key": {
                 "column": 19,
                 "data": 0,
+                "end": 19,
                 "line": 1,
-                "range": [
-                  18,
-                  19
-                ],
                 "raw": "0",
+                "start": 18,
                 "type": "Int"
               },
               "line": 1,
-              "range": [
-                18,
-                28
-              ],
               "raw": "0: 'Hello'",
+              "start": 18,
               "type": "ObjectInitialiserMember"
             },
             {
               "column": 31,
+              "end": 37,
               "expression": {
                 "column": 37,
                 "data": 0,
+                "end": 37,
                 "line": 1,
-                "range": [
-                  36,
-                  37
-                ],
                 "raw": "0",
+                "start": 36,
                 "type": "Int"
               },
               "key": {
                 "column": 31,
                 "data": 3.14,
+                "end": 34,
                 "line": 1,
-                "range": [
-                  30,
-                  34
-                ],
                 "raw": "3.14",
+                "start": 30,
                 "type": "Float"
               },
               "line": 1,
-              "range": [
-                30,
-                37
-              ],
               "raw": "3.14: 0",
+              "start": 30,
               "type": "ObjectInitialiserMember"
             }
           ],
-          "range": [
-            6,
-            38
-          ],
           "raw": "{length: 1, 0: 'Hello', 3.14: 0}",
+          "start": 6,
           "type": "ObjectInitialiser"
         },
         "line": 1,
-        "range": [
-          0,
-          38
-        ],
         "raw": "arr = {length: 1, 0: 'Hello', 3.14: 0}",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 39,
   "line": 1,
-  "range": [
-    0,
-    39
-  ],
   "raw": "arr = {length: 1, 0: 'Hello', 3.14: 0}\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/object-destructure-with-default/output.json
+++ b/test/examples/object-destructure-with-default/output.json
@@ -1,88 +1,72 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "{a = 1} = b",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
+          "end": 7,
           "line": 1,
           "members": [
             {
               "assignee": {
                 "column": 2,
                 "data": "a",
+                "end": 2,
                 "line": 1,
-                "range": [
-                  1,
-                  2
-                ],
                 "raw": "a",
+                "start": 1,
                 "type": "Identifier"
               },
               "column": 2,
+              "end": 6,
               "expression": {
                 "column": 6,
                 "data": 1,
+                "end": 6,
                 "line": 1,
-                "range": [
-                  5,
-                  6
-                ],
                 "raw": "1",
+                "start": 5,
                 "type": "Int"
               },
               "line": 1,
-              "range": [
-                1,
-                6
-              ],
               "raw": "a = 1",
+              "start": 1,
               "type": "AssignOp"
             }
           ],
-          "range": [
-            0,
-            7
-          ],
           "raw": "{a = 1}",
+          "start": 0,
           "type": "ObjectInitialiser"
         },
         "column": 1,
+        "end": 11,
         "expression": {
           "column": 11,
           "data": "b",
+          "end": 11,
           "line": 1,
-          "range": [
-            10,
-            11
-          ],
           "raw": "b",
+          "start": 10,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          11
-        ],
         "raw": "{a = 1} = b",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "{a = 1} = b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/object-with-block-comments/output.json
+++ b/test/examples/object-with-block-comments/output.json
@@ -1,88 +1,72 @@
 {
   "body": {
     "column": 1,
+    "end": 47,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      47
-    ],
     "raw": "obj =\n  ###\n  # @returns {boolean}\n  ###\n  a: 1",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "obj",
+          "end": 3,
           "line": 1,
-          "range": [
-            0,
-            3
-          ],
           "raw": "obj",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 47,
         "expression": {
           "column": 3,
+          "end": 47,
           "line": 2,
           "members": [
             {
               "column": 3,
+              "end": 47,
               "expression": {
                 "column": 6,
                 "data": 1,
+                "end": 47,
                 "line": 5,
-                "range": [
-                  46,
-                  47
-                ],
                 "raw": "1",
+                "start": 46,
                 "type": "Int"
               },
               "key": {
                 "column": 3,
                 "data": "a",
+                "end": 44,
                 "line": 5,
-                "range": [
-                  43,
-                  44
-                ],
                 "raw": "a",
+                "start": 43,
                 "type": "Identifier"
               },
               "line": 5,
-              "range": [
-                43,
-                47
-              ],
               "raw": "a: 1",
+              "start": 43,
               "type": "ObjectInitialiserMember"
             }
           ],
-          "range": [
-            8,
-            47
-          ],
           "raw": "###\n  # @returns {boolean}\n  ###\n  a: 1",
+          "start": 8,
           "type": "ObjectInitialiser"
         },
         "line": 1,
-        "range": [
-          0,
-          47
-        ],
         "raw": "obj =\n  ###\n  # @returns {boolean}\n  ###\n  a: 1",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 47,
   "line": 1,
-  "range": [
-    0,
-    47
-  ],
   "raw": "obj =\n  ###\n  # @returns {boolean}\n  ###\n  a: 1",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/object-with-braces/output.json
+++ b/test/examples/object-with-braces/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "{a: 1}",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "line": 1,
         "members": [
           {
             "column": 2,
+            "end": 5,
             "expression": {
               "column": 5,
               "data": 1,
+              "end": 5,
               "line": 1,
-              "range": [
-                4,
-                5
-              ],
               "raw": "1",
+              "start": 4,
               "type": "Int"
             },
             "key": {
               "column": 2,
               "data": "a",
+              "end": 2,
               "line": 1,
-              "range": [
-                1,
-                2
-              ],
               "raw": "a",
+              "start": 1,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              1,
-              5
-            ],
             "raw": "a: 1",
+            "start": 1,
             "type": "ObjectInitialiserMember"
           }
         ],
-        "range": [
-          0,
-          6
-        ],
         "raw": "{a: 1}",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "{a: 1}",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/object-with-combined-key-value/output.json
+++ b/test/examples/object-with-combined-key-value/output.json
@@ -1,99 +1,73 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "{ a, b: 1 }",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "line": 1,
         "members": [
           {
             "column": 3,
-            "expression": {
-              "column": 3,
-              "data": "a",
-              "line": 1,
-              "range": [
-                2,
-                3
-              ],
-              "raw": "a",
-              "type": "Identifier"
-            },
+            "end": 3,
+            "expression": null,
             "key": {
               "column": 3,
               "data": "a",
+              "end": 3,
               "line": 1,
-              "range": [
-                2,
-                3
-              ],
               "raw": "a",
+              "start": 2,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              2,
-              3
-            ],
             "raw": "a",
+            "start": 2,
             "type": "ObjectInitialiserMember"
           },
           {
             "column": 6,
+            "end": 9,
             "expression": {
               "column": 9,
               "data": 1,
+              "end": 9,
               "line": 1,
-              "range": [
-                8,
-                9
-              ],
               "raw": "1",
+              "start": 8,
               "type": "Int"
             },
             "key": {
               "column": 6,
               "data": "b",
+              "end": 6,
               "line": 1,
-              "range": [
-                5,
-                6
-              ],
               "raw": "b",
+              "start": 5,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              5,
-              9
-            ],
             "raw": "b: 1",
+            "start": 5,
             "type": "ObjectInitialiserMember"
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "{ a, b: 1 }",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "{ a, b: 1 }",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/object-with-multiple-properties/output.json
+++ b/test/examples/object-with-multiple-properties/output.json
@@ -1,99 +1,81 @@
 {
   "body": {
     "column": 1,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      18
-    ],
     "raw": "{\n  a: 1,\n  b: 2\n}",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 18,
         "line": 1,
         "members": [
           {
             "column": 3,
+            "end": 8,
             "expression": {
               "column": 6,
               "data": 1,
+              "end": 8,
               "line": 2,
-              "range": [
-                7,
-                8
-              ],
               "raw": "1",
+              "start": 7,
               "type": "Int"
             },
             "key": {
               "column": 3,
               "data": "a",
+              "end": 5,
               "line": 2,
-              "range": [
-                4,
-                5
-              ],
               "raw": "a",
+              "start": 4,
               "type": "Identifier"
             },
             "line": 2,
-            "range": [
-              4,
-              8
-            ],
             "raw": "a: 1",
+            "start": 4,
             "type": "ObjectInitialiserMember"
           },
           {
             "column": 3,
+            "end": 16,
             "expression": {
               "column": 6,
               "data": 2,
+              "end": 16,
               "line": 3,
-              "range": [
-                15,
-                16
-              ],
               "raw": "2",
+              "start": 15,
               "type": "Int"
             },
             "key": {
               "column": 3,
               "data": "b",
+              "end": 13,
               "line": 3,
-              "range": [
-                12,
-                13
-              ],
               "raw": "b",
+              "start": 12,
               "type": "Identifier"
             },
             "line": 3,
-            "range": [
-              12,
-              16
-            ],
             "raw": "b: 2",
+            "start": 12,
             "type": "ObjectInitialiserMember"
           }
         ],
-        "range": [
-          0,
-          18
-        ],
         "raw": "{\n  a: 1,\n  b: 2\n}",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "{\n  a: 1,\n  b: 2\n}",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/object-with-parenthesized-value/output.json
+++ b/test/examples/object-with-parenthesized-value/output.json
@@ -1,99 +1,73 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "{a: (b), c}",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "line": 1,
         "members": [
           {
             "column": 2,
+            "end": 7,
             "expression": {
               "column": 6,
               "data": "b",
+              "end": 6,
               "line": 1,
-              "range": [
-                5,
-                6
-              ],
               "raw": "b",
+              "start": 5,
               "type": "Identifier"
             },
             "key": {
               "column": 2,
               "data": "a",
+              "end": 2,
               "line": 1,
-              "range": [
-                1,
-                2
-              ],
               "raw": "a",
+              "start": 1,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              1,
-              7
-            ],
             "raw": "a: (b)",
+            "start": 1,
             "type": "ObjectInitialiserMember"
           },
           {
             "column": 10,
-            "expression": {
-              "column": 10,
-              "data": "c",
-              "line": 1,
-              "range": [
-                9,
-                10
-              ],
-              "raw": "c",
-              "type": "Identifier"
-            },
+            "end": 10,
+            "expression": null,
             "key": {
               "column": 10,
               "data": "c",
+              "end": 10,
               "line": 1,
-              "range": [
-                9,
-                10
-              ],
               "raw": "c",
+              "start": 9,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              9,
-              10
-            ],
             "raw": "c",
+            "start": 9,
             "type": "ObjectInitialiserMember"
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "{a: (b), c}",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "{a: (b), c}\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/object-without-braces/output.json
+++ b/test/examples/object-without-braces/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "a: 1",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 4,
         "line": 1,
         "members": [
           {
             "column": 1,
+            "end": 4,
             "expression": {
               "column": 4,
               "data": 1,
+              "end": 4,
               "line": 1,
-              "range": [
-                3,
-                4
-              ],
               "raw": "1",
+              "start": 3,
               "type": "Int"
             },
             "key": {
               "column": 1,
               "data": "a",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "a",
+              "start": 0,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              0,
-              4
-            ],
             "raw": "a: 1",
+            "start": 0,
             "type": "ObjectInitialiserMember"
           }
         ],
-        "range": [
-          0,
-          4
-        ],
         "raw": "a: 1",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": "a: 1",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/octal-number/output.json
+++ b/test/examples/octal-number/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "0o1234",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": 668,
+        "end": 6,
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "0o1234",
+        "start": 0,
         "type": "Int"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "0o1234",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/of-not/output.json
+++ b/test/examples/of-not/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 10,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      10
-    ],
     "raw": "a not of b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 10,
         "isNot": true,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          10
-        ],
         "raw": "a not of b",
         "right": {
           "column": 10,
           "data": "b",
+          "end": 10,
           "line": 1,
-          "range": [
-            9,
-            10
-          ],
           "raw": "b",
+          "start": 9,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "OfOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "a not of b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/of/output.json
+++ b/test/examples/of/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a of b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "isNot": false,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a of b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "OfOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a of b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/only-empty-string-interpolation/output.json
+++ b/test/examples/only-empty-string-interpolation/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "\"#{}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expressions": [
           null
         ],
@@ -19,42 +18,33 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 5,
             "data": "",
+            "end": 4,
             "line": 1,
-            "range": [
-              4,
-              4
-            ],
             "raw": "",
+            "start": 4,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          5
-        ],
         "raw": "\"#{}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "\"#{}\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/parentheses/output.json
+++ b/test/examples/parentheses/output.json
@@ -1,76 +1,62 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "(a + b) * c",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "left": {
           "column": 2,
+          "end": 6,
           "left": {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            1,
-            6
-          ],
           "raw": "a + b",
           "right": {
             "column": 6,
             "data": "b",
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "b",
+            "start": 5,
             "type": "Identifier"
           },
+          "start": 1,
           "type": "PlusOp"
         },
         "line": 1,
-        "range": [
-          0,
-          11
-        ],
         "raw": "(a + b) * c",
         "right": {
           "column": 11,
           "data": "c",
+          "end": 11,
           "line": 1,
-          "range": [
-            10,
-            11
-          ],
           "raw": "c",
+          "start": 10,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "MultiplyOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "(a + b) * c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/parenthesized-member-access/output.json
+++ b/test/examples/parenthesized-member-access/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "(a).b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expression": {
           "column": 2,
           "data": "a",
+          "end": 2,
           "line": 1,
-          "range": [
-            1,
-            2
-          ],
           "raw": "a",
+          "start": 1,
           "type": "Identifier"
         },
         "line": 1,
         "member": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          5
-        ],
         "raw": "(a).b",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "(a).b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/post-decrement/output.json
+++ b/test/examples/post-decrement/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "a--",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": "a--",
+        "start": 0,
         "type": "PostDecrementOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "a--",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/post-for/output.json
+++ b/test/examples/post-for/output.json
@@ -1,70 +1,58 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "a for a in b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 1,
+          "end": 1,
           "inline": true,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "statements": [
             {
               "column": 1,
               "data": "a",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "a",
+              "start": 0,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 12,
         "filter": null,
         "keyAssignee": null,
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "a for a in b",
+        "start": 0,
         "step": null,
         "target": {
           "column": 12,
           "data": "b",
+          "end": 12,
           "line": 1,
-          "range": [
-            11,
-            12
-          ],
           "raw": "b",
+          "start": 11,
           "type": "Identifier"
         },
         "type": "ForIn",
         "valAssignee": {
           "column": 7,
           "data": "a",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "type": "Identifier"
         }
       }
@@ -72,11 +60,9 @@
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "a for a in b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/post-increment/output.json
+++ b/test/examples/post-increment/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "a++",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": "a++",
+        "start": 0,
         "type": "PostIncrementOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "a++",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/post-unless-not-if/output.json
+++ b/test/examples/post-unless-not-if/output.json
@@ -1,92 +1,76 @@
 {
   "body": {
     "column": 1,
+    "end": 19,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      19
-    ],
     "raw": "c unless a not in b",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
         "column": 1,
         "condition": {
           "column": 10,
+          "end": 19,
           "isNot": true,
           "left": {
             "column": 10,
             "data": "a",
+            "end": 10,
             "line": 1,
-            "range": [
-              9,
-              10
-            ],
             "raw": "a",
+            "start": 9,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            9,
-            19
-          ],
           "raw": "a not in b",
           "right": {
             "column": 19,
             "data": "b",
+            "end": 19,
             "line": 1,
-            "range": [
-              18,
-              19
-            ],
             "raw": "b",
+            "start": 18,
             "type": "Identifier"
           },
+          "start": 9,
           "type": "InOp"
         },
         "consequent": {
           "column": 1,
+          "end": 1,
           "inline": true,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "c",
+          "start": 0,
           "statements": [
             {
               "column": 1,
               "data": "c",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "c",
+              "start": 0,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 19,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          19
-        ],
         "raw": "c unless a not in b",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 20,
   "line": 1,
-  "range": [
-    0,
-    20
-  ],
   "raw": "c unless a not in b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/post-while-with-loop/output.json
+++ b/test/examples/post-while-with-loop/output.json
@@ -1,45 +1,37 @@
 {
   "body": {
     "column": 1,
+    "end": 14,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      14
-    ],
     "raw": "loop a while b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 6,
+          "end": 14,
           "inline": true,
           "line": 1,
-          "range": [
-            5,
-            14
-          ],
           "raw": "a while b",
+          "start": 5,
           "statements": [
             {
               "body": {
                 "column": 6,
+                "end": 6,
                 "inline": true,
                 "line": 1,
-                "range": [
-                  5,
-                  6
-                ],
                 "raw": "a",
+                "start": 5,
                 "statements": [
                   {
                     "column": 6,
                     "data": "a",
+                    "end": 6,
                     "line": 1,
-                    "range": [
-                      5,
-                      6
-                    ],
                     "raw": "a",
+                    "start": 5,
                     "type": "Identifier"
                   }
                 ],
@@ -49,45 +41,37 @@
               "condition": {
                 "column": 14,
                 "data": "b",
+                "end": 14,
                 "line": 1,
-                "range": [
-                  13,
-                  14
-                ],
                 "raw": "b",
+                "start": 13,
                 "type": "Identifier"
               },
+              "end": 14,
               "guard": null,
               "isUntil": false,
               "line": 1,
-              "range": [
-                5,
-                14
-              ],
               "raw": "a while b",
+              "start": 5,
               "type": "While"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 14,
         "line": 1,
-        "range": [
-          0,
-          14
-        ],
         "raw": "loop a while b",
+        "start": 0,
         "type": "Loop"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 15,
   "line": 1,
-  "range": [
-    0,
-    15
-  ],
   "raw": "loop a while b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/pow/output.json
+++ b/test/examples/pow/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a ** b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "left": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a ** b",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "ExpOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a ** b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/pre-decrement/output.json
+++ b/test/examples/pre-decrement/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "--a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "expression": {
           "column": 3,
           "data": "a",
+          "end": 3,
           "line": 1,
-          "range": [
-            2,
-            3
-          ],
           "raw": "a",
+          "start": 2,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": "--a",
+        "start": 0,
         "type": "PreDecrementOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "--a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/pre-increment/output.json
+++ b/test/examples/pre-increment/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "++a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "expression": {
           "column": 3,
           "data": "a",
+          "end": 3,
           "line": 1,
-          "range": [
-            2,
-            3
-          ],
           "raw": "a",
+          "start": 2,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": "++a",
+        "start": 0,
         "type": "PreIncrementOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "++a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/prototype-member-access/output.json
+++ b/test/examples/prototype-member-access/output.json
@@ -1,65 +1,53 @@
 {
   "body": {
     "column": 1,
+    "end": 16,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      16
-    ],
     "raw": "Object::toString",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 16,
         "expression": {
           "column": 1,
+          "end": 8,
           "expression": {
             "column": 1,
             "data": "Object",
+            "end": 6,
             "line": 1,
-            "range": [
-              0,
-              6
-            ],
             "raw": "Object",
+            "start": 0,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            0,
-            8
-          ],
           "raw": "Object::",
+          "start": 0,
           "type": "ProtoMemberAccessOp"
         },
         "line": 1,
         "member": {
           "column": 9,
           "data": "toString",
+          "end": 16,
           "line": 1,
-          "range": [
-            8,
-            16
-          ],
           "raw": "toString",
+          "start": 8,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          16
-        ],
         "raw": "Object::toString",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 16,
   "line": 1,
-  "range": [
-    0,
-    16
-  ],
   "raw": "Object::toString",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/range-exclusive/output.json
+++ b/test/examples/range-exclusive/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "[a...b]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "isInclusive": false,
         "left": {
           "column": 2,
           "data": "a",
+          "end": 2,
           "line": 1,
-          "range": [
-            1,
-            2
-          ],
           "raw": "a",
+          "start": 1,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          7
-        ],
         "raw": "[a...b]",
         "right": {
           "column": 6,
           "data": "b",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "b",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "Range"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "[a...b]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/range-inclusive/output.json
+++ b/test/examples/range-inclusive/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "[a..b]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "isInclusive": true,
         "left": {
           "column": 2,
           "data": "a",
+          "end": 2,
           "line": 1,
-          "range": [
-            1,
-            2
-          ],
           "raw": "a",
+          "start": 1,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "[a..b]",
         "right": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "Range"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "[a..b]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/regexp/output.json
+++ b/test/examples/regexp/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "/a/",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "flags": {
           "g": false,
           "global": false,
@@ -23,22 +22,17 @@
         },
         "line": 1,
         "pattern": "a",
-        "range": [
-          0,
-          3
-        ],
         "raw": "/a/",
+        "start": 0,
         "type": "Regex"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": "/a/\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/remainder/output.json
+++ b/test/examples/remainder/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "3 % 4",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": 3,
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "3",
+          "start": 0,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "3 % 4",
         "right": {
           "column": 5,
           "data": 4,
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "4",
+          "start": 4,
           "type": "Int"
         },
+        "start": 0,
         "type": "RemOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "3 % 4",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/rest-param-in-bound-function/output.json
+++ b/test/examples/rest-param-in-bound-function/output.json
@@ -1,57 +1,47 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "(rest...) =>",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 12,
         "line": 1,
         "parameters": [
           {
             "column": 2,
+            "end": 8,
             "expression": {
               "column": 2,
               "data": "rest",
+              "end": 5,
               "line": 1,
-              "range": [
-                1,
-                5
-              ],
               "raw": "rest",
+              "start": 1,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              1,
-              8
-            ],
             "raw": "rest...",
+            "start": 1,
             "type": "Rest"
           }
         ],
-        "range": [
-          0,
-          12
-        ],
         "raw": "(rest...) =>",
+        "start": 0,
         "type": "BoundFunction"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "(rest...) =>",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/rest-param-in-function/output.json
+++ b/test/examples/rest-param-in-function/output.json
@@ -1,57 +1,47 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "(rest...) ->",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 12,
         "line": 1,
         "parameters": [
           {
             "column": 2,
+            "end": 8,
             "expression": {
               "column": 2,
               "data": "rest",
+              "end": 5,
               "line": 1,
-              "range": [
-                1,
-                5
-              ],
               "raw": "rest",
+              "start": 1,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              1,
-              8
-            ],
             "raw": "rest...",
+            "start": 1,
             "type": "Rest"
           }
         ],
-        "range": [
-          0,
-          12
-        ],
         "raw": "(rest...) ->",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "(rest...) ->",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/return-with-expression/output.json
+++ b/test/examples/return-with-expression/output.json
@@ -1,69 +1,57 @@
 {
   "body": {
     "column": 1,
+    "end": 13,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      13
-    ],
     "raw": "->\n  return a",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 13,
           "inline": false,
           "line": 2,
-          "range": [
-            5,
-            13
-          ],
           "raw": "return a",
+          "start": 5,
           "statements": [
             {
               "column": 3,
+              "end": 13,
               "expression": {
                 "column": 10,
                 "data": "a",
+                "end": 13,
                 "line": 2,
-                "range": [
-                  12,
-                  13
-                ],
                 "raw": "a",
+                "start": 12,
                 "type": "Identifier"
               },
               "line": 2,
-              "range": [
-                5,
-                13
-              ],
               "raw": "return a",
+              "start": 5,
               "type": "Return"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 13,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          13
-        ],
         "raw": "->\n  return a",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "->\n  return a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/return-without-expression/output.json
+++ b/test/examples/return-without-expression/output.json
@@ -1,59 +1,49 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "->\n  return",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 11,
           "inline": false,
           "line": 2,
-          "range": [
-            5,
-            11
-          ],
           "raw": "return",
+          "start": 5,
           "statements": [
             {
               "column": 3,
+              "end": 11,
               "expression": null,
               "line": 2,
-              "range": [
-                5,
-                11
-              ],
               "raw": "return",
+              "start": 5,
               "type": "Return"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 11,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "->\n  return",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "->\n  return",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/shorthand-object-with-interpolated-strings/output.json
+++ b/test/examples/shorthand-object-with-interpolated-strings/output.json
@@ -1,92 +1,44 @@
 {
   "body": {
     "column": 1,
+    "end": 14,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      14
-    ],
     "raw": "x = {\"a#{b}c\"}",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "x",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "x",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 14,
         "expression": {
           "column": 5,
+          "end": 14,
           "line": 1,
           "members": [
             {
               "column": 6,
-              "expression": {
-                "column": 6,
-                "expressions": [
-                  {
-                    "column": 10,
-                    "data": "b",
-                    "line": 1,
-                    "range": [
-                      9,
-                      10
-                    ],
-                    "raw": "b",
-                    "type": "Identifier"
-                  }
-                ],
-                "line": 1,
-                "quasis": [
-                  {
-                    "column": 7,
-                    "data": "a",
-                    "line": 1,
-                    "range": [
-                      6,
-                      7
-                    ],
-                    "raw": "a",
-                    "type": "Quasi"
-                  },
-                  {
-                    "column": 12,
-                    "data": "c",
-                    "line": 1,
-                    "range": [
-                      11,
-                      12
-                    ],
-                    "raw": "c",
-                    "type": "Quasi"
-                  }
-                ],
-                "range": [
-                  5,
-                  13
-                ],
-                "raw": "\"a#{b}c\"",
-                "type": "String"
-              },
+              "end": 13,
+              "expression": null,
               "key": {
                 "column": 6,
+                "end": 13,
                 "expressions": [
                   {
                     "column": 10,
                     "data": "b",
+                    "end": 10,
                     "line": 1,
-                    "range": [
-                      9,
-                      10
-                    ],
                     "raw": "b",
+                    "start": 9,
                     "type": "Identifier"
                   }
                 ],
@@ -95,66 +47,48 @@
                   {
                     "column": 7,
                     "data": "a",
+                    "end": 7,
                     "line": 1,
-                    "range": [
-                      6,
-                      7
-                    ],
                     "raw": "a",
+                    "start": 6,
                     "type": "Quasi"
                   },
                   {
                     "column": 12,
                     "data": "c",
+                    "end": 12,
                     "line": 1,
-                    "range": [
-                      11,
-                      12
-                    ],
                     "raw": "c",
+                    "start": 11,
                     "type": "Quasi"
                   }
                 ],
-                "range": [
-                  5,
-                  13
-                ],
                 "raw": "\"a#{b}c\"",
+                "start": 5,
                 "type": "String"
               },
               "line": 1,
-              "range": [
-                5,
-                13
-              ],
               "raw": "\"a#{b}c\"",
+              "start": 5,
               "type": "ObjectInitialiserMember"
             }
           ],
-          "range": [
-            4,
-            14
-          ],
           "raw": "{\"a#{b}c\"}",
+          "start": 4,
           "type": "ObjectInitialiser"
         },
         "line": 1,
-        "range": [
-          0,
-          14
-        ],
         "raw": "x = {\"a#{b}c\"}",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 15,
   "line": 1,
-  "range": [
-    0,
-    15
-  ],
   "raw": "x = {\"a#{b}c\"}\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/shorthand-object-with-strings/output.json
+++ b/test/examples/shorthand-object-with-strings/output.json
@@ -1,60 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 25,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      25
-    ],
     "raw": "x = {\"FOO\", \"BAR\", \"BAZ\"}",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
           "data": "x",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "x",
+          "start": 0,
           "type": "Identifier"
         },
         "column": 1,
+        "end": 25,
         "expression": {
           "column": 5,
+          "end": 25,
           "line": 1,
           "members": [
             {
               "column": 6,
-              "expression": {
-                "column": 6,
-                "expressions": [
-                ],
-                "line": 1,
-                "quasis": [
-                  {
-                    "column": 7,
-                    "data": "FOO",
-                    "line": 1,
-                    "range": [
-                      6,
-                      9
-                    ],
-                    "raw": "FOO",
-                    "type": "Quasi"
-                  }
-                ],
-                "range": [
-                  5,
-                  10
-                ],
-                "raw": "\"FOO\"",
-                "type": "String"
-              },
+              "end": 10,
+              "expression": null,
               "key": {
                 "column": 6,
+                "end": 10,
                 "expressions": [
                 ],
                 "line": 1,
@@ -62,59 +38,29 @@
                   {
                     "column": 7,
                     "data": "FOO",
+                    "end": 9,
                     "line": 1,
-                    "range": [
-                      6,
-                      9
-                    ],
                     "raw": "FOO",
+                    "start": 6,
                     "type": "Quasi"
                   }
                 ],
-                "range": [
-                  5,
-                  10
-                ],
                 "raw": "\"FOO\"",
+                "start": 5,
                 "type": "String"
               },
               "line": 1,
-              "range": [
-                5,
-                10
-              ],
               "raw": "\"FOO\"",
+              "start": 5,
               "type": "ObjectInitialiserMember"
             },
             {
               "column": 13,
-              "expression": {
-                "column": 13,
-                "expressions": [
-                ],
-                "line": 1,
-                "quasis": [
-                  {
-                    "column": 14,
-                    "data": "BAR",
-                    "line": 1,
-                    "range": [
-                      13,
-                      16
-                    ],
-                    "raw": "BAR",
-                    "type": "Quasi"
-                  }
-                ],
-                "range": [
-                  12,
-                  17
-                ],
-                "raw": "\"BAR\"",
-                "type": "String"
-              },
+              "end": 17,
+              "expression": null,
               "key": {
                 "column": 13,
+                "end": 17,
                 "expressions": [
                 ],
                 "line": 1,
@@ -122,59 +68,29 @@
                   {
                     "column": 14,
                     "data": "BAR",
+                    "end": 16,
                     "line": 1,
-                    "range": [
-                      13,
-                      16
-                    ],
                     "raw": "BAR",
+                    "start": 13,
                     "type": "Quasi"
                   }
                 ],
-                "range": [
-                  12,
-                  17
-                ],
                 "raw": "\"BAR\"",
+                "start": 12,
                 "type": "String"
               },
               "line": 1,
-              "range": [
-                12,
-                17
-              ],
               "raw": "\"BAR\"",
+              "start": 12,
               "type": "ObjectInitialiserMember"
             },
             {
               "column": 20,
-              "expression": {
-                "column": 20,
-                "expressions": [
-                ],
-                "line": 1,
-                "quasis": [
-                  {
-                    "column": 21,
-                    "data": "BAZ",
-                    "line": 1,
-                    "range": [
-                      20,
-                      23
-                    ],
-                    "raw": "BAZ",
-                    "type": "Quasi"
-                  }
-                ],
-                "range": [
-                  19,
-                  24
-                ],
-                "raw": "\"BAZ\"",
-                "type": "String"
-              },
+              "end": 24,
+              "expression": null,
               "key": {
                 "column": 20,
+                "end": 24,
                 "expressions": [
                 ],
                 "line": 1,
@@ -182,55 +98,39 @@
                   {
                     "column": 21,
                     "data": "BAZ",
+                    "end": 23,
                     "line": 1,
-                    "range": [
-                      20,
-                      23
-                    ],
                     "raw": "BAZ",
+                    "start": 20,
                     "type": "Quasi"
                   }
                 ],
-                "range": [
-                  19,
-                  24
-                ],
                 "raw": "\"BAZ\"",
+                "start": 19,
                 "type": "String"
               },
               "line": 1,
-              "range": [
-                19,
-                24
-              ],
               "raw": "\"BAZ\"",
+              "start": 19,
               "type": "ObjectInitialiserMember"
             }
           ],
-          "range": [
-            4,
-            25
-          ],
           "raw": "{\"FOO\", \"BAR\", \"BAZ\"}",
+          "start": 4,
           "type": "ObjectInitialiser"
         },
         "line": 1,
-        "range": [
-          0,
-          25
-        ],
         "raw": "x = {\"FOO\", \"BAR\", \"BAZ\"}",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 26,
   "line": 1,
-  "range": [
-    0,
-    26
-  ],
   "raw": "x = {\"FOO\", \"BAR\", \"BAZ\"}\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/shorthand-object-with-this/output.json
+++ b/test/examples/shorthand-object-with-this/output.json
@@ -1,107 +1,63 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "{@a}",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 4,
         "line": 1,
         "members": [
           {
             "column": 2,
-            "expression": {
-              "column": 2,
-              "expression": {
-                "column": 2,
-                "line": 1,
-                "range": [
-                  1,
-                  2
-                ],
-                "raw": "@",
-                "type": "This"
-              },
-              "line": 1,
-              "member": {
-                "column": 3,
-                "data": "a",
-                "line": 1,
-                "range": [
-                  2,
-                  3
-                ],
-                "raw": "a",
-                "type": "Identifier"
-              },
-              "range": [
-                1,
-                3
-              ],
-              "raw": "@a",
-              "type": "MemberAccessOp"
-            },
+            "end": 3,
+            "expression": null,
             "key": {
               "column": 2,
+              "end": 3,
               "expression": {
                 "column": 2,
+                "end": 2,
                 "line": 1,
-                "range": [
-                  1,
-                  2
-                ],
                 "raw": "@",
+                "start": 1,
                 "type": "This"
               },
               "line": 1,
               "member": {
                 "column": 3,
                 "data": "a",
+                "end": 3,
                 "line": 1,
-                "range": [
-                  2,
-                  3
-                ],
                 "raw": "a",
+                "start": 2,
                 "type": "Identifier"
               },
-              "range": [
-                1,
-                3
-              ],
               "raw": "@a",
+              "start": 1,
               "type": "MemberAccessOp"
             },
             "line": 1,
-            "range": [
-              1,
-              3
-            ],
             "raw": "@a",
+            "start": 1,
             "type": "ObjectInitialiserMember"
           }
         ],
-        "range": [
-          0,
-          4
-        ],
         "raw": "{@a}",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "{@a}\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/shorthand-this-member-expression-with-dot/output.json
+++ b/test/examples/shorthand-this-member-expression-with-dot/output.json
@@ -1,54 +1,44 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "@.a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "expression": {
           "column": 1,
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "@",
+          "start": 0,
           "type": "This"
         },
         "line": 1,
         "member": {
           "column": 3,
           "data": "a",
+          "end": 3,
           "line": 1,
-          "range": [
-            2,
-            3
-          ],
           "raw": "a",
+          "start": 2,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          3
-        ],
         "raw": "@.a",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "@.a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/shorthand-this-member-expression/output.json
+++ b/test/examples/shorthand-this-member-expression/output.json
@@ -1,54 +1,44 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "@a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 2,
         "expression": {
           "column": 1,
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "@",
+          "start": 0,
           "type": "This"
         },
         "line": 1,
         "member": {
           "column": 2,
           "data": "a",
+          "end": 2,
           "line": 1,
-          "range": [
-            1,
-            2
-          ],
           "raw": "a",
+          "start": 1,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          2
-        ],
         "raw": "@a",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "@a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/shorthand-this/output.json
+++ b/test/examples/shorthand-this/output.json
@@ -1,33 +1,27 @@
 {
   "body": {
     "column": 1,
+    "end": 1,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      1
-    ],
     "raw": "@",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 1,
         "line": 1,
-        "range": [
-          0,
-          1
-        ],
         "raw": "@",
+        "start": 0,
         "type": "This"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 1,
   "line": 1,
-  "range": [
-    0,
-    1
-  ],
   "raw": "@",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/simple-call/output.json
+++ b/test/examples/simple-call/output.json
@@ -1,46 +1,38 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "a()",
+    "start": 0,
     "statements": [
       {
         "arguments": [
         ],
         "column": 1,
+        "end": 3,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          3
-        ],
         "raw": "a()",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "a()",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/simple-member-expression/output.json
+++ b/test/examples/simple-member-expression/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 3,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      3
-    ],
     "raw": "a.b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 3,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
         "member": {
           "column": 3,
           "data": "b",
+          "end": 3,
           "line": 1,
-          "range": [
-            2,
-            3
-          ],
           "raw": "b",
+          "start": 2,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          3
-        ],
         "raw": "a.b",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 3,
   "line": 1,
-  "range": [
-    0,
-    3
-  ],
   "raw": "a.b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/slice-with-lower-and-upper-bounds/output.json
+++ b/test/examples/slice-with-lower-and-upper-bounds/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "a[b..c]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "isInclusive": true,
         "left": {
           "column": 3,
           "data": "b",
+          "end": 3,
           "line": 1,
-          "range": [
-            2,
-            3
-          ],
           "raw": "b",
+          "start": 2,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          7
-        ],
         "raw": "a[b..c]",
         "right": {
           "column": 6,
           "data": "c",
+          "end": 6,
           "line": 1,
-          "range": [
-            5,
-            6
-          ],
           "raw": "c",
+          "start": 5,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "Slice"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "a[b..c]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/slice-with-no-bounds/output.json
+++ b/test/examples/slice-with-no-bounds/output.json
@@ -1,47 +1,39 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a[..]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "isInclusive": true,
         "left": null,
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a[..]",
         "right": null,
+        "start": 0,
         "type": "Slice"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a[..]\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/soaked-dynamic-member-access/output.json
+++ b/test/examples/soaked-dynamic-member-access/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a?[b]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "indexingExpr": {
           "column": 4,
           "data": "b",
+          "end": 4,
           "line": 1,
-          "range": [
-            3,
-            4
-          ],
           "raw": "b",
+          "start": 3,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "a?[b]",
+        "start": 0,
         "type": "SoakedDynamicMemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "a?[b]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/soaked-function-call/output.json
+++ b/test/examples/soaked-function-call/output.json
@@ -1,46 +1,38 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "a?()",
+    "start": 0,
     "statements": [
       {
         "arguments": [
         ],
         "column": 1,
+        "end": 4,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          4
-        ],
         "raw": "a?()",
+        "start": 0,
         "type": "SoakedFunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": "a?()",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/soaked-member-access/output.json
+++ b/test/examples/soaked-member-access/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "a?.b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 4,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
         "member": {
           "column": 4,
           "data": "b",
+          "end": 4,
           "line": 1,
-          "range": [
-            3,
-            4
-          ],
           "raw": "b",
+          "start": 3,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          4
-        ],
         "raw": "a?.b",
+        "start": 0,
         "type": "SoakedMemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": "a?.b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/soaked-method-call/output.json
+++ b/test/examples/soaked-method-call/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "a?.b()",
+    "start": 0,
     "statements": [
       {
         "arguments": [
         ],
         "column": 1,
+        "end": 6,
         "function": {
           "column": 1,
+          "end": 4,
           "expression": {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           "line": 1,
           "member": {
             "column": 4,
             "data": "b",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "b",
+            "start": 3,
             "type": "Identifier"
           },
-          "range": [
-            0,
-            4
-          ],
           "raw": "a?.b",
+          "start": 0,
           "type": "SoakedMemberAccessOp"
         },
         "line": 1,
-        "range": [
-          0,
-          6
-        ],
         "raw": "a?.b()",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a?.b()",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/soaked-new/output.json
+++ b/test/examples/soaked-new/output.json
@@ -1,25 +1,21 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "new A? b",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 8,
             "data": "b",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "b",
+            "start": 7,
             "type": "Identifier"
           }
         ],
@@ -27,31 +23,25 @@
         "ctor": {
           "column": 5,
           "data": "A",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "A",
+          "start": 4,
           "type": "Identifier"
         },
+        "end": 8,
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "new A? b",
+        "start": 0,
         "type": "SoakedNewOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "new A? b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/soaked-prototype-access/output.json
+++ b/test/examples/soaked-prototype-access/output.json
@@ -1,65 +1,53 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "a?::b",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expression": {
           "column": 1,
+          "end": 4,
           "expression": {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            0,
-            4
-          ],
           "raw": "a?::",
+          "start": 0,
           "type": "SoakedProtoMemberAccessOp"
         },
         "line": 1,
         "member": {
           "column": 5,
           "data": "b",
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "b",
+          "start": 4,
           "type": "Identifier"
         },
-        "range": [
-          0,
-          5
-        ],
         "raw": "a?::b",
+        "start": 0,
         "type": "MemberAccessOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "a?::b\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/soaked-slice/output.json
+++ b/test/examples/soaked-slice/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "a?[b..c]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 8,
         "expression": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "isInclusive": true,
         "left": {
           "column": 4,
           "data": "b",
+          "end": 4,
           "line": 1,
-          "range": [
-            3,
-            4
-          ],
           "raw": "b",
+          "start": 3,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "a?[b..c]",
         "right": {
           "column": 7,
           "data": "c",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "c",
+          "start": 6,
           "type": "Identifier"
         },
+        "start": 0,
         "type": "SoakedSlice"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "a?[b..c]\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/soaked-splice/output.json
+++ b/test/examples/soaked-splice/output.json
@@ -1,88 +1,72 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "a?[b..c] = d",
+    "start": 0,
     "statements": [
       {
         "assignee": {
           "column": 1,
+          "end": 8,
           "expression": {
             "column": 1,
             "data": "a",
+            "end": 1,
             "line": 1,
-            "range": [
-              0,
-              1
-            ],
             "raw": "a",
+            "start": 0,
             "type": "Identifier"
           },
           "isInclusive": true,
           "left": {
             "column": 4,
             "data": "b",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "b",
+            "start": 3,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            0,
-            8
-          ],
           "raw": "a?[b..c]",
           "right": {
             "column": 7,
             "data": "c",
+            "end": 7,
             "line": 1,
-            "range": [
-              6,
-              7
-            ],
             "raw": "c",
+            "start": 6,
             "type": "Identifier"
           },
+          "start": 0,
           "type": "SoakedSlice"
         },
         "column": 1,
+        "end": 12,
         "expression": {
           "column": 12,
           "data": "d",
+          "end": 12,
           "line": 1,
-          "range": [
-            11,
-            12
-          ],
           "raw": "d",
+          "start": 11,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "a?[b..c] = d",
+        "start": 0,
         "type": "AssignOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "a?[b..c] = d\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/splat-in-array-with-other-members/output.json
+++ b/test/examples/splat-in-array-with-other-members/output.json
@@ -1,78 +1,64 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "[a, b..., c]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 12,
         "line": 1,
         "members": [
           {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Identifier"
           },
           {
             "column": 5,
+            "end": 8,
             "expression": {
               "column": 5,
               "data": "b",
+              "end": 5,
               "line": 1,
-              "range": [
-                4,
-                5
-              ],
               "raw": "b",
+              "start": 4,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              4,
-              8
-            ],
             "raw": "b...",
+            "start": 4,
             "type": "Spread"
           },
           {
             "column": 11,
             "data": "c",
+            "end": 11,
             "line": 1,
-            "range": [
-              10,
-              11
-            ],
             "raw": "c",
+            "start": 10,
             "type": "Identifier"
           }
         ],
-        "range": [
-          0,
-          12
-        ],
         "raw": "[a, b..., c]",
+        "start": 0,
         "type": "ArrayInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "[a, b..., c]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/splat-in-array/output.json
+++ b/test/examples/splat-in-array/output.json
@@ -1,56 +1,46 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "[a...]",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "line": 1,
         "members": [
           {
             "column": 2,
+            "end": 5,
             "expression": {
               "column": 2,
               "data": "a",
+              "end": 2,
               "line": 1,
-              "range": [
-                1,
-                2
-              ],
               "raw": "a",
+              "start": 1,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              1,
-              5
-            ],
             "raw": "a...",
+            "start": 1,
             "type": "Spread"
           }
         ],
-        "range": [
-          0,
-          6
-        ],
         "raw": "[a...]",
+        "start": 0,
         "type": "ArrayInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "[a...]",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/splat-in-function-call-with-other-args/output.json
+++ b/test/examples/splat-in-function-call-with-other-args/output.json
@@ -1,89 +1,73 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "a b, c..., d",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 3,
             "data": "b",
+            "end": 3,
             "line": 1,
-            "range": [
-              2,
-              3
-            ],
             "raw": "b",
+            "start": 2,
             "type": "Identifier"
           },
           {
             "column": 6,
+            "end": 9,
             "expression": {
               "column": 6,
               "data": "c",
+              "end": 6,
               "line": 1,
-              "range": [
-                5,
-                6
-              ],
               "raw": "c",
+              "start": 5,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              5,
-              9
-            ],
             "raw": "c...",
+            "start": 5,
             "type": "Spread"
           },
           {
             "column": 12,
             "data": "d",
+            "end": 12,
             "line": 1,
-            "range": [
-              11,
-              12
-            ],
             "raw": "d",
+            "start": 11,
             "type": "Identifier"
           }
         ],
         "column": 1,
+        "end": 12,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "a b, c..., d",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "a b, c..., d",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/splat-in-function-call/output.json
+++ b/test/examples/splat-in-function-call/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "a(b...)",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 3,
+            "end": 6,
             "expression": {
               "column": 3,
               "data": "b",
+              "end": 3,
               "line": 1,
-              "range": [
-                2,
-                3
-              ],
               "raw": "b",
+              "start": 2,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              2,
-              6
-            ],
             "raw": "b...",
+            "start": 2,
             "type": "Spread"
           }
         ],
         "column": 1,
+        "end": 7,
         "function": {
           "column": 1,
           "data": "a",
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          7
-        ],
         "raw": "a(b...)",
+        "start": 0,
         "type": "FunctionApplication"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "a(b...)",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/splat-in-new-call/output.json
+++ b/test/examples/splat-in-new-call/output.json
@@ -1,35 +1,29 @@
 {
   "body": {
     "column": 1,
+    "end": 16,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      16
-    ],
     "raw": "new Foo(args...)",
+    "start": 0,
     "statements": [
       {
         "arguments": [
           {
             "column": 9,
+            "end": 15,
             "expression": {
               "column": 9,
               "data": "args",
+              "end": 12,
               "line": 1,
-              "range": [
-                8,
-                12
-              ],
               "raw": "args",
+              "start": 8,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              8,
-              15
-            ],
             "raw": "args...",
+            "start": 8,
             "type": "Spread"
           }
         ],
@@ -37,31 +31,25 @@
         "ctor": {
           "column": 5,
           "data": "Foo",
+          "end": 7,
           "line": 1,
-          "range": [
-            4,
-            7
-          ],
           "raw": "Foo",
+          "start": 4,
           "type": "Identifier"
         },
+        "end": 16,
         "line": 1,
-        "range": [
-          0,
-          16
-        ],
         "raw": "new Foo(args...)",
+        "start": 0,
         "type": "NewOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 16,
   "line": 1,
-  "range": [
-    0,
-    16
-  ],
   "raw": "new Foo(args...)",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-ending-with-interpolation/output.json
+++ b/test/examples/string-ending-with-interpolation/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "\"a#{b}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "expressions": [
           {
             "column": 5,
             "data": "b",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "b",
+            "start": 4,
             "type": "Identifier"
           }
         ],
@@ -29,42 +26,33 @@
           {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 7,
             "data": "",
+            "end": 6,
             "line": 1,
-            "range": [
-              6,
-              6
-            ],
             "raw": "",
+            "start": 6,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          7
-        ],
         "raw": "\"a#{b}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "\"a#{b}\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-interpolation-in-object-literal/output.json
+++ b/test/examples/string-interpolation-in-object-literal/output.json
@@ -1,32 +1,31 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "{a: \"#{b}\"}",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "line": 1,
         "members": [
           {
             "column": 2,
+            "end": 10,
             "expression": {
               "column": 5,
+              "end": 10,
               "expressions": [
                 {
                   "column": 8,
                   "data": "b",
+                  "end": 8,
                   "line": 1,
-                  "range": [
-                    7,
-                    8
-                  ],
                   "raw": "b",
+                  "start": 7,
                   "type": "Identifier"
                 }
               ],
@@ -35,69 +34,52 @@
                 {
                   "column": 6,
                   "data": "",
+                  "end": 5,
                   "line": 1,
-                  "range": [
-                    5,
-                    5
-                  ],
                   "raw": "",
+                  "start": 5,
                   "type": "Quasi"
                 },
                 {
                   "column": 10,
                   "data": "",
+                  "end": 9,
                   "line": 1,
-                  "range": [
-                    9,
-                    9
-                  ],
                   "raw": "",
+                  "start": 9,
                   "type": "Quasi"
                 }
               ],
-              "range": [
-                4,
-                10
-              ],
               "raw": "\"#{b}\"",
+              "start": 4,
               "type": "String"
             },
             "key": {
               "column": 2,
               "data": "a",
+              "end": 2,
               "line": 1,
-              "range": [
-                1,
-                2
-              ],
               "raw": "a",
+              "start": 1,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              1,
-              10
-            ],
             "raw": "a: \"#{b}\"",
+            "start": 1,
             "type": "ObjectInitialiserMember"
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "{a: \"#{b}\"}",
+        "start": 0,
         "type": "ObjectInitialiser"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "{a: \"#{b}\"}\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-interpolation-plus-normal-string/output.json
+++ b/test/examples/string-interpolation-plus-normal-string/output.json
@@ -1,28 +1,26 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "\"#{a}\" + \"b\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 12,
         "left": {
           "column": 1,
+          "end": 6,
           "expressions": [
             {
               "column": 4,
               "data": "a",
+              "end": 4,
               "line": 1,
-              "range": [
-                3,
-                4
-              ],
               "raw": "a",
+              "start": 3,
               "type": "Identifier"
             }
           ],
@@ -31,41 +29,31 @@
             {
               "column": 2,
               "data": "",
+              "end": 1,
               "line": 1,
-              "range": [
-                1,
-                1
-              ],
               "raw": "",
+              "start": 1,
               "type": "Quasi"
             },
             {
               "column": 6,
               "data": "",
+              "end": 5,
               "line": 1,
-              "range": [
-                5,
-                5
-              ],
               "raw": "",
+              "start": 5,
               "type": "Quasi"
             }
           ],
-          "range": [
-            0,
-            6
-          ],
           "raw": "\"#{a}\"",
+          "start": 0,
           "type": "String"
         },
         "line": 1,
-        "range": [
-          0,
-          12
-        ],
         "raw": "\"#{a}\" + \"b\"",
         "right": {
           "column": 10,
+          "end": 12,
           "expressions": [
           ],
           "line": 1,
@@ -73,33 +61,27 @@
             {
               "column": 11,
               "data": "b",
+              "end": 11,
               "line": 1,
-              "range": [
-                10,
-                11
-              ],
               "raw": "b",
+              "start": 10,
               "type": "Quasi"
             }
           ],
-          "range": [
-            9,
-            12
-          ],
           "raw": "\"b\"",
+          "start": 9,
           "type": "String"
         },
+        "start": 0,
         "type": "PlusOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "\"#{a}\" + \"b\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-interpolation-preceded-by-parenthesis/output.json
+++ b/test/examples/string-interpolation-preceded-by-parenthesis/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 65,
     "inline": false,
     "line": 2,
-    "range": [
-      58,
-      65
-    ],
     "raw": "\"(#{a}\"",
+    "start": 58,
     "statements": [
       {
         "column": 1,
+        "end": 65,
         "expressions": [
           {
             "column": 5,
             "data": "a",
+            "end": 63,
             "line": 2,
-            "range": [
-              62,
-              63
-            ],
             "raw": "a",
+            "start": 62,
             "type": "Identifier"
           }
         ],
@@ -29,42 +26,33 @@
           {
             "column": 2,
             "data": "(",
+            "end": 60,
             "line": 2,
-            "range": [
-              59,
-              60
-            ],
             "raw": "(",
+            "start": 59,
             "type": "Quasi"
           },
           {
             "column": 7,
             "data": "",
+            "end": 64,
             "line": 2,
-            "range": [
-              64,
-              64
-            ],
             "raw": "",
+            "start": 64,
             "type": "Quasi"
           }
         ],
-        "range": [
-          58,
-          65
-        ],
         "raw": "\"(#{a}\"",
+        "start": 58,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 66,
   "line": 1,
-  "range": [
-    0,
-    66
-  ],
   "raw": "# https://github.com/decaffeinate/decaffeinate/issues/212\n\"(#{a}\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-interpolation-with-escaped-newline/output.json
+++ b/test/examples/string-interpolation-with-escaped-newline/output.json
@@ -1,37 +1,32 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "\"#{a}\\\n#{b}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 12,
         "expressions": [
           {
             "column": 4,
             "data": "a",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "a",
+            "start": 3,
             "type": "Identifier"
           },
           {
             "column": 3,
             "data": "b",
+            "end": 10,
             "line": 2,
-            "range": [
-              9,
-              10
-            ],
             "raw": "b",
+            "start": 9,
             "type": "Identifier"
           }
         ],
@@ -40,53 +35,42 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 6,
             "data": "",
+            "end": 7,
             "line": 1,
-            "range": [
-              5,
-              7
-            ],
             "raw": "\\\n",
+            "start": 5,
             "type": "Quasi"
           },
           {
             "column": 5,
             "data": "",
+            "end": 11,
             "line": 2,
-            "range": [
-              11,
-              11
-            ],
             "raw": "",
+            "start": 11,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          12
-        ],
         "raw": "\"#{a}\\\n#{b}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "\"#{a}\\\n#{b}\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-interpolation-with-plus/output.json
+++ b/test/examples/string-interpolation-with-plus/output.json
@@ -1,47 +1,40 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "\"#{a + b}c\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "expressions": [
           {
             "column": 4,
+            "end": 8,
             "left": {
               "column": 4,
               "data": "a",
+              "end": 4,
               "line": 1,
-              "range": [
-                3,
-                4
-              ],
               "raw": "a",
+              "start": 3,
               "type": "Identifier"
             },
             "line": 1,
-            "range": [
-              3,
-              8
-            ],
             "raw": "a + b",
             "right": {
               "column": 8,
               "data": "b",
+              "end": 8,
               "line": 1,
-              "range": [
-                7,
-                8
-              ],
               "raw": "b",
+              "start": 7,
               "type": "Identifier"
             },
+            "start": 3,
             "type": "PlusOp"
           }
         ],
@@ -50,42 +43,33 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 10,
             "data": "c",
+            "end": 10,
             "line": 1,
-            "range": [
-              9,
-              10
-            ],
             "raw": "c",
+            "start": 9,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "\"#{a + b}c\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "\"#{a + b}c\"\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-starting-with-interpolation/output.json
+++ b/test/examples/string-starting-with-interpolation/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "\"#{a}b\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 7,
         "expressions": [
           {
             "column": 4,
             "data": "a",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "a",
+            "start": 3,
             "type": "Identifier"
           }
         ],
@@ -29,42 +26,33 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 6,
             "data": "b",
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": "b",
+            "start": 5,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          7
-        ],
         "raw": "\"#{a}b\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "\"#{a}b\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-double-quotes/output.json
+++ b/test/examples/string-with-double-quotes/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "\"coffee me\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "expressions": [
         ],
         "line": 1,
@@ -18,31 +17,24 @@
           {
             "column": 2,
             "data": "coffee me",
+            "end": 10,
             "line": 1,
-            "range": [
-              1,
-              10
-            ],
             "raw": "coffee me",
+            "start": 1,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "\"coffee me\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "\"coffee me\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-interpolation/output.json
+++ b/test/examples/string-with-interpolation/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "\"a#{b}c\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 8,
         "expressions": [
           {
             "column": 5,
             "data": "b",
+            "end": 5,
             "line": 1,
-            "range": [
-              4,
-              5
-            ],
             "raw": "b",
+            "start": 4,
             "type": "Identifier"
           }
         ],
@@ -29,42 +26,33 @@
           {
             "column": 2,
             "data": "a",
+            "end": 2,
             "line": 1,
-            "range": [
-              1,
-              2
-            ],
             "raw": "a",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 7,
             "data": "c",
+            "end": 7,
             "line": 1,
-            "range": [
-              6,
-              7
-            ],
             "raw": "c",
+            "start": 6,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          8
-        ],
         "raw": "\"a#{b}c\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "\"a#{b}c\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-interpolations-at-start-and-end/output.json
+++ b/test/examples/string-with-interpolations-at-start-and-end/output.json
@@ -1,37 +1,32 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "\"#{a} #{b}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 11,
         "expressions": [
           {
             "column": 4,
             "data": "a",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "a",
+            "start": 3,
             "type": "Identifier"
           },
           {
             "column": 9,
             "data": "b",
+            "end": 9,
             "line": 1,
-            "range": [
-              8,
-              9
-            ],
             "raw": "b",
+            "start": 8,
             "type": "Identifier"
           }
         ],
@@ -40,53 +35,42 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 6,
             "data": " ",
+            "end": 6,
             "line": 1,
-            "range": [
-              5,
-              6
-            ],
             "raw": " ",
+            "start": 5,
             "type": "Quasi"
           },
           {
             "column": 11,
             "data": "",
+            "end": 10,
             "line": 1,
-            "range": [
-              10,
-              10
-            ],
             "raw": "",
+            "start": 10,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          11
-        ],
         "raw": "\"#{a} #{b}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "\"#{a} #{b}\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-noop-escape/output.json
+++ b/test/examples/string-with-noop-escape/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "'\\.'",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 4,
         "expressions": [
         ],
         "line": 1,
@@ -18,31 +17,24 @@
           {
             "column": 2,
             "data": ".",
+            "end": 3,
             "line": 1,
-            "range": [
-              1,
-              3
-            ],
             "raw": "\\.",
+            "start": 1,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          4
-        ],
         "raw": "'\\.'",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": "'\\.'",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-only-multiple-interpolations/output.json
+++ b/test/examples/string-with-only-multiple-interpolations/output.json
@@ -1,48 +1,41 @@
 {
   "body": {
     "column": 1,
+    "end": 14,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      14
-    ],
     "raw": "\"#{a}#{b}#{c}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 14,
         "expressions": [
           {
             "column": 4,
             "data": "a",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "a",
+            "start": 3,
             "type": "Identifier"
           },
           {
             "column": 8,
             "data": "b",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "b",
+            "start": 7,
             "type": "Identifier"
           },
           {
             "column": 12,
             "data": "c",
+            "end": 12,
             "line": 1,
-            "range": [
-              11,
-              12
-            ],
             "raw": "c",
+            "start": 11,
             "type": "Identifier"
           }
         ],
@@ -51,64 +44,51 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 6,
             "data": "",
+            "end": 5,
             "line": 1,
-            "range": [
-              5,
-              5
-            ],
             "raw": "",
+            "start": 5,
             "type": "Quasi"
           },
           {
             "column": 10,
             "data": "",
+            "end": 9,
             "line": 1,
-            "range": [
-              9,
-              9
-            ],
             "raw": "",
+            "start": 9,
             "type": "Quasi"
           },
           {
             "column": 14,
             "data": "",
+            "end": 13,
             "line": 1,
-            "range": [
-              13,
-              13
-            ],
             "raw": "",
+            "start": 13,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          14
-        ],
         "raw": "\"#{a}#{b}#{c}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 14,
   "line": 1,
-  "range": [
-    0,
-    14
-  ],
   "raw": "\"#{a}#{b}#{c}\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-only-single-interpolation/output.json
+++ b/test/examples/string-with-only-single-interpolation/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 6,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      6
-    ],
     "raw": "\"#{a}\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 6,
         "expressions": [
           {
             "column": 4,
             "data": "a",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "a",
+            "start": 3,
             "type": "Identifier"
           }
         ],
@@ -29,42 +26,33 @@
           {
             "column": 2,
             "data": "",
+            "end": 1,
             "line": 1,
-            "range": [
-              1,
-              1
-            ],
             "raw": "",
+            "start": 1,
             "type": "Quasi"
           },
           {
             "column": 6,
             "data": "",
+            "end": 5,
             "line": 1,
-            "range": [
-              5,
-              5
-            ],
             "raw": "",
+            "start": 5,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          6
-        ],
         "raw": "\"#{a}\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 6,
   "line": 1,
-  "range": [
-    0,
-    6
-  ],
   "raw": "\"#{a}\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-parentheses-inside/output.json
+++ b/test/examples/string-with-parentheses-inside/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "\"( a\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "expressions": [
         ],
         "line": 1,
@@ -18,31 +17,24 @@
           {
             "column": 2,
             "data": "( a",
+            "end": 4,
             "line": 1,
-            "range": [
-              1,
-              4
-            ],
             "raw": "( a",
+            "start": 1,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          5
-        ],
         "raw": "\"( a\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "\"( a\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-single-quotes/output.json
+++ b/test/examples/string-with-single-quotes/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 15,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      15
-    ],
     "raw": "'coffee script'",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 15,
         "expressions": [
         ],
         "line": 1,
@@ -18,31 +17,24 @@
           {
             "column": 2,
             "data": "coffee script",
+            "end": 14,
             "line": 1,
-            "range": [
-              1,
-              14
-            ],
             "raw": "coffee script",
+            "start": 1,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          15
-        ],
         "raw": "'coffee script'",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 15,
   "line": 1,
-  "range": [
-    0,
-    15
-  ],
   "raw": "'coffee script'",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-triple-double-quotes/output.json
+++ b/test/examples/string-with-triple-double-quotes/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 26,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      26
-    ],
     "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 26,
         "expressions": [
         ],
         "line": 1,
@@ -18,31 +17,24 @@
           {
             "column": 4,
             "data": "multi-line strings",
+            "end": 23,
             "line": 1,
-            "range": [
-              3,
-              23
-            ],
             "raw": "\nmulti-line strings\n",
+            "start": 3,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          26
-        ],
         "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 26,
   "line": 1,
-  "range": [
-    0,
-    26
-  ],
   "raw": "\"\"\"\nmulti-line strings\n\"\"\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-triple-quote-interpolation-containing-quotes/output.json
+++ b/test/examples/string-with-triple-quote-interpolation-containing-quotes/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 20,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      20
-    ],
     "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 20,
         "expressions": [
           {
             "column": 8,
             "data": "bar",
+            "end": 14,
             "line": 2,
-            "range": [
-              11,
-              14
-            ],
             "raw": "bar",
+            "start": 11,
             "type": "Identifier"
           }
         ],
@@ -29,42 +26,33 @@
           {
             "column": 4,
             "data": "bar=\"",
+            "end": 9,
             "line": 1,
-            "range": [
-              3,
-              9
-            ],
             "raw": "\nbar=\"",
+            "start": 3,
             "type": "Quasi"
           },
           {
             "column": 12,
             "data": "\"",
+            "end": 17,
             "line": 2,
-            "range": [
-              15,
-              17
-            ],
             "raw": "\"\n",
+            "start": 15,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          20
-        ],
         "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 20,
   "line": 1,
-  "range": [
-    0,
-    20
-  ],
   "raw": "\"\"\"\nbar=\"#{bar}\"\n\"\"\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-triple-quote-interpolation/output.json
+++ b/test/examples/string-with-triple-quote-interpolation/output.json
@@ -1,26 +1,23 @@
 {
   "body": {
     "column": 1,
+    "end": 12,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      12
-    ],
     "raw": "\"\"\"\n#{a}\n\"\"\"",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 12,
         "expressions": [
           {
             "column": 3,
             "data": "a",
+            "end": 7,
             "line": 2,
-            "range": [
-              6,
-              7
-            ],
             "raw": "a",
+            "start": 6,
             "type": "Identifier"
           }
         ],
@@ -29,42 +26,33 @@
           {
             "column": 4,
             "data": "",
+            "end": 4,
             "line": 1,
-            "range": [
-              3,
-              4
-            ],
             "raw": "\n",
+            "start": 3,
             "type": "Quasi"
           },
           {
             "column": 5,
             "data": "",
+            "end": 9,
             "line": 2,
-            "range": [
-              8,
-              9
-            ],
             "raw": "\n",
+            "start": 8,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          12
-        ],
         "raw": "\"\"\"\n#{a}\n\"\"\"",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 12,
   "line": 1,
-  "range": [
-    0,
-    12
-  ],
   "raw": "\"\"\"\n#{a}\n\"\"\"",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/string-with-triple-single-quotes/output.json
+++ b/test/examples/string-with-triple-single-quotes/output.json
@@ -1,16 +1,15 @@
 {
   "body": {
     "column": 1,
+    "end": 26,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      26
-    ],
     "raw": "'''\nmulti-line strings\n'''",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 26,
         "expressions": [
         ],
         "line": 1,
@@ -18,31 +17,24 @@
           {
             "column": 4,
             "data": "multi-line strings",
+            "end": 23,
             "line": 1,
-            "range": [
-              3,
-              23
-            ],
             "raw": "\nmulti-line strings\n",
+            "start": 3,
             "type": "Quasi"
           }
         ],
-        "range": [
-          0,
-          26
-        ],
         "raw": "'''\nmulti-line strings\n'''",
+        "start": 0,
         "type": "String"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 26,
   "line": 1,
-  "range": [
-    0,
-    26
-  ],
   "raw": "'''\nmulti-line strings\n'''",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/subtraction/output.json
+++ b/test/examples/subtraction/output.json
@@ -1,55 +1,45 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "3 - 4",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 5,
         "left": {
           "column": 1,
           "data": 3,
+          "end": 1,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "3",
+          "start": 0,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "3 - 4",
         "right": {
           "column": 5,
           "data": 4,
+          "end": 5,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "4",
+          "start": 4,
           "type": "Int"
         },
+        "start": 0,
         "type": "SubtractOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "3 - 4",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/switch-with-alternate/output.json
+++ b/test/examples/switch-with-alternate/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 37,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      37
-    ],
     "raw": "switch a\n  when b\n    c\n\n  else\n    d",
+    "start": 0,
     "statements": [
       {
         "alternate": {
           "column": 5,
+          "end": 37,
           "inline": false,
           "line": 6,
-          "range": [
-            36,
-            37
-          ],
           "raw": "d",
+          "start": 36,
           "statements": [
             {
               "column": 5,
               "data": "d",
+              "end": 37,
               "line": 6,
-              "range": [
-                36,
-                37
-              ],
               "raw": "d",
+              "start": 36,
               "type": "Identifier"
             }
           ],
@@ -41,77 +35,63 @@
               {
                 "column": 8,
                 "data": "b",
+                "end": 17,
                 "line": 2,
-                "range": [
-                  16,
-                  17
-                ],
                 "raw": "b",
+                "start": 16,
                 "type": "Identifier"
               }
             ],
             "consequent": {
               "column": 5,
+              "end": 23,
               "inline": false,
               "line": 3,
-              "range": [
-                22,
-                23
-              ],
               "raw": "c",
+              "start": 22,
               "statements": [
                 {
                   "column": 5,
                   "data": "c",
+                  "end": 23,
                   "line": 3,
-                  "range": [
-                    22,
-                    23
-                  ],
                   "raw": "c",
+                  "start": 22,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
+            "end": 23,
             "line": 2,
-            "range": [
-              11,
-              23
-            ],
             "raw": "when b\n    c",
+            "start": 11,
             "type": "SwitchCase"
           }
         ],
         "column": 1,
+        "end": 37,
         "expression": {
           "column": 8,
           "data": "a",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "a",
+          "start": 7,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          37
-        ],
         "raw": "switch a\n  when b\n    c\n\n  else\n    d",
+        "start": 0,
         "type": "Switch"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 37,
   "line": 1,
-  "range": [
-    0,
-    37
-  ],
   "raw": "switch a\n  when b\n    c\n\n  else\n    d",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/switch-with-multiple-cases/output.json
+++ b/test/examples/switch-with-multiple-cases/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 38,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      38
-    ],
     "raw": "switch a\n  when b\n    c\n  when d\n    e",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
@@ -18,45 +16,37 @@
               {
                 "column": 8,
                 "data": "b",
+                "end": 17,
                 "line": 2,
-                "range": [
-                  16,
-                  17
-                ],
                 "raw": "b",
+                "start": 16,
                 "type": "Identifier"
               }
             ],
             "consequent": {
               "column": 5,
+              "end": 23,
               "inline": false,
               "line": 3,
-              "range": [
-                22,
-                23
-              ],
               "raw": "c",
+              "start": 22,
               "statements": [
                 {
                   "column": 5,
                   "data": "c",
+                  "end": 23,
                   "line": 3,
-                  "range": [
-                    22,
-                    23
-                  ],
                   "raw": "c",
+                  "start": 22,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
+            "end": 23,
             "line": 2,
-            "range": [
-              11,
-              23
-            ],
             "raw": "when b\n    c",
+            "start": 11,
             "type": "SwitchCase"
           },
           {
@@ -65,77 +55,63 @@
               {
                 "column": 8,
                 "data": "d",
+                "end": 32,
                 "line": 4,
-                "range": [
-                  31,
-                  32
-                ],
                 "raw": "d",
+                "start": 31,
                 "type": "Identifier"
               }
             ],
             "consequent": {
               "column": 5,
+              "end": 38,
               "inline": false,
               "line": 5,
-              "range": [
-                37,
-                38
-              ],
               "raw": "e",
+              "start": 37,
               "statements": [
                 {
                   "column": 5,
                   "data": "e",
+                  "end": 38,
                   "line": 5,
-                  "range": [
-                    37,
-                    38
-                  ],
                   "raw": "e",
+                  "start": 37,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
+            "end": 38,
             "line": 4,
-            "range": [
-              26,
-              38
-            ],
             "raw": "when d\n    e",
+            "start": 26,
             "type": "SwitchCase"
           }
         ],
         "column": 1,
+        "end": 38,
         "expression": {
           "column": 8,
           "data": "a",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "a",
+          "start": 7,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          38
-        ],
         "raw": "switch a\n  when b\n    c\n  when d\n    e",
+        "start": 0,
         "type": "Switch"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 39,
   "line": 1,
-  "range": [
-    0,
-    39
-  ],
   "raw": "switch a\n  when b\n    c\n  when d\n    e\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/switch-with-multiple-conditions/output.json
+++ b/test/examples/switch-with-multiple-conditions/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 26,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      26
-    ],
     "raw": "switch a\n  when b, c\n    d",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
@@ -18,88 +16,72 @@
               {
                 "column": 8,
                 "data": "b",
+                "end": 17,
                 "line": 2,
-                "range": [
-                  16,
-                  17
-                ],
                 "raw": "b",
+                "start": 16,
                 "type": "Identifier"
               },
               {
                 "column": 11,
                 "data": "c",
+                "end": 20,
                 "line": 2,
-                "range": [
-                  19,
-                  20
-                ],
                 "raw": "c",
+                "start": 19,
                 "type": "Identifier"
               }
             ],
             "consequent": {
               "column": 5,
+              "end": 26,
               "inline": false,
               "line": 3,
-              "range": [
-                25,
-                26
-              ],
               "raw": "d",
+              "start": 25,
               "statements": [
                 {
                   "column": 5,
                   "data": "d",
+                  "end": 26,
                   "line": 3,
-                  "range": [
-                    25,
-                    26
-                  ],
                   "raw": "d",
+                  "start": 25,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
+            "end": 26,
             "line": 2,
-            "range": [
-              11,
-              26
-            ],
             "raw": "when b, c\n    d",
+            "start": 11,
             "type": "SwitchCase"
           }
         ],
         "column": 1,
+        "end": 26,
         "expression": {
           "column": 8,
           "data": "a",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "a",
+          "start": 7,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          26
-        ],
         "raw": "switch a\n  when b, c\n    d",
+        "start": 0,
         "type": "Switch"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 26,
   "line": 1,
-  "range": [
-    0,
-    26
-  ],
   "raw": "switch a\n  when b, c\n    d",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/switch-with-one-case/output.json
+++ b/test/examples/switch-with-one-case/output.json
@@ -1,13 +1,11 @@
 {
   "body": {
     "column": 1,
+    "end": 23,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      23
-    ],
     "raw": "switch a\n  when b\n    c",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
@@ -18,77 +16,63 @@
               {
                 "column": 8,
                 "data": "b",
+                "end": 17,
                 "line": 2,
-                "range": [
-                  16,
-                  17
-                ],
                 "raw": "b",
+                "start": 16,
                 "type": "Identifier"
               }
             ],
             "consequent": {
               "column": 5,
+              "end": 23,
               "inline": false,
               "line": 3,
-              "range": [
-                22,
-                23
-              ],
               "raw": "c",
+              "start": 22,
               "statements": [
                 {
                   "column": 5,
                   "data": "c",
+                  "end": 23,
                   "line": 3,
-                  "range": [
-                    22,
-                    23
-                  ],
                   "raw": "c",
+                  "start": 22,
                   "type": "Identifier"
                 }
               ],
               "type": "Block"
             },
+            "end": 23,
             "line": 2,
-            "range": [
-              11,
-              23
-            ],
             "raw": "when b\n    c",
+            "start": 11,
             "type": "SwitchCase"
           }
         ],
         "column": 1,
+        "end": 23,
         "expression": {
           "column": 8,
           "data": "a",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "a",
+          "start": 7,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          23
-        ],
         "raw": "switch a\n  when b\n    c",
+        "start": 0,
         "type": "Switch"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 24,
   "line": 1,
-  "range": [
-    0,
-    24
-  ],
   "raw": "switch a\n  when b\n    c\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/this-assign-with-keyword/output.json
+++ b/test/examples/this-assign-with-keyword/output.json
@@ -1,67 +1,55 @@
 {
   "body": {
     "column": 1,
+    "end": 10,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      10
-    ],
     "raw": "(@case) ->",
+    "start": 0,
     "statements": [
       {
         "body": null,
         "column": 1,
+        "end": 10,
         "line": 1,
         "parameters": [
           {
             "column": 2,
+            "end": 6,
             "expression": {
               "column": 2,
+              "end": 2,
               "line": 1,
-              "range": [
-                1,
-                2
-              ],
               "raw": "@",
+              "start": 1,
               "type": "This"
             },
             "line": 1,
             "member": {
               "column": 3,
               "data": "case",
+              "end": 6,
               "line": 1,
-              "range": [
-                2,
-                6
-              ],
               "raw": "case",
+              "start": 2,
               "type": "Identifier"
             },
-            "range": [
-              1,
-              6
-            ],
             "raw": "@case",
+            "start": 1,
             "type": "MemberAccessOp"
           }
         ],
-        "range": [
-          0,
-          10
-        ],
         "raw": "(@case) ->",
+        "start": 0,
         "type": "Function"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "(@case) ->\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/throw/output.json
+++ b/test/examples/throw/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "throw 42",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 8,
         "expression": {
           "column": 7,
           "data": 42,
+          "end": 8,
           "line": 1,
-          "range": [
-            6,
-            8
-          ],
           "raw": "42",
+          "start": 6,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "throw 42",
+        "start": 0,
         "type": "Throw"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "throw 42",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/true/output.json
+++ b/test/examples/true/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 4,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      4
-    ],
     "raw": "true",
+    "start": 0,
     "statements": [
       {
         "column": 1,
         "data": true,
+        "end": 4,
         "line": 1,
-        "range": [
-          0,
-          4
-        ],
         "raw": "true",
+        "start": 0,
         "type": "Bool"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 4,
   "line": 1,
-  "range": [
-    0,
-    4
-  ],
   "raw": "true",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/try-with-catch-and-finally/output.json
+++ b/test/examples/try-with-catch-and-finally/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 29,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      29
-    ],
     "raw": "try\n  a\ncatch\n  b\nfinally\n  c",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 7,
           "inline": false,
           "line": 2,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "statements": [
             {
               "column": 3,
               "data": "a",
+              "end": 7,
               "line": 2,
-              "range": [
-                6,
-                7
-              ],
               "raw": "a",
+              "start": 6,
               "type": "Identifier"
             }
           ],
@@ -37,70 +31,58 @@
         "catchAssignee": null,
         "catchBody": {
           "column": 3,
+          "end": 17,
           "inline": false,
           "line": 4,
-          "range": [
-            16,
-            17
-          ],
           "raw": "b",
+          "start": 16,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 17,
               "line": 4,
-              "range": [
-                16,
-                17
-              ],
               "raw": "b",
+              "start": 16,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 29,
         "finallyBody": {
           "column": 3,
+          "end": 29,
           "inline": false,
           "line": 6,
-          "range": [
-            28,
-            29
-          ],
           "raw": "c",
+          "start": 28,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 29,
               "line": 6,
-              "range": [
-                28,
-                29
-              ],
               "raw": "c",
+              "start": 28,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "line": 1,
-        "range": [
-          0,
-          29
-        ],
         "raw": "try\n  a\ncatch\n  b\nfinally\n  c",
+        "start": 0,
         "type": "Try"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 30,
   "line": 1,
-  "range": [
-    0,
-    30
-  ],
   "raw": "try\n  a\ncatch\n  b\nfinally\n  c\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/try-with-catch-assignee/output.json
+++ b/test/examples/try-with-catch-assignee/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 21,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      21
-    ],
     "raw": "try\n  a\ncatch err\n  b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 7,
           "inline": false,
           "line": 2,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "statements": [
             {
               "column": 3,
               "data": "a",
+              "end": 7,
               "line": 2,
-              "range": [
-                6,
-                7
-              ],
               "raw": "a",
+              "start": 6,
               "type": "Identifier"
             }
           ],
@@ -37,57 +31,47 @@
         "catchAssignee": {
           "column": 7,
           "data": "err",
+          "end": 17,
           "line": 3,
-          "range": [
-            14,
-            17
-          ],
           "raw": "err",
+          "start": 14,
           "type": "Identifier"
         },
         "catchBody": {
           "column": 3,
+          "end": 21,
           "inline": false,
           "line": 4,
-          "range": [
-            20,
-            21
-          ],
           "raw": "b",
+          "start": 20,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 21,
               "line": 4,
-              "range": [
-                20,
-                21
-              ],
               "raw": "b",
+              "start": 20,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 21,
         "finallyBody": null,
         "line": 1,
-        "range": [
-          0,
-          21
-        ],
         "raw": "try\n  a\ncatch err\n  b",
+        "start": 0,
         "type": "Try"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 21,
   "line": 1,
-  "range": [
-    0,
-    21
-  ],
   "raw": "try\n  a\ncatch err\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/try-with-catch-single-line/output.json
+++ b/test/examples/try-with-catch-single-line/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 13,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      13
-    ],
     "raw": "try a catch b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 5,
+          "end": 5,
           "inline": true,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "statements": [
             {
               "column": 5,
               "data": "a",
+              "end": 5,
               "line": 1,
-              "range": [
-                4,
-                5
-              ],
               "raw": "a",
+              "start": 4,
               "type": "Identifier"
             }
           ],
@@ -37,34 +31,28 @@
         "catchAssignee": {
           "column": 13,
           "data": "b",
+          "end": 13,
           "line": 1,
-          "range": [
-            12,
-            13
-          ],
           "raw": "b",
+          "start": 12,
           "type": "Identifier"
         },
         "catchBody": null,
         "column": 1,
+        "end": 13,
         "finallyBody": null,
         "line": 1,
-        "range": [
-          0,
-          13
-        ],
         "raw": "try a catch b",
+        "start": 0,
         "type": "Try"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 13,
   "line": 1,
-  "range": [
-    0,
-    13
-  ],
   "raw": "try a catch b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/try-with-catch-without-assignee/output.json
+++ b/test/examples/try-with-catch-without-assignee/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "try\n  a\ncatch\n  b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 7,
           "inline": false,
           "line": 2,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "statements": [
             {
               "column": 3,
               "data": "a",
+              "end": 7,
               "line": 2,
-              "range": [
-                6,
-                7
-              ],
               "raw": "a",
+              "start": 6,
               "type": "Identifier"
             }
           ],
@@ -37,47 +31,39 @@
         "catchAssignee": null,
         "catchBody": {
           "column": 3,
+          "end": 17,
           "inline": false,
           "line": 4,
-          "range": [
-            16,
-            17
-          ],
           "raw": "b",
+          "start": 16,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 17,
               "line": 4,
-              "range": [
-                16,
-                17
-              ],
               "raw": "b",
+              "start": 16,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 17,
         "finallyBody": null,
         "line": 1,
-        "range": [
-          0,
-          17
-        ],
         "raw": "try\n  a\ncatch\n  b",
+        "start": 0,
         "type": "Try"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 17,
   "line": 1,
-  "range": [
-    0,
-    17
-  ],
   "raw": "try\n  a\ncatch\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/try-without-catch-or-finally/output.json
+++ b/test/examples/try-without-catch-or-finally/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 7,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      7
-    ],
     "raw": "try\n  a",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 7,
           "inline": false,
           "line": 2,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "statements": [
             {
               "column": 3,
               "data": "a",
+              "end": 7,
               "line": 2,
-              "range": [
-                6,
-                7
-              ],
               "raw": "a",
+              "start": 6,
               "type": "Identifier"
             }
           ],
@@ -37,24 +31,20 @@
         "catchAssignee": null,
         "catchBody": null,
         "column": 1,
+        "end": 7,
         "finallyBody": null,
         "line": 1,
-        "range": [
-          0,
-          7
-        ],
         "raw": "try\n  a",
+        "start": 0,
         "type": "Try"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 7,
   "line": 1,
-  "range": [
-    0,
-    7
-  ],
   "raw": "try\n  a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/try-without-catch-single-line/output.json
+++ b/test/examples/try-without-catch-single-line/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 5,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      5
-    ],
     "raw": "try a",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 5,
+          "end": 5,
           "inline": true,
           "line": 1,
-          "range": [
-            4,
-            5
-          ],
           "raw": "a",
+          "start": 4,
           "statements": [
             {
               "column": 5,
               "data": "a",
+              "end": 5,
               "line": 1,
-              "range": [
-                4,
-                5
-              ],
               "raw": "a",
+              "start": 4,
               "type": "Identifier"
             }
           ],
@@ -37,24 +31,20 @@
         "catchAssignee": null,
         "catchBody": null,
         "column": 1,
+        "end": 5,
         "finallyBody": null,
         "line": 1,
-        "range": [
-          0,
-          5
-        ],
         "raw": "try a",
+        "start": 0,
         "type": "Try"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 5,
   "line": 1,
-  "range": [
-    0,
-    5
-  ],
   "raw": "try a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/try-without-catch-with-finally/output.json
+++ b/test/examples/try-without-catch-with-finally/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 19,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      19
-    ],
     "raw": "try\n  a\nfinally\n  b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 7,
           "inline": false,
           "line": 2,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "statements": [
             {
               "column": 3,
               "data": "a",
+              "end": 7,
               "line": 2,
-              "range": [
-                6,
-                7
-              ],
               "raw": "a",
+              "start": 6,
               "type": "Identifier"
             }
           ],
@@ -37,47 +31,39 @@
         "catchAssignee": null,
         "catchBody": null,
         "column": 1,
+        "end": 19,
         "finallyBody": {
           "column": 3,
+          "end": 19,
           "inline": false,
           "line": 4,
-          "range": [
-            18,
-            19
-          ],
           "raw": "b",
+          "start": 18,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 19,
               "line": 4,
-              "range": [
-                18,
-                19
-              ],
               "raw": "b",
+              "start": 18,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
         "line": 1,
-        "range": [
-          0,
-          19
-        ],
         "raw": "try\n  a\nfinally\n  b",
+        "start": 0,
         "type": "Try"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 19,
   "line": 1,
-  "range": [
-    0,
-    19
-  ],
   "raw": "try\n  a\nfinally\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/typeof/output.json
+++ b/test/examples/typeof/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      8
-    ],
     "raw": "typeof a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 8,
         "expression": {
           "column": 8,
           "data": "a",
+          "end": 8,
           "line": 1,
-          "range": [
-            7,
-            8
-          ],
           "raw": "a",
+          "start": 7,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          8
-        ],
         "raw": "typeof a",
+        "start": 0,
         "type": "TypeofOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 8,
   "line": 1,
-  "range": [
-    0,
-    8
-  ],
   "raw": "typeof a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/unary-bitwise-negation/output.json
+++ b/test/examples/unary-bitwise-negation/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "~a",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 2,
         "expression": {
           "column": 2,
           "data": "a",
+          "end": 2,
           "line": 1,
-          "range": [
-            1,
-            2
-          ],
           "raw": "a",
+          "start": 1,
           "type": "Identifier"
         },
         "line": 1,
-        "range": [
-          0,
-          2
-        ],
         "raw": "~a",
+        "start": 0,
         "type": "BitNotOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "~a",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/unary-minus/output.json
+++ b/test/examples/unary-minus/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "-1",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 2,
         "expression": {
           "column": 2,
           "data": 1,
+          "end": 2,
           "line": 1,
-          "range": [
-            1,
-            2
-          ],
           "raw": "1",
+          "start": 1,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          2
-        ],
         "raw": "-1",
+        "start": 0,
         "type": "UnaryNegateOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "-1",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/unary-plus/output.json
+++ b/test/examples/unary-plus/output.json
@@ -1,44 +1,36 @@
 {
   "body": {
     "column": 1,
+    "end": 2,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      2
-    ],
     "raw": "+1",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 2,
         "expression": {
           "column": 2,
           "data": 1,
+          "end": 2,
           "line": 1,
-          "range": [
-            1,
-            2
-          ],
           "raw": "1",
+          "start": 1,
           "type": "Int"
         },
         "line": 1,
-        "range": [
-          0,
-          2
-        ],
         "raw": "+1",
+        "start": 0,
         "type": "UnaryPlusOp"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 2,
   "line": 1,
-  "range": [
-    0,
-    2
-  ],
   "raw": "+1",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/undefined/output.json
+++ b/test/examples/undefined/output.json
@@ -1,33 +1,27 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "undefined",
+    "start": 0,
     "statements": [
       {
         "column": 1,
+        "end": 9,
         "line": 1,
-        "range": [
-          0,
-          9
-        ],
         "raw": "undefined",
+        "start": 0,
         "type": "Undefined"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "undefined",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/unless-in/output.json
+++ b/test/examples/unless-in/output.json
@@ -1,92 +1,76 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "unless a in b\n  c",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
         "column": 1,
         "condition": {
           "column": 8,
+          "end": 13,
           "isNot": false,
           "left": {
             "column": 8,
             "data": "a",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "a",
+            "start": 7,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            7,
-            13
-          ],
           "raw": "a in b",
           "right": {
             "column": 13,
             "data": "b",
+            "end": 13,
             "line": 1,
-            "range": [
-              12,
-              13
-            ],
             "raw": "b",
+            "start": 12,
             "type": "Identifier"
           },
+          "start": 7,
           "type": "InOp"
         },
         "consequent": {
           "column": 3,
+          "end": 17,
           "inline": false,
           "line": 2,
-          "range": [
-            16,
-            17
-          ],
           "raw": "c",
+          "start": 16,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 17,
               "line": 2,
-              "range": [
-                16,
-                17
-              ],
               "raw": "c",
+              "start": 16,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 17,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          17
-        ],
         "raw": "unless a in b\n  c",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "unless a in b\n  c\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/unless-not-in/output.json
+++ b/test/examples/unless-not-in/output.json
@@ -1,92 +1,76 @@
 {
   "body": {
     "column": 1,
+    "end": 21,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      21
-    ],
     "raw": "unless a not in b\n  c",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
         "column": 1,
         "condition": {
           "column": 8,
+          "end": 17,
           "isNot": true,
           "left": {
             "column": 8,
             "data": "a",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "a",
+            "start": 7,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            7,
-            17
-          ],
           "raw": "a not in b",
           "right": {
             "column": 17,
             "data": "b",
+            "end": 17,
             "line": 1,
-            "range": [
-              16,
-              17
-            ],
             "raw": "b",
+            "start": 16,
             "type": "Identifier"
           },
+          "start": 7,
           "type": "InOp"
         },
         "consequent": {
           "column": 3,
+          "end": 21,
           "inline": false,
           "line": 2,
-          "range": [
-            20,
-            21
-          ],
           "raw": "c",
+          "start": 20,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 21,
               "line": 2,
-              "range": [
-                20,
-                21
-              ],
               "raw": "c",
+              "start": 20,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 21,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          21
-        ],
         "raw": "unless a not in b\n  c",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 22,
   "line": 1,
-  "range": [
-    0,
-    22
-  ],
   "raw": "unless a not in b\n  c\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/unless-not-instanceof/output.json
+++ b/test/examples/unless-not-instanceof/output.json
@@ -1,92 +1,76 @@
 {
   "body": {
     "column": 1,
+    "end": 29,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      29
-    ],
     "raw": "unless a not instanceof b\n  c",
+    "start": 0,
     "statements": [
       {
         "alternate": null,
         "column": 1,
         "condition": {
           "column": 8,
+          "end": 25,
           "isNot": true,
           "left": {
             "column": 8,
             "data": "a",
+            "end": 8,
             "line": 1,
-            "range": [
-              7,
-              8
-            ],
             "raw": "a",
+            "start": 7,
             "type": "Identifier"
           },
           "line": 1,
-          "range": [
-            7,
-            25
-          ],
           "raw": "a not instanceof b",
           "right": {
             "column": 25,
             "data": "b",
+            "end": 25,
             "line": 1,
-            "range": [
-              24,
-              25
-            ],
             "raw": "b",
+            "start": 24,
             "type": "Identifier"
           },
+          "start": 7,
           "type": "InstanceofOp"
         },
         "consequent": {
           "column": 3,
+          "end": 29,
           "inline": false,
           "line": 2,
-          "range": [
-            28,
-            29
-          ],
           "raw": "c",
+          "start": 28,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 29,
               "line": 2,
-              "range": [
-                28,
-                29
-              ],
               "raw": "c",
+              "start": 28,
               "type": "Identifier"
             }
           ],
           "type": "Block"
         },
+        "end": 29,
         "isUnless": true,
         "line": 1,
-        "range": [
-          0,
-          29
-        ],
         "raw": "unless a not instanceof b\n  c",
+        "start": 0,
         "type": "Conditional"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 30,
   "line": 1,
-  "range": [
-    0,
-    30
-  ],
   "raw": "unless a not instanceof b\n  c\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/until/output.json
+++ b/test/examples/until/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "until a\n  b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 11,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            11
-          ],
           "raw": "b",
+          "start": 10,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 11,
               "line": 2,
-              "range": [
-                10,
-                11
-              ],
               "raw": "b",
+              "start": 10,
               "type": "Identifier"
             }
           ],
@@ -38,33 +32,27 @@
         "condition": {
           "column": 7,
           "data": "a",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "type": "Identifier"
         },
+        "end": 11,
         "guard": null,
         "isUntil": true,
         "line": 1,
-        "range": [
-          0,
-          11
-        ],
         "raw": "until a\n  b",
+        "start": 0,
         "type": "While"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "until a\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/while-on-multiple-lines/output.json
+++ b/test/examples/while-on-multiple-lines/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 11,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      11
-    ],
     "raw": "while a\n  b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 11,
           "inline": false,
           "line": 2,
-          "range": [
-            10,
-            11
-          ],
           "raw": "b",
+          "start": 10,
           "statements": [
             {
               "column": 3,
               "data": "b",
+              "end": 11,
               "line": 2,
-              "range": [
-                10,
-                11
-              ],
               "raw": "b",
+              "start": 10,
               "type": "Identifier"
             }
           ],
@@ -38,33 +32,27 @@
         "condition": {
           "column": 7,
           "data": "a",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "type": "Identifier"
         },
+        "end": 11,
         "guard": null,
         "isUntil": false,
         "line": 1,
-        "range": [
-          0,
-          11
-        ],
         "raw": "while a\n  b",
+        "start": 0,
         "type": "While"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 11,
   "line": 1,
-  "range": [
-    0,
-    11
-  ],
   "raw": "while a\n  b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/while-on-one-line/output.json
+++ b/test/examples/while-on-one-line/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 9,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      9
-    ],
     "raw": "a while b",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 1,
+          "end": 1,
           "inline": true,
           "line": 1,
-          "range": [
-            0,
-            1
-          ],
           "raw": "a",
+          "start": 0,
           "statements": [
             {
               "column": 1,
               "data": "a",
+              "end": 1,
               "line": 1,
-              "range": [
-                0,
-                1
-              ],
               "raw": "a",
+              "start": 0,
               "type": "Identifier"
             }
           ],
@@ -38,33 +32,27 @@
         "condition": {
           "column": 9,
           "data": "b",
+          "end": 9,
           "line": 1,
-          "range": [
-            8,
-            9
-          ],
           "raw": "b",
+          "start": 8,
           "type": "Identifier"
         },
+        "end": 9,
         "guard": null,
         "isUntil": false,
         "line": 1,
-        "range": [
-          0,
-          9
-        ],
         "raw": "a while b",
+        "start": 0,
         "type": "While"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 9,
   "line": 1,
-  "range": [
-    0,
-    9
-  ],
   "raw": "a while b",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/while-with-guard/output.json
+++ b/test/examples/while-with-guard/output.json
@@ -1,34 +1,28 @@
 {
   "body": {
     "column": 1,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      18
-    ],
     "raw": "while a when b\n  c",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 3,
+          "end": 18,
           "inline": false,
           "line": 2,
-          "range": [
-            17,
-            18
-          ],
           "raw": "c",
+          "start": 17,
           "statements": [
             {
               "column": 3,
               "data": "c",
+              "end": 18,
               "line": 2,
-              "range": [
-                17,
-                18
-              ],
               "raw": "c",
+              "start": 17,
               "type": "Identifier"
             }
           ],
@@ -38,43 +32,35 @@
         "condition": {
           "column": 7,
           "data": "a",
+          "end": 7,
           "line": 1,
-          "range": [
-            6,
-            7
-          ],
           "raw": "a",
+          "start": 6,
           "type": "Identifier"
         },
+        "end": 18,
         "guard": {
           "column": 14,
           "data": "b",
+          "end": 14,
           "line": 1,
-          "range": [
-            13,
-            14
-          ],
           "raw": "b",
+          "start": 13,
           "type": "Identifier"
         },
         "isUntil": false,
         "line": 1,
-        "range": [
-          0,
-          18
-        ],
         "raw": "while a when b\n  c",
+        "start": 0,
         "type": "While"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "while a when b\n  c",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/yield-from/output.json
+++ b/test/examples/yield-from/output.json
@@ -1,81 +1,67 @@
 {
   "body": {
     "column": 1,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      18
-    ],
     "raw": "-> yield from fn()",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 4,
+          "end": 18,
           "inline": true,
           "line": 1,
-          "range": [
-            3,
-            18
-          ],
           "raw": "yield from fn()",
+          "start": 3,
           "statements": [
             {
               "column": 4,
+              "end": 18,
               "expression": {
                 "arguments": [
                 ],
                 "column": 15,
+                "end": 18,
                 "function": {
                   "column": 15,
                   "data": "fn",
+                  "end": 16,
                   "line": 1,
-                  "range": [
-                    14,
-                    16
-                  ],
                   "raw": "fn",
+                  "start": 14,
                   "type": "Identifier"
                 },
                 "line": 1,
-                "range": [
-                  14,
-                  18
-                ],
                 "raw": "fn()",
+                "start": 14,
                 "type": "FunctionApplication"
               },
               "line": 1,
-              "range": [
-                3,
-                18
-              ],
               "raw": "yield from fn()",
+              "start": 3,
               "type": "YieldFrom"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 18,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          18
-        ],
         "raw": "-> yield from fn()",
+        "start": 0,
         "type": "GeneratorFunction"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "-> yield from fn()",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/yield-return-empty/output.json
+++ b/test/examples/yield-return-empty/output.json
@@ -1,59 +1,49 @@
 {
   "body": {
     "column": 1,
+    "end": 15,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      15
-    ],
     "raw": "-> yield return",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 4,
+          "end": 15,
           "inline": true,
           "line": 1,
-          "range": [
-            3,
-            15
-          ],
           "raw": "yield return",
+          "start": 3,
           "statements": [
             {
               "column": 4,
+              "end": 15,
               "expression": null,
               "line": 1,
-              "range": [
-                3,
-                15
-              ],
               "raw": "yield return",
+              "start": 3,
               "type": "YieldReturn"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 15,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          15
-        ],
         "raw": "-> yield return",
+        "start": 0,
         "type": "GeneratorFunction"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 16,
   "line": 1,
-  "range": [
-    0,
-    16
-  ],
   "raw": "-> yield return\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/yield-return/output.json
+++ b/test/examples/yield-return/output.json
@@ -1,69 +1,57 @@
 {
   "body": {
     "column": 1,
+    "end": 17,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      17
-    ],
     "raw": "-> yield return 3",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 4,
+          "end": 17,
           "inline": true,
           "line": 1,
-          "range": [
-            3,
-            17
-          ],
           "raw": "yield return 3",
+          "start": 3,
           "statements": [
             {
               "column": 4,
+              "end": 17,
               "expression": {
                 "column": 17,
                 "data": 3,
+                "end": 17,
                 "line": 1,
-                "range": [
-                  16,
-                  17
-                ],
                 "raw": "3",
+                "start": 16,
                 "type": "Int"
               },
               "line": 1,
-              "range": [
-                3,
-                17
-              ],
               "raw": "yield return 3",
+              "start": 3,
               "type": "YieldReturn"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 17,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          17
-        ],
         "raw": "-> yield return 3",
+        "start": 0,
         "type": "GeneratorFunction"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 18,
   "line": 1,
-  "range": [
-    0,
-    18
-  ],
   "raw": "-> yield return 3\n",
+  "start": 0,
   "type": "Program"
 }

--- a/test/examples/yield/output.json
+++ b/test/examples/yield/output.json
@@ -1,69 +1,57 @@
 {
   "body": {
     "column": 1,
+    "end": 10,
     "inline": false,
     "line": 1,
-    "range": [
-      0,
-      10
-    ],
     "raw": "-> yield 1",
+    "start": 0,
     "statements": [
       {
         "body": {
           "column": 4,
+          "end": 10,
           "inline": true,
           "line": 1,
-          "range": [
-            3,
-            10
-          ],
           "raw": "yield 1",
+          "start": 3,
           "statements": [
             {
               "column": 4,
+              "end": 10,
               "expression": {
                 "column": 10,
                 "data": 1,
+                "end": 10,
                 "line": 1,
-                "range": [
-                  9,
-                  10
-                ],
                 "raw": "1",
+                "start": 9,
                 "type": "Int"
               },
               "line": 1,
-              "range": [
-                3,
-                10
-              ],
               "raw": "yield 1",
+              "start": 3,
               "type": "Yield"
             }
           ],
           "type": "Block"
         },
         "column": 1,
+        "end": 10,
         "line": 1,
         "parameters": [
         ],
-        "range": [
-          0,
-          10
-        ],
         "raw": "-> yield 1",
+        "start": 0,
         "type": "GeneratorFunction"
       }
     ],
     "type": "Block"
   },
   "column": 1,
+  "end": 10,
   "line": 1,
-  "range": [
-    0,
-    10
-  ],
   "raw": "-> yield 1",
+  "start": 0,
   "type": "Program"
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,9 +1,9 @@
-import { deepEqual } from 'assert';
+import { deepEqual, equal } from 'assert';
 import { readdirSync, readFileSync, writeFileSync } from 'fs';
 import * as stringify from 'json-stable-stringify';
 import { join } from 'path';
 import { Node, Program } from '../src/nodes';
-import { parse } from '../src/parser';
+import { parse, traverse } from '../src/parser';
 
 let examplesPath = join(__dirname, 'examples');
 
@@ -31,14 +31,10 @@ function stripContext(programNode: Program): Program {
 }
 
 function stripExtraInfo(node: Node): Node {
-  for (let key in node) {
-    if (key === 'start' || key === 'end') {
-      delete node[key];
-    }
-  }
-  for (let child of node.getChildren()) {
-    stripExtraInfo(child);
-  }
+  traverse(node, (node, parent) => {
+    equal(node.parentNode, parent);
+    delete node.parentNode;
+  });
   return node;
 }
 


### PR DESCRIPTION
Also throw in some other breaking changes and other cleanups.

BREAKING CHANGE: All nodes now have a `parentNode` field.

Shorthand object initializers now have a `null` value rather than using the same
node as the key and the value. This ensures no node gets traversed twice in a
traversal.

The `range` field has been removed from nodes. Code should now use `start` and
`end` instead.