### PR TITLE
feat: add parsing for import and export declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   ],
   "dependencies": {
     "babylon": "^6.18.0",
-    "coffee-lex": "^8.0.0",
-    "decaffeinate-coffeescript": "1.12.7-patch.1",
+    "coffee-lex": "^8.1.0",
+    "decaffeinate-coffeescript": "1.12.7-patch.2",
     "json-stable-stringify": "^1.0.1",
     "lines-and-columns": "^1.1.6"
   },

--- a/src/mappers/mapAny.ts
+++ b/src/mappers/mapAny.ts
@@ -1,7 +1,7 @@
 import {
   Arr, Assign, Base, Block, Call, Class, Code, Comment, Existence, Expansion, Extends,
-  For, If, In, Literal, Obj, Op, Param, Parens, Range, Return, Splat, Switch,
-  Throw, Try, Value, While
+  For, If, In, Literal, ModuleDeclaration, Obj, Op, Param, Parens, Range, Return, Splat, Switch,
+  Throw, Try, Value, While,
 } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
 import { Node } from '../nodes';
 import ParseContext from '../util/ParseContext';
@@ -19,6 +19,7 @@ import mapFor from './mapFor';
 import mapIf from './mapIf';
 import mapIn from './mapIn';
 import mapLiteral from './mapLiteral';
+import mapModuleDeclaration from './mapModuleDeclaration';
 import mapObj from './mapObj';
 import mapOp from './mapOp';
 import mapParam from './mapParam';
@@ -131,6 +132,10 @@ export default function mapAny(context: ParseContext, node: Base): Node {
 
   if (node instanceof Extends) {
     return mapExtends(context, node);
+  }
+
+  if (node instanceof ModuleDeclaration) {
+    return mapModuleDeclaration(context, node);
   }
 
   if (node instanceof Comment) {

--- a/src/mappers/mapModuleDeclaration.ts
+++ b/src/mappers/mapModuleDeclaration.ts
@@ -1,0 +1,113 @@
+import {
+  ExportAllDeclaration as CoffeeExportAllDeclaration,
+  ExportDefaultDeclaration as CoffeeExportDefaultDeclaration,
+  ExportNamedDeclaration as CoffeeExportNamedDeclaration, ExportSpecifierList,
+  ImportClause,
+  ImportDeclaration as CoffeeImportDeclaration,
+  ImportNamespaceSpecifier,
+  ImportSpecifierList,
+  Literal,
+  ModuleDeclaration,
+  ModuleSpecifier as CoffeeModuleSpecifier, StringLiteral,
+} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import {
+  ExportAllDeclaration,
+  ExportBindingsDeclaration, ExportDefaultDeclaration,
+  ExportNamedDeclaration,
+  Identifier,
+  ImportDeclaration,
+  ModuleSpecifier,
+  Node,
+  String,
+} from '../nodes';
+import getLocation from '../util/getLocation';
+import ParseContext from '../util/ParseContext';
+import UnsupportedNodeError from '../util/UnsupportedNodeError';
+import mapAny from './mapAny';
+import mapLiteral from './mapLiteral';
+
+export default function mapModuleDeclaration(context: ParseContext, node: ModuleDeclaration): Node {
+  let { line, column, start, end, raw } = getLocation(context, node);
+
+  if (node instanceof CoffeeImportDeclaration) {
+    let clause = node.clause;
+    if (!(clause instanceof ImportClause)) {
+      throw new Error('Expected import clause as the clause for an import declaration.');
+    }
+    let defaultBinding = clause.defaultBinding && mapIdentifierSpecifier(context, clause.defaultBinding);
+    let namespaceImport = null;
+    let namedImports = null;
+
+    if (clause.namedImports instanceof ImportNamespaceSpecifier) {
+      namespaceImport = mapStarSpecifier(context, clause.namedImports);
+    } else if (clause.namedImports instanceof ImportSpecifierList) {
+      namedImports = clause.namedImports.specifiers.map((specifier) => mapSpecifier(context, specifier));
+    }
+
+    if (!node.source) {
+      throw new Error('Expected non-null source for import.');
+    }
+    let source = mapSource(context, node.source);
+    return new ImportDeclaration(line, column, start, end, raw, defaultBinding, namespaceImport, namedImports, source);
+  } else if (node instanceof CoffeeExportNamedDeclaration) {
+    if (node.clause instanceof ExportSpecifierList) {
+      let namedExports = node.clause.specifiers.map((specifier) => mapSpecifier(context, specifier));
+      let source = node.source ? mapSource(context, node.source) : null;
+      return new ExportBindingsDeclaration(line, column, start, end, raw, namedExports, source);
+    } else {
+      let expression = mapAny(context, node.clause);
+      return new ExportNamedDeclaration(line, column, start, end, raw, expression);
+    }
+  } else if (node instanceof CoffeeExportDefaultDeclaration) {
+    let expression = mapAny(context, node.clause);
+    return new ExportDefaultDeclaration(line, column, start, end, raw, expression);
+  } else if (node instanceof CoffeeExportAllDeclaration) {
+    if (!node.source) {
+      throw new Error('Expected non-null source for star export.');
+    }
+    let source = mapSource(context, node.source);
+    return new ExportAllDeclaration(line, column, start, end, raw, source);
+  } else {
+    throw new UnsupportedNodeError(node);
+  }
+}
+
+function mapSource(context: ParseContext, coffeeSource: StringLiteral): String {
+  let source = mapLiteral(context, coffeeSource);
+  if (!(source instanceof String)) {
+    throw new Error('Expected string literal as import source.');
+  }
+  return source;
+}
+
+function mapIdentifierSpecifier(context: ParseContext, specifier: CoffeeModuleSpecifier): Identifier {
+  if (specifier.alias) {
+    throw new Error('Expected no alias for identifier specifier.');
+  }
+  return mapLiteralToIdentifier(context, specifier.original);
+}
+
+function mapStarSpecifier(context: ParseContext, specifier: CoffeeModuleSpecifier): Identifier {
+  if (specifier.original.value !== '*') {
+    throw new Error('Expected a star on the LHS of a star specifier.');
+  }
+  if (!specifier.alias) {
+    throw new Error('Expected node on the RHS of star specifier.');
+  }
+  return mapLiteralToIdentifier(context, specifier.alias);
+}
+
+function mapSpecifier(context: ParseContext, specifier: CoffeeModuleSpecifier): ModuleSpecifier {
+  let { line, column, start, end, raw } = getLocation(context, specifier);
+  let original = mapLiteralToIdentifier(context, specifier.original);
+  let alias = specifier.alias ? mapLiteralToIdentifier(context, specifier.alias) : null;
+  return new ModuleSpecifier(line, column, start, end, raw, original, alias);
+}
+
+function mapLiteralToIdentifier(context: ParseContext, literal: Literal): Identifier {
+  let identifier = mapLiteral(context, literal);
+  if (!(identifier instanceof Identifier)) {
+    throw new Error('Expected identifier in declaration.');
+  }
+  return identifier;
+}

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -1894,3 +1894,111 @@ export class DoOp extends Node {
     return ['expression'];
   }
 }
+
+export class ImportDeclaration extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    readonly defaultBinding: Identifier | null,
+    readonly namespaceImport: Identifier | null,
+    readonly namedImports: Array<ModuleSpecifier> | null,
+    readonly source: String,
+  ) {
+    super('ImportDeclaration', line, column, start, end, raw);
+  }
+
+  getChildNames(): Array<keyof this> {
+    return ['defaultBinding', 'namespaceImport', 'namedImports', 'source'];
+  }
+}
+
+export class ExportNamedDeclaration extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    // This may be an assignment to an identifier, or it could be another binding expression like a class.
+    readonly expression: Node,
+  ) {
+    super('ExportNamedDeclaration', line, column, start, end, raw);
+  }
+
+  getChildNames(): Array<keyof this> {
+    return ['expression'];
+  }
+}
+
+export class ExportBindingsDeclaration extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    readonly namedExports: Array<ModuleSpecifier>,
+    readonly source: String | null,
+  ) {
+    super('ExportBindingsDeclaration', line, column, start, end, raw);
+  }
+
+  getChildNames(): Array<keyof this> {
+    return ['namedExports', 'source'];
+  }
+}
+
+export class ExportDefaultDeclaration extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    readonly expression: Node,
+  ) {
+    super('ExportDefaultDeclaration', line, column, start, end, raw);
+  }
+
+  getChildNames(): Array<keyof this> {
+    return ['expression'];
+  }
+}
+
+export class ExportAllDeclaration extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    readonly source: String,
+  ) {
+    super('ExportAllDeclaration', line, column, start, end, raw);
+  }
+
+  getChildNames(): Array<keyof this> {
+    return ['source'];
+  }
+}
+
+export class ModuleSpecifier extends Node {
+  constructor(
+    line: number,
+    column: number,
+    start: number,
+    end: number,
+    raw: string,
+    readonly original: Identifier,
+    readonly alias: Identifier | null,
+  ) {
+    super('ModuleSpecifier', line, column, start, end, raw);
+  }
+
+  getChildNames(): Array<keyof this> {
+    return ['original', 'alias'];
+  }
+}

--- a/test/examples/export-assignment/input.coffee
+++ b/test/examples/export-assignment/input.coffee
@@ -1,0 +1,1 @@
+export a = 1

--- a/test/examples/export-assignment/output.json
+++ b/test/examples/export-assignment/output.json
@@ -1,0 +1,53 @@
+{
+  "body": {
+    "column": 1,
+    "end": 12,
+    "inline": false,
+    "line": 1,
+    "raw": "export a = 1",
+    "start": 0,
+    "statements": [
+      {
+        "column": 1,
+        "end": 12,
+        "expression": {
+          "assignee": {
+            "column": 8,
+            "data": "a",
+            "end": 8,
+            "line": 1,
+            "raw": "a",
+            "start": 7,
+            "type": "Identifier"
+          },
+          "column": 1,
+          "end": 12,
+          "expression": {
+            "column": 12,
+            "data": 1,
+            "end": 12,
+            "line": 1,
+            "raw": "1",
+            "start": 11,
+            "type": "Int"
+          },
+          "line": 1,
+          "raw": "export a = 1",
+          "start": 0,
+          "type": "AssignOp"
+        },
+        "line": 1,
+        "raw": "export a = 1",
+        "start": 0,
+        "type": "ExportNamedDeclaration"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 13,
+  "line": 1,
+  "raw": "export a = 1\n",
+  "start": 0,
+  "type": "Program"
+}

--- a/test/examples/export-default/input.coffee
+++ b/test/examples/export-default/input.coffee
@@ -1,0 +1,1 @@
+export default a

--- a/test/examples/export-default/output.json
+++ b/test/examples/export-default/output.json
@@ -1,0 +1,36 @@
+{
+  "body": {
+    "column": 1,
+    "end": 16,
+    "inline": false,
+    "line": 1,
+    "raw": "export default a",
+    "start": 0,
+    "statements": [
+      {
+        "column": 1,
+        "end": 16,
+        "expression": {
+          "column": 16,
+          "data": "a",
+          "end": 16,
+          "line": 1,
+          "raw": "a",
+          "start": 15,
+          "type": "Identifier"
+        },
+        "line": 1,
+        "raw": "export default a",
+        "start": 0,
+        "type": "ExportDefaultDeclaration"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 17,
+  "line": 1,
+  "raw": "export default a\n",
+  "start": 0,
+  "type": "Program"
+}

--- a/test/examples/export-multiple-bindings/input.coffee
+++ b/test/examples/export-multiple-bindings/input.coffee
@@ -1,0 +1,2 @@
+export {a, b as c} from 'd'
+export {e as f}

--- a/test/examples/export-multiple-bindings/output.json
+++ b/test/examples/export-multiple-bindings/output.json
@@ -1,0 +1,131 @@
+{
+  "body": {
+    "column": 1,
+    "end": 43,
+    "inline": false,
+    "line": 1,
+    "raw": "export {a, b as c} from 'd'\nexport {e as f}",
+    "start": 0,
+    "statements": [
+      {
+        "column": 1,
+        "end": 27,
+        "line": 1,
+        "namedExports": [
+          {
+            "alias": null,
+            "column": 9,
+            "end": 9,
+            "line": 1,
+            "original": {
+              "column": 9,
+              "data": "a",
+              "end": 9,
+              "line": 1,
+              "raw": "a",
+              "start": 8,
+              "type": "Identifier"
+            },
+            "raw": "a",
+            "start": 8,
+            "type": "ModuleSpecifier"
+          },
+          {
+            "alias": {
+              "column": 17,
+              "data": "c",
+              "end": 17,
+              "line": 1,
+              "raw": "c",
+              "start": 16,
+              "type": "Identifier"
+            },
+            "column": 12,
+            "end": 17,
+            "line": 1,
+            "original": {
+              "column": 12,
+              "data": "b",
+              "end": 12,
+              "line": 1,
+              "raw": "b",
+              "start": 11,
+              "type": "Identifier"
+            },
+            "raw": "b as c",
+            "start": 11,
+            "type": "ModuleSpecifier"
+          }
+        ],
+        "raw": "export {a, b as c} from 'd'",
+        "source": {
+          "column": 25,
+          "end": 27,
+          "expressions": [
+          ],
+          "line": 1,
+          "quasis": [
+            {
+              "column": 26,
+              "data": "d",
+              "end": 26,
+              "line": 1,
+              "raw": "d",
+              "start": 25,
+              "type": "Quasi"
+            }
+          ],
+          "raw": "'d'",
+          "start": 24,
+          "type": "String"
+        },
+        "start": 0,
+        "type": "ExportBindingsDeclaration"
+      },
+      {
+        "column": 1,
+        "end": 43,
+        "line": 2,
+        "namedExports": [
+          {
+            "alias": {
+              "column": 14,
+              "data": "f",
+              "end": 42,
+              "line": 2,
+              "raw": "f",
+              "start": 41,
+              "type": "Identifier"
+            },
+            "column": 9,
+            "end": 42,
+            "line": 2,
+            "original": {
+              "column": 9,
+              "data": "e",
+              "end": 37,
+              "line": 2,
+              "raw": "e",
+              "start": 36,
+              "type": "Identifier"
+            },
+            "raw": "e as f",
+            "start": 36,
+            "type": "ModuleSpecifier"
+          }
+        ],
+        "raw": "export {e as f}",
+        "source": null,
+        "start": 28,
+        "type": "ExportBindingsDeclaration"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 44,
+  "line": 1,
+  "raw": "export {a, b as c} from 'd'\nexport {e as f}\n",
+  "start": 0,
+  "type": "Program"
+}

--- a/test/examples/export-star/input.coffee
+++ b/test/examples/export-star/input.coffee
@@ -1,0 +1,1 @@
+export * from 'a'

--- a/test/examples/export-star/output.json
+++ b/test/examples/export-star/output.json
@@ -1,0 +1,48 @@
+{
+  "body": {
+    "column": 1,
+    "end": 17,
+    "inline": false,
+    "line": 1,
+    "raw": "export * from 'a'",
+    "start": 0,
+    "statements": [
+      {
+        "column": 1,
+        "end": 17,
+        "line": 1,
+        "raw": "export * from 'a'",
+        "source": {
+          "column": 15,
+          "end": 17,
+          "expressions": [
+          ],
+          "line": 1,
+          "quasis": [
+            {
+              "column": 16,
+              "data": "a",
+              "end": 16,
+              "line": 1,
+              "raw": "a",
+              "start": 15,
+              "type": "Quasi"
+            }
+          ],
+          "raw": "'a'",
+          "start": 14,
+          "type": "String"
+        },
+        "start": 0,
+        "type": "ExportAllDeclaration"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 18,
+  "line": 1,
+  "raw": "export * from 'a'\n",
+  "start": 0,
+  "type": "Program"
+}

--- a/test/examples/import-default/input.coffee
+++ b/test/examples/import-default/input.coffee
@@ -1,0 +1,1 @@
+import a from 'b'

--- a/test/examples/import-default/output.json
+++ b/test/examples/import-default/output.json
@@ -1,0 +1,59 @@
+{
+  "body": {
+    "column": 1,
+    "end": 17,
+    "inline": false,
+    "line": 1,
+    "raw": "import a from 'b'",
+    "start": 0,
+    "statements": [
+      {
+        "column": 1,
+        "defaultBinding": {
+          "column": 8,
+          "data": "a",
+          "end": 8,
+          "line": 1,
+          "raw": "a",
+          "start": 7,
+          "type": "Identifier"
+        },
+        "end": 17,
+        "line": 1,
+        "namedImports": null,
+        "namespaceImport": null,
+        "raw": "import a from 'b'",
+        "source": {
+          "column": 15,
+          "end": 17,
+          "expressions": [
+          ],
+          "line": 1,
+          "quasis": [
+            {
+              "column": 16,
+              "data": "b",
+              "end": 16,
+              "line": 1,
+              "raw": "b",
+              "start": 15,
+              "type": "Quasi"
+            }
+          ],
+          "raw": "'b'",
+          "start": 14,
+          "type": "String"
+        },
+        "start": 0,
+        "type": "ImportDeclaration"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 18,
+  "line": 1,
+  "raw": "import a from 'b'\n",
+  "start": 0,
+  "type": "Program"
+}

--- a/test/examples/import-named-with-alias/input.coffee
+++ b/test/examples/import-named-with-alias/input.coffee
@@ -1,0 +1,1 @@
+import {a, b as c} from 'd'

--- a/test/examples/import-named-with-alias/output.json
+++ b/test/examples/import-named-with-alias/output.json
@@ -1,0 +1,96 @@
+{
+  "body": {
+    "column": 1,
+    "end": 27,
+    "inline": false,
+    "line": 1,
+    "raw": "import {a, b as c} from 'd'",
+    "start": 0,
+    "statements": [
+      {
+        "column": 1,
+        "defaultBinding": null,
+        "end": 27,
+        "line": 1,
+        "namedImports": [
+          {
+            "alias": null,
+            "column": 9,
+            "end": 9,
+            "line": 1,
+            "original": {
+              "column": 9,
+              "data": "a",
+              "end": 9,
+              "line": 1,
+              "raw": "a",
+              "start": 8,
+              "type": "Identifier"
+            },
+            "raw": "a",
+            "start": 8,
+            "type": "ModuleSpecifier"
+          },
+          {
+            "alias": {
+              "column": 17,
+              "data": "c",
+              "end": 17,
+              "line": 1,
+              "raw": "c",
+              "start": 16,
+              "type": "Identifier"
+            },
+            "column": 12,
+            "end": 17,
+            "line": 1,
+            "original": {
+              "column": 12,
+              "data": "b",
+              "end": 12,
+              "line": 1,
+              "raw": "b",
+              "start": 11,
+              "type": "Identifier"
+            },
+            "raw": "b as c",
+            "start": 11,
+            "type": "ModuleSpecifier"
+          }
+        ],
+        "namespaceImport": null,
+        "raw": "import {a, b as c} from 'd'",
+        "source": {
+          "column": 25,
+          "end": 27,
+          "expressions": [
+          ],
+          "line": 1,
+          "quasis": [
+            {
+              "column": 26,
+              "data": "d",
+              "end": 26,
+              "line": 1,
+              "raw": "d",
+              "start": 25,
+              "type": "Quasi"
+            }
+          ],
+          "raw": "'d'",
+          "start": 24,
+          "type": "String"
+        },
+        "start": 0,
+        "type": "ImportDeclaration"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 28,
+  "line": 1,
+  "raw": "import {a, b as c} from 'd'\n",
+  "start": 0,
+  "type": "Program"
+}

--- a/test/examples/import-star/input.coffee
+++ b/test/examples/import-star/input.coffee
@@ -1,0 +1,1 @@
+import * as a from 'b'

--- a/test/examples/import-star/output.json
+++ b/test/examples/import-star/output.json
@@ -1,0 +1,59 @@
+{
+  "body": {
+    "column": 1,
+    "end": 22,
+    "inline": false,
+    "line": 1,
+    "raw": "import * as a from 'b'",
+    "start": 0,
+    "statements": [
+      {
+        "column": 1,
+        "defaultBinding": null,
+        "end": 22,
+        "line": 1,
+        "namedImports": null,
+        "namespaceImport": {
+          "column": 13,
+          "data": "a",
+          "end": 13,
+          "line": 1,
+          "raw": "a",
+          "start": 12,
+          "type": "Identifier"
+        },
+        "raw": "import * as a from 'b'",
+        "source": {
+          "column": 20,
+          "end": 22,
+          "expressions": [
+          ],
+          "line": 1,
+          "quasis": [
+            {
+              "column": 21,
+              "data": "b",
+              "end": 21,
+              "line": 1,
+              "raw": "b",
+              "start": 20,
+              "type": "Quasi"
+            }
+          ],
+          "raw": "'b'",
+          "start": 19,
+          "type": "String"
+        },
+        "start": 0,
+        "type": "ImportDeclaration"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 23,
+  "line": 1,
+  "raw": "import * as a from 'b'\n",
+  "start": 0,
+  "type": "Program"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,9 +942,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-coffee-lex@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.npmjs.org/coffee-lex/-/coffee-lex-8.0.0.tgz#acdc94e8122351f254465854facba4c7afee5a6c"
+coffee-lex@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/coffee-lex/-/coffee-lex-8.1.0.tgz#dfdcb5d802403a23375bef6dd776462ca7f1d556"
 
 coffee-script-redux@^2.0.0-beta8:
   version "2.0.0-beta8"
@@ -1150,9 +1150,9 @@ debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-decaffeinate-coffeescript@1.12.7-patch.1:
-  version "1.12.7-patch.1"
-  resolved "https://registry.npmjs.org/decaffeinate-coffeescript/-/decaffeinate-coffeescript-1.12.7-patch.1.tgz#e44b7a4b8bc91fccb8add06fa95dd309b30178cf"
+decaffeinate-coffeescript@1.12.7-patch.2:
+  version "1.12.7-patch.2"
+  resolved "https://registry.npmjs.org/decaffeinate-coffeescript/-/decaffeinate-coffeescript-1.12.7-patch.2.tgz#c0a453395e0194bcf0dce8d81dbf7170c5a1d578"
 
 decamelize@^1.0.0, decamelize@^1.1.2:
   version "1.2.0"


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/427

The AST format is a little simpler than what CoffeeScript uses, partly because
we won't need to transform much, and partly to make the type signatures more
precise.