### PR TITLE
feat: switch to the CS2 AST format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ node_js:
   - '9'
   - '8'
   - '6'
-  - '4'
 before_install:
   # TODO: Switch this back to yarn when greenkeeperio/greenkeeper-lockfile#98 is fixed.
   # https://github.com/greenkeeperio/greenkeeper-lockfile/issues/98

--- a/package.json
+++ b/package.json
@@ -22,10 +22,14 @@
   "files": [
     "dist/"
   ],
+  "engines": {
+    "node": ">=6"
+  },
   "dependencies": {
     "babylon": "^6.18.0",
     "coffee-lex": "^8.1.1",
     "decaffeinate-coffeescript": "1.12.7-patch.2",
+    "decaffeinate-coffeescript2": "2.2.1-patch.1",
     "json-stable-stringify": "^1.0.1",
     "lines-and-columns": "^1.1.6"
   },

--- a/src/ext/coffee-script.ts
+++ b/src/ext/coffee-script.ts
@@ -1,6 +1,9 @@
-import { Base, Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base as CS1Base, Op as CS1Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base, Op } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 
 export function patchCoffeeScript(): void {
+  CS1Op.prototype.invert = invert;
+  CS1Base.prototype.invert = invert;
   Op.prototype.invert = invert;
   Base.prototype.invert = invert;
 }

--- a/src/mappers/mapAny.ts
+++ b/src/mappers/mapAny.ts
@@ -1,8 +1,8 @@
 import {
-  Arr, Assign, Base, Block, Call, Class, Code, Comment, Existence, Expansion, Extends,
-  For, If, In, Literal, ModuleDeclaration, Obj, Op, Param, Parens, Range, Return, Splat, Switch, TaggedTemplateCall,
-  Throw, Try, Value, While,
-} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+  Arr, Assign, Base, Block, Call, Class, Code, Existence, Expansion, Extends, For, If, In, Literal, ModuleDeclaration,
+  Obj, Op, Param, Parens, Range, Return, Splat, StringWithInterpolations, Switch, TaggedTemplateCall, Throw, Try, Value,
+  While,
+} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Node } from '../nodes';
 import ParseContext from '../util/ParseContext';
 import UnsupportedNodeError from '../util/UnsupportedNodeError';
@@ -79,7 +79,7 @@ export default function mapAny(context: ParseContext, node: Base): Node {
     return mapObj(context, node);
   }
 
-  if (node instanceof Parens) {
+  if (node instanceof Parens || node instanceof StringWithInterpolations) {
     return mapParens(context, node);
   }
 
@@ -141,11 +141,6 @@ export default function mapAny(context: ParseContext, node: Base): Node {
 
   if (node instanceof ModuleDeclaration) {
     return mapModuleDeclaration(context, node);
-  }
-
-  if (node instanceof Comment) {
-    throw new UnsupportedNodeError(
-      node, 'Expected comment notes to be filtered out by mapBlock rather than processed directly.');
   }
 
   throw new UnsupportedNodeError(node);

--- a/src/mappers/mapArr.ts
+++ b/src/mappers/mapArr.ts
@@ -1,4 +1,4 @@
-import { Arr } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Arr } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { ArrayInitialiser } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapAssign.ts
+++ b/src/mappers/mapAssign.ts
@@ -1,4 +1,4 @@
-import { Assign } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Assign } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { AssignOp, BaseAssignOp, BitAndOp, BitOrOp, BitXorOp, CompoundAssignOp, DivideOp, ExistsOp, ExpOp, FloorDivideOp, LeftShiftOp, LogicalAndOp, LogicalOrOp, ModuloOp, MultiplyOp, PlusOp, RemOp, SignedRightShiftOp, SubtractOp, UnsignedRightShiftOp } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapBlock.ts
+++ b/src/mappers/mapBlock.ts
@@ -1,8 +1,9 @@
 import { SourceType } from 'coffee-lex';
-import { Assign, Base, Block as CoffeeBlock, Comment, Obj, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Assign, Base, Block as CoffeeBlock, Obj, Value } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 import { AssignOp, Block, BoundFunction, BoundGeneratorFunction, ClassProtoAssignOp, Constructor, Identifier, MemberAccessOp, Node, This } from '../nodes';
 import getLocation from '../util/getLocation';
+import isCommentOnlyNode from '../util/isCommentOnlyNode';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
 
@@ -28,7 +29,7 @@ export default function mapBlock(context: ParseContext, node: CoffeeBlock): Bloc
   return new Block(
     line, column, start, end, raw,
     node.expressions
-      .filter(expression => !(expression instanceof Comment))
+      .filter(expression => !isCommentOnlyNode(expression))
       .map(expression => mapChild(context, childContext, expression))
       .reduce((arr, current) => arr.concat(current), []),
     inline
@@ -44,9 +45,7 @@ function mapChild(blockContext: ParseContext, childContext: ParseContext, node: 
 
     let statements: Array<Node> = [];
     for (let property of obj.properties) {
-      if (property instanceof Comment) {
-        continue;
-      } else if (property instanceof Assign) {
+      if (property instanceof Assign) {
         let { line, column, start, end, raw } = getLocation(childContext, property);
         let key = mapAny(childContext, property.variable);
         let value = mapAny(childContext, property.value);

--- a/src/mappers/mapCall.ts
+++ b/src/mappers/mapCall.ts
@@ -1,5 +1,12 @@
 import SourceType from 'coffee-lex/dist/SourceType';
-import { Call, Literal, Parens, Splat, SuperCall, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import {
+  Call,
+  Literal,
+  Splat,
+  StringWithInterpolations,
+  SuperCall,
+  Value,
+} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 import {
   AssignOp,
@@ -20,7 +27,7 @@ export default function mapCall(context: ParseContext, node: Call): Node {
 
   if (isHeregexTemplateNode(node, context)) {
     let firstArg = node.args[0];
-    if (!(firstArg instanceof Value) || !(firstArg.base instanceof Parens)) {
+    if (!(firstArg instanceof Value) || !(firstArg.base instanceof StringWithInterpolations)) {
       throw new Error('Expected a valid first heregex arg in the AST.');
     }
     let strNode = firstArg.base.body.expressions[0];

--- a/src/mappers/mapClass.ts
+++ b/src/mappers/mapClass.ts
@@ -1,4 +1,4 @@
-import { Class as CoffeeClass } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Class as CoffeeClass } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Class } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapCode.ts
+++ b/src/mappers/mapCode.ts
@@ -1,4 +1,4 @@
-import { Code } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Code } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { BaseFunction, BoundFunction, BoundGeneratorFunction, Function, GeneratorFunction } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapExistence.ts
+++ b/src/mappers/mapExistence.ts
@@ -1,4 +1,4 @@
-import { Existence } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Existence } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { UnaryExistsOp } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapExpansion.ts
+++ b/src/mappers/mapExpansion.ts
@@ -1,4 +1,4 @@
-import { Expansion as CoffeeExpansion } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Expansion as CoffeeExpansion } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Expansion } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapExtends.ts
+++ b/src/mappers/mapExtends.ts
@@ -1,4 +1,4 @@
-import { Extends } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Extends } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { ExtendsOp } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapFor.ts
+++ b/src/mappers/mapFor.ts
@@ -1,4 +1,4 @@
-import { For as CoffeeFor } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { For as CoffeeFor } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import {For, ForFrom, ForIn, ForOf} from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapIf.ts
+++ b/src/mappers/mapIf.ts
@@ -1,6 +1,6 @@
 import { SourceType } from 'coffee-lex';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
-import { If } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { If } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Conditional } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapIn.ts
+++ b/src/mappers/mapIn.ts
@@ -1,5 +1,5 @@
 import SourceType from 'coffee-lex/dist/SourceType';
-import { In as CoffeeIn } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { In as CoffeeIn } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { InOp } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapLiteral.ts
+++ b/src/mappers/mapLiteral.ts
@@ -11,7 +11,7 @@ import {
   StringLiteral,
   ThisLiteral,
   UndefinedLiteral,
-} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import {
   Bool,
   Break,

--- a/src/mappers/mapModuleDeclaration.ts
+++ b/src/mappers/mapModuleDeclaration.ts
@@ -9,7 +9,7 @@ import {
   Literal,
   ModuleDeclaration,
   ModuleSpecifier as CoffeeModuleSpecifier, StringLiteral,
-} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import {
   ExportAllDeclaration,
   ExportBindingsDeclaration, ExportDefaultDeclaration,

--- a/src/mappers/mapObj.ts
+++ b/src/mappers/mapObj.ts
@@ -1,4 +1,4 @@
-import { Assign, Comment, Obj, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Assign, Obj, Value } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { AssignOp, ObjectInitialiser, ObjectInitialiserMember } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';
@@ -41,8 +41,6 @@ export default function mapObj(context: ParseContext, node: Obj): ObjectInitiali
         assignee,
         expression
       ));
-    } else if (property instanceof Comment) {
-      // Ignore.
     } else {
       throw new UnsupportedNodeError(property, 'Unexpected object member.');
     }

--- a/src/mappers/mapOp.ts
+++ b/src/mappers/mapOp.ts
@@ -1,5 +1,5 @@
 import { SourceType } from 'coffee-lex';
-import {Literal, Op as CoffeeOp, Value} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import {Literal, Op as CoffeeOp, Value} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 import {
   BinaryOp, BitAndOp, BitNotOp, BitOrOp, BitXorOp, ChainedComparisonOp, DeleteOp, DivideOp, ExistsOp, ExpOp, EQOp, FloorDivideOp,

--- a/src/mappers/mapParam.ts
+++ b/src/mappers/mapParam.ts
@@ -1,4 +1,4 @@
-import { Param } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Param } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { DefaultParam, Node, Rest } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapParens.ts
+++ b/src/mappers/mapParens.ts
@@ -1,17 +1,16 @@
-import {
-  Block, Comment, Parens
-} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import {Block, Parens, StringWithInterpolations} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Node, SeqOp } from '../nodes';
+import isCommentOnlyNode from '../util/isCommentOnlyNode';
 import ParseContext from '../util/ParseContext';
 import mapAny from './mapAny';
 
-export default function mapParens(context: ParseContext, node: Parens): Node {
+export default function mapParens(context: ParseContext, node: Parens | StringWithInterpolations): Node {
   if (!(node.body instanceof Block)) {
     return mapAny(context, node.body);
   }
 
   let { expressions } = node.body;
-  expressions = expressions.filter((expr) => !(expr instanceof Comment));
+  expressions = expressions.filter((expr) => !isCommentOnlyNode(expr));
 
   if (expressions.length === 1) {
     return mapAny(context, expressions[0]);

--- a/src/mappers/mapPossiblyEmptyBlock.ts
+++ b/src/mappers/mapPossiblyEmptyBlock.ts
@@ -1,5 +1,6 @@
-import { Block as CoffeeBlock } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Block as CoffeeBlock } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Block } from '../nodes';
+import isCommentOnlyNode from '../util/isCommentOnlyNode';
 import ParseContext from '../util/ParseContext';
 import mapBlock from './mapBlock';
 
@@ -24,6 +25,9 @@ import mapBlock from './mapBlock';
  */
 export default function mapPossiblyEmptyBlock(context: ParseContext, node: CoffeeBlock | null | undefined): Block | null {
   if (!node) {
+    return null;
+  }
+  if (node.expressions.every((expression) => isCommentOnlyNode(expression))) {
     return null;
   }
 

--- a/src/mappers/mapRange.ts
+++ b/src/mappers/mapRange.ts
@@ -1,4 +1,4 @@
-import { Range as CoffeeRange } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Range as CoffeeRange } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 import { Range } from '../nodes';
 import getLocation from '../util/getLocation';

--- a/src/mappers/mapReturn.ts
+++ b/src/mappers/mapReturn.ts
@@ -1,4 +1,4 @@
-import { Return as CoffeeReturn, YieldReturn as CoffeeYieldReturn } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Return as CoffeeReturn, YieldReturn as CoffeeYieldReturn } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import {Return, YieldReturn} from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapSplat.ts
+++ b/src/mappers/mapSplat.ts
@@ -1,4 +1,4 @@
-import { Splat } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Splat } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Spread } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapSwitch.ts
+++ b/src/mappers/mapSwitch.ts
@@ -1,6 +1,6 @@
 import SourceToken from 'coffee-lex/dist/SourceToken';
 import SourceType from 'coffee-lex/dist/SourceType';
-import { Switch as CoffeeSwitch } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Switch as CoffeeSwitch } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Switch, SwitchCase } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapTaggedTemplateCall.ts
+++ b/src/mappers/mapTaggedTemplateCall.ts
@@ -1,4 +1,4 @@
-import {TaggedTemplateCall} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import {TaggedTemplateCall} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import {Node, String, TaggedTemplateLiteral} from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapThrow.ts
+++ b/src/mappers/mapThrow.ts
@@ -1,4 +1,4 @@
-import { Throw as CoffeeThrow } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Throw as CoffeeThrow } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Throw } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapTry.ts
+++ b/src/mappers/mapTry.ts
@@ -1,4 +1,4 @@
-import { Try as CoffeeTry } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Try as CoffeeTry } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Try } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/mappers/mapValue.ts
+++ b/src/mappers/mapValue.ts
@@ -2,7 +2,7 @@ import { SourceType } from 'coffee-lex';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
 import {
   Access, Index, Literal, LocationData, Slice as CoffeeSlice, Value
-} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 import {
   DynamicMemberAccessOp,

--- a/src/mappers/mapWhile.ts
+++ b/src/mappers/mapWhile.ts
@@ -1,5 +1,5 @@
 import { SourceType } from 'coffee-lex';
-import { While as CoffeeWhile } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { While as CoffeeWhile } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Block, Loop, While } from '../nodes';
 import getLocation from '../util/getLocation';
 import ParseContext from '../util/ParseContext';

--- a/src/parseCS1AsCS2.ts
+++ b/src/parseCS1AsCS2.ts
@@ -1,0 +1,241 @@
+import {nodes} from 'decaffeinate-coffeescript';
+import {
+  Access as CS1Access,
+  Arr as CS1Arr,
+  Assign as CS1Assign,
+  Base as CS1Base,
+  Block as CS1Block,
+  BooleanLiteral as CS1BooleanLiteral,
+  Call as CS1Call,
+  Class as CS1Class,
+  Code as CS1Code,
+  Comment as CS1Comment,
+  Existence as CS1Existence,
+  Expansion as CS1Expansion,
+  ExportAllDeclaration as CS1ExportAllDeclaration,
+  ExportDeclaration as CS1ExportDeclaration,
+  ExportDefaultDeclaration as CS1ExportDefaultDeclaration,
+  ExportNamedDeclaration as CS1ExportNamedDeclaration,
+  ExportSpecifier as CS1ExportSpecifier,
+  ExportSpecifierList as CS1ExportSpecifierList,
+  Extends as CS1Extends,
+  For as CS1For,
+  IdentifierLiteral as CS1IdentifierLiteral,
+  If as CS1If,
+  ImportClause as CS1ImportClause,
+  ImportDeclaration as CS1ImportDeclaration,
+  ImportDefaultSpecifier as CS1ImportDefaultSpecifier,
+  ImportNamespaceSpecifier as CS1ImportNamespaceSpecifier,
+  ImportSpecifier as CS1ImportSpecifier,
+  ImportSpecifierList as CS1ImportSpecifierList,
+  In as CS1In,
+  Index as CS1Index,
+  InfinityLiteral as CS1InfinityLiteral,
+  Literal as CS1Literal,
+  ModuleDeclaration as CS1ModuleDeclaration,
+  ModuleSpecifier as CS1ModuleSpecifier,
+  ModuleSpecifierList as CS1ModuleSpecifierList,
+  NaNLiteral as CS1NaNLiteral,
+  NullLiteral as CS1NullLiteral,
+  NumberLiteral as CS1NumberLiteral,
+  Obj as CS1Obj,
+  Op as CS1Op,
+  Param as CS1Param,
+  Parens as CS1Parens,
+  PassthroughLiteral as CS1PassthroughLiteral,
+  PropertyName as CS1PropertyName,
+  Range as CS1Range,
+  RegexLiteral as CS1RegexLiteral,
+  RegexWithInterpolations as CS1RegexWithInterpolations,
+  Return as CS1Return,
+  Slice as CS1Slice,
+  Splat as CS1Splat,
+  StatementLiteral as CS1StatementLiteral,
+  StringLiteral as CS1StringLiteral,
+  StringWithInterpolations as CS1StringWithInterpolations,
+  SuperCall as CS1SuperCall,
+  Switch as CS1Switch,
+  SwitchCaseCondition as CS1SwitchCaseCondition,
+  TaggedTemplateCall as CS1TaggedTemplateCall,
+  ThisLiteral as CS1ThisLiteral,
+  Throw as CS1Throw,
+  Try as CS1Try,
+  UndefinedLiteral as CS1UndefinedLiteral,
+  Value as CS1Value,
+  While as CS1While,
+  YieldReturn as CS1YieldReturn,
+} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import {
+  Access,
+  Arr,
+  Assign,
+  Base,
+  Block,
+  BooleanLiteral,
+  Call,
+  Class,
+  Code,
+  Existence,
+  Expansion,
+  ExportAllDeclaration,
+  ExportDeclaration,
+  ExportDefaultDeclaration,
+  ExportNamedDeclaration,
+  ExportSpecifier,
+  ExportSpecifierList,
+  Extends,
+  For,
+  IdentifierLiteral,
+  If,
+  ImportClause,
+  ImportDeclaration,
+  ImportDefaultSpecifier,
+  ImportNamespaceSpecifier,
+  ImportSpecifier,
+  ImportSpecifierList,
+  In,
+  Index,
+  InfinityLiteral,
+  Literal,
+  ModuleDeclaration,
+  ModuleSpecifier,
+  ModuleSpecifierList,
+  NaNLiteral,
+  NullLiteral,
+  NumberLiteral,
+  Obj,
+  Op,
+  Param,
+  Parens,
+  PassthroughLiteral,
+  PropertyName,
+  Range,
+  RegexLiteral,
+  RegexWithInterpolations,
+  Return,
+  Slice,
+  Splat,
+  StatementLiteral,
+  StringLiteral,
+  StringWithInterpolations,
+  SuperCall,
+  Switch,
+  TaggedTemplateCall,
+  ThisLiteral,
+  Throw,
+  Try,
+  UndefinedLiteral,
+  Value,
+  While,
+  YieldReturn,
+} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
+
+const nodeTypeMap = new Map();
+nodeTypeMap.set(CS1Base, Base);
+nodeTypeMap.set(CS1Block, Block);
+nodeTypeMap.set(CS1Literal, Literal);
+nodeTypeMap.set(CS1NumberLiteral, NumberLiteral);
+nodeTypeMap.set(CS1InfinityLiteral, InfinityLiteral);
+nodeTypeMap.set(CS1NaNLiteral, NaNLiteral);
+nodeTypeMap.set(CS1StringLiteral, StringLiteral);
+nodeTypeMap.set(CS1RegexLiteral, RegexLiteral);
+nodeTypeMap.set(CS1PassthroughLiteral, PassthroughLiteral);
+nodeTypeMap.set(CS1IdentifierLiteral, IdentifierLiteral);
+nodeTypeMap.set(CS1PropertyName, PropertyName);
+nodeTypeMap.set(CS1StatementLiteral, StatementLiteral);
+nodeTypeMap.set(CS1ThisLiteral, ThisLiteral);
+nodeTypeMap.set(CS1UndefinedLiteral, UndefinedLiteral);
+nodeTypeMap.set(CS1NullLiteral, NullLiteral);
+nodeTypeMap.set(CS1BooleanLiteral, BooleanLiteral);
+nodeTypeMap.set(CS1Return, Return);
+nodeTypeMap.set(CS1YieldReturn, YieldReturn);
+nodeTypeMap.set(CS1Value, Value);
+nodeTypeMap.set(CS1Call, Call);
+nodeTypeMap.set(CS1SuperCall, SuperCall);
+nodeTypeMap.set(CS1RegexWithInterpolations, RegexWithInterpolations);
+nodeTypeMap.set(CS1TaggedTemplateCall, TaggedTemplateCall);
+nodeTypeMap.set(CS1Extends, Extends);
+nodeTypeMap.set(CS1Access, Access);
+nodeTypeMap.set(CS1Index, Index);
+nodeTypeMap.set(CS1Range, Range);
+nodeTypeMap.set(CS1Slice, Slice);
+nodeTypeMap.set(CS1Obj, Obj);
+nodeTypeMap.set(CS1Arr, Arr);
+nodeTypeMap.set(CS1Class, Class);
+nodeTypeMap.set(CS1ModuleDeclaration, ModuleDeclaration);
+nodeTypeMap.set(CS1ImportDeclaration, ImportDeclaration);
+nodeTypeMap.set(CS1ImportClause, ImportClause);
+nodeTypeMap.set(CS1ExportDeclaration, ExportDeclaration);
+nodeTypeMap.set(CS1ExportNamedDeclaration, ExportNamedDeclaration);
+nodeTypeMap.set(CS1ExportDefaultDeclaration, ExportDefaultDeclaration);
+nodeTypeMap.set(CS1ExportAllDeclaration, ExportAllDeclaration);
+nodeTypeMap.set(CS1ModuleSpecifierList, ModuleSpecifierList);
+nodeTypeMap.set(CS1ImportSpecifierList, ImportSpecifierList);
+nodeTypeMap.set(CS1ExportSpecifierList, ExportSpecifierList);
+nodeTypeMap.set(CS1ModuleSpecifier, ModuleSpecifier);
+nodeTypeMap.set(CS1ImportSpecifier, ImportSpecifier);
+nodeTypeMap.set(CS1ImportDefaultSpecifier, ImportDefaultSpecifier);
+nodeTypeMap.set(CS1ImportNamespaceSpecifier, ImportNamespaceSpecifier);
+nodeTypeMap.set(CS1ExportSpecifier, ExportSpecifier);
+nodeTypeMap.set(CS1Assign, Assign);
+nodeTypeMap.set(CS1Code, Code);
+nodeTypeMap.set(CS1Param, Param);
+nodeTypeMap.set(CS1Splat, Splat);
+nodeTypeMap.set(CS1Expansion, Expansion);
+nodeTypeMap.set(CS1While, While);
+nodeTypeMap.set(CS1Op, Op);
+nodeTypeMap.set(CS1In, In);
+nodeTypeMap.set(CS1Try, Try);
+nodeTypeMap.set(CS1Throw, Throw);
+nodeTypeMap.set(CS1Existence, Existence);
+nodeTypeMap.set(CS1Parens, Parens);
+nodeTypeMap.set(CS1StringWithInterpolations, StringWithInterpolations);
+nodeTypeMap.set(CS1For, For);
+nodeTypeMap.set(CS1Switch, Switch);
+nodeTypeMap.set(CS1If, If);
+
+/**
+ * Run the CS1 parser and convert the resulting AST into a CS2-compatible AST.
+ */
+export default function parseCS1AsCS2(source: string): Block {
+  let cs1AST = nodes(source);
+  let cs2AST = convertCS1NodeToCS2(cs1AST);
+  if (!(cs2AST instanceof Block)) {
+    throw new Error('Expected top-level CS file to convert to a Block');
+  }
+  return cs2AST;
+}
+
+function convertCS1NodeToCS2(node: CS1Base): Base {
+  let cs1Constructor = node.constructor;
+  let cs2Constructor = nodeTypeMap.get(cs1Constructor);
+  if (!cs2Constructor) {
+    throw new Error(`Unexpected CS1 type for node ${node}`);
+  }
+  let result = Object.create(cs2Constructor.prototype);
+  for (let key of Object.keys(node)) {
+    let value = node[key];
+    if (Array.isArray(value) && value.length > 0 && value[0] instanceof CS1Base) {
+      result[key] = value
+        .filter((child) => !(child instanceof CS1Comment))
+        .map((child: CS1Base) => convertCS1NodeToCS2(child));
+    } else if (key === 'cases') {
+      // Switch cases have a complex structure, so special-case those.
+      result[key] = value.map(([switchCaseCondition, block]: [CS1SwitchCaseCondition, CS1Block]) => {
+        if (Array.isArray(switchCaseCondition)) {
+          return [
+            switchCaseCondition.map((condition) => convertCS1NodeToCS2(condition)),
+            convertCS1NodeToCS2(block)
+          ];
+        } else {
+          return [convertCS1NodeToCS2(switchCaseCondition), convertCS1NodeToCS2(block)];
+        }
+      });
+    } else if (value instanceof CS1Base) {
+      result[key] = convertCS1NodeToCS2(value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,14 +1,14 @@
 import lex from 'coffee-lex';
-import * as CoffeeScript from 'decaffeinate-coffeescript';
 import { patchCoffeeScript } from './ext/coffee-script';
 import mapProgram from './mappers/mapProgram';
 import { Node, Program } from './nodes';
+import parseCS1AsCS2 from './parseCS1AsCS2';
 import fixLocations from './util/fixLocations';
 import ParseContext from './util/ParseContext';
 
 export function parse(source: string): Program {
   patchCoffeeScript();
-  let context = ParseContext.fromSource(source, lex, CoffeeScript.nodes);
+  let context = ParseContext.fromSource(source, lex, parseCS1AsCS2);
   fixLocations(context, context.ast);
   let program = mapProgram(context);
   traverse(program, (node, parent) => {

--- a/src/util/ParseContext.ts
+++ b/src/util/ParseContext.ts
@@ -1,5 +1,5 @@
 import SourceTokenList from 'coffee-lex/dist/SourceTokenList';
-import { Base, Block, LocationData } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base, Block, LocationData } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import LinesAndColumns from 'lines-and-columns';
 import { ClassProtoAssignOp, Constructor } from '../nodes';
 

--- a/src/util/UnsupportedNodeError.ts
+++ b/src/util/UnsupportedNodeError.ts
@@ -1,4 +1,4 @@
-import { Base } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 
 export default class UnsupportedNodeError extends Error {

--- a/src/util/fixInvalidLocationData.ts
+++ b/src/util/fixInvalidLocationData.ts
@@ -1,4 +1,4 @@
-import { LocationData } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { LocationData } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import LinesAndColumns from 'lines-and-columns';
 
 /**

--- a/src/util/fixLocations.ts
+++ b/src/util/fixLocations.ts
@@ -2,7 +2,7 @@ import SourceType from 'coffee-lex/dist/SourceType';
 import {
   Assign, Base, Block, Call, Class, Code, Extends, For, If, In, Index, Literal,
   Obj, Op, Param, Slice, Switch, Try, Value, While
-} from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import fixInvalidLocationData from './fixInvalidLocationData';
 import locationWithLastPosition from './locationWithLastPosition';
 import mergeLocations from './mergeLocations';

--- a/src/util/getLocation.ts
+++ b/src/util/getLocation.ts
@@ -1,7 +1,7 @@
 import { SourceType } from 'coffee-lex';
 import SourceToken from 'coffee-lex/dist/SourceToken';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
-import { Base } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 import ParseContext from './ParseContext';
 

--- a/src/util/getTemplateLiteralComponents.ts
+++ b/src/util/getTemplateLiteralComponents.ts
@@ -2,7 +2,7 @@ import SourceToken from 'coffee-lex/dist/SourceToken';
 import SourceTokenList from 'coffee-lex/dist/SourceTokenList';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
 import SourceType from 'coffee-lex/dist/SourceType';
-import { Base, Literal, Op, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base, Literal, Op, Value } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { Quasi } from '../nodes';
 import isImplicitPlusOp from './isImplicitPlusOp';
 import ParseContext from './ParseContext';

--- a/src/util/isChainedComparison.ts
+++ b/src/util/isChainedComparison.ts
@@ -1,4 +1,4 @@
-import { Base, Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base, Op } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 
 import isComparisonOperator from './isComparisonOperator';
 

--- a/src/util/isCommentOnlyNode.ts
+++ b/src/util/isCommentOnlyNode.ts
@@ -1,0 +1,5 @@
+import {Base, PassthroughLiteral, Value} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
+
+export default function isCommentOnlyNode(base: Base): boolean {
+  return base instanceof Value && base.base instanceof PassthroughLiteral && base.base.value === '';
+}

--- a/src/util/isComparisonOperator.ts
+++ b/src/util/isComparisonOperator.ts
@@ -1,4 +1,4 @@
-import { Base, Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base, Op } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 
 export default function isComparisonOperator(node: Base): boolean {
   if (!(node instanceof Op)) {

--- a/src/util/isHeregexTemplateNode.ts
+++ b/src/util/isHeregexTemplateNode.ts
@@ -1,5 +1,5 @@
 import { SourceType } from 'coffee-lex';
-import { Base, Call, Literal, Value } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base, Call, Literal, Value } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import ParseContext from './ParseContext';
 
 /**

--- a/src/util/isImplicitPlusOp.ts
+++ b/src/util/isImplicitPlusOp.ts
@@ -1,4 +1,4 @@
-import { Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Op } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import isPlusTokenBetweenRanges from './isPlusTokenBetweenRanges';
 import ParseContext from './ParseContext';
 

--- a/src/util/locationWithLastPosition.ts
+++ b/src/util/locationWithLastPosition.ts
@@ -1,4 +1,4 @@
-import { LocationData } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { LocationData } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 
 export default function locationWithLastPosition(loc: LocationData, last: LocationData): LocationData {
   return {

--- a/src/util/locationsEqual.ts
+++ b/src/util/locationsEqual.ts
@@ -1,4 +1,4 @@
-import { LocationData } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { LocationData } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 
 export default function locationsEqual(first: LocationData, second: LocationData): boolean {
   return first.first_line === second.first_line &&

--- a/src/util/makeHeregex.ts
+++ b/src/util/makeHeregex.ts
@@ -1,4 +1,4 @@
-import { Base } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import mapAny from '../mappers/mapAny';
 import { Heregex, RegexFlags } from '../nodes';
 import getTemplateLiteralComponents from './getTemplateLiteralComponents';

--- a/src/util/makeString.ts
+++ b/src/util/makeString.ts
@@ -1,4 +1,4 @@
-import { Base } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import mapAny from '../mappers/mapAny';
 import { String } from '../nodes';
 import getTemplateLiteralComponents from './getTemplateLiteralComponents';

--- a/src/util/mergeLocations.ts
+++ b/src/util/mergeLocations.ts
@@ -1,4 +1,4 @@
-import { LocationData } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { LocationData } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 
 export default function mergeLocations(left: LocationData, right: LocationData): LocationData {
   let first_line;

--- a/src/util/rangeOfBracketTokensForIndexNode.ts
+++ b/src/util/rangeOfBracketTokensForIndexNode.ts
@@ -1,6 +1,6 @@
 import { SourceType } from 'coffee-lex';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
-import { Index, Slice } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Index, Slice } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 import ParseContext from './ParseContext';
 

--- a/src/util/unwindChainedComparison.ts
+++ b/src/util/unwindChainedComparison.ts
@@ -1,4 +1,4 @@
-import { Base, Op } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base, Op } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { inspect } from 'util';
 
 import isComparisonOperator from './isComparisonOperator';

--- a/test/examples/block-comment-in-function/output.json
+++ b/test/examples/block-comment-in-function/output.json
@@ -8,17 +8,7 @@
     "start": 0,
     "statements": [
       {
-        "body": {
-          "column": 3,
-          "end": 18,
-          "inline": false,
-          "line": 2,
-          "raw": "###\n  a\n  ###",
-          "start": 5,
-          "statements": [
-          ],
-          "type": "Block"
-        },
+        "body": null,
         "column": 1,
         "end": 18,
         "line": 1,

--- a/test/examples/block-comment-only-file/output.json
+++ b/test/examples/block-comment-only-file/output.json
@@ -1,15 +1,5 @@
 {
-  "body": {
-    "column": 1,
-    "end": 19,
-    "inline": false,
-    "line": 1,
-    "raw": "###\n# hey there\n###",
-    "start": 0,
-    "statements": [
-    ],
-    "type": "Block"
-  },
+  "body": null,
   "column": 1,
   "end": 20,
   "line": 1,

--- a/test/examples/conditional-ending-in-semicolon/output.json
+++ b/test/examples/conditional-ending-in-semicolon/output.json
@@ -31,17 +31,7 @@
             "start": 7,
             "type": "Identifier"
           },
-          "consequent": {
-            "column": 1,
-            "end": 12,
-            "inline": false,
-            "line": 2,
-            "raw": ";",
-            "start": 11,
-            "statements": [
-            ],
-            "type": "Block"
-          },
+          "consequent": null,
           "end": 12,
           "isUnless": false,
           "line": 1,

--- a/test/examples/function-ending-in-block-comment/output.json
+++ b/test/examples/function-ending-in-block-comment/output.json
@@ -1,10 +1,10 @@
 {
   "body": {
     "column": 1,
-    "end": 20,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "raw": "a ->\n  b\n  ### c ###",
+    "raw": "a ->\n  b",
     "start": 0,
     "statements": [
       {
@@ -12,10 +12,10 @@
           {
             "body": {
               "column": 3,
-              "end": 20,
+              "end": 8,
               "inline": false,
               "line": 2,
-              "raw": "b\n  ### c ###",
+              "raw": "b",
               "start": 7,
               "statements": [
                 {
@@ -31,17 +31,17 @@
               "type": "Block"
             },
             "column": 3,
-            "end": 20,
+            "end": 8,
             "line": 1,
             "parameters": [
             ],
-            "raw": "->\n  b\n  ### c ###",
+            "raw": "->\n  b",
             "start": 2,
             "type": "Function"
           }
         ],
         "column": 1,
-        "end": 20,
+        "end": 8,
         "function": {
           "column": 1,
           "data": "a",
@@ -52,7 +52,7 @@
           "type": "Identifier"
         },
         "line": 1,
-        "raw": "a ->\n  b\n  ### c ###",
+        "raw": "a ->\n  b",
         "start": 0,
         "type": "FunctionApplication"
       }

--- a/test/examples/function-ending-in-semicolon/output.json
+++ b/test/examples/function-ending-in-semicolon/output.json
@@ -8,17 +8,7 @@
     "start": 0,
     "statements": [
       {
-        "body": {
-          "column": 1,
-          "end": 6,
-          "inline": false,
-          "line": 2,
-          "raw": ";",
-          "start": 5,
-          "statements": [
-          ],
-          "type": "Block"
-        },
+        "body": null,
         "column": 1,
         "end": 6,
         "line": 1,

--- a/test/examples/function-followed-by-block-comment/output.json
+++ b/test/examples/function-followed-by-block-comment/output.json
@@ -1,10 +1,10 @@
 {
   "body": {
     "column": 1,
-    "end": 18,
+    "end": 8,
     "inline": false,
     "line": 1,
-    "raw": "a ->\n  b\n### c ###",
+    "raw": "a ->\n  b",
     "start": 0,
     "statements": [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,9 +1150,13 @@ debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+decaffeinate-coffeescript2@2.2.1-patch.1:
+  version "2.2.1-patch.1"
+  resolved "https://registry.npmjs.org/decaffeinate-coffeescript2/-/decaffeinate-coffeescript2-2.2.1-patch.1.tgz#e63a33cfb5870534107b82cb2604f1e4ff126684"
+
 decaffeinate-coffeescript@1.12.7-patch.2:
   version "1.12.7-patch.2"
-  resolved "https://registry.npmjs.org/decaffeinate-coffeescript/-/decaffeinate-coffeescript-1.12.7-patch.2.tgz#c0a453395e0194bcf0dce8d81dbf7170c5a1d578"
+  resolved "https://registry.npmjs.org/decaffeinate-coffeescript2/-/decaffeinate-coffeescript-1.12.7-patch.2.tgz#c0a453395e0194bcf0dce8d81dbf7170c5a1d578"
 
 decamelize@^1.0.0, decamelize@^1.1.2:
   version "1.2.0"


### PR DESCRIPTION
There's some CS2-specific code, but we don't yet ever run the CS2 parser.
Instead, we run the CS1 parser, convert that AST to a CS2 AST, then convert that
to a decaffeinate-parser AST. This should make it possible to variably use the
CS1 or CS2 parser depending on configuration.

BREAKING CHANGE: Node 4 is no longer supported. The returned CoffeeScript AST is
now a CS2 AST, and there are slight differences in ranges and AST structure for
comment-only blocks.