### PR TITLE
fix: add node 8 to the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 notifications:
   email: false
 node_js:
+  - '8'
   - '7'
   - '6'
   - '4'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2625,9 +2625,9 @@ safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-semantic-release@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.npmjs.org/semantic-release/-/semantic-release-8.2.0.tgz#972aa3a7246065d8a405991005a210e46995d4b6"
+semantic-release@^8.2.0:
+  version "8.2.1"
+  resolved "https://registry.npmjs.org/semantic-release/-/semantic-release-8.2.1.tgz#0bd4c2d372b328b2617fb34688937e58387f1bc1"
   dependencies:
     "@semantic-release/commit-analyzer" "^3.0.1"
     "@semantic-release/condition-travis" "^6.0.0"


### PR DESCRIPTION
We need node 8 for semantic-release to work, and it's a good idea to add it
anyway. Note that this works with travis_after_all since the first build is
always the build leader, but it's possible we can/should get rid of that, but
I'll do the easy thing for now.

Also fix an issue with the lockfile being non-canonical, presumably due to a
greenkeeper issue.