### PR TITLE
fix: improve CS1 function ranges

### DIFF
--- a/src/mappers/mapBlock.ts
+++ b/src/mappers/mapBlock.ts
@@ -45,6 +45,9 @@ function mapChild(blockContext: ParseContext, childContext: ParseContext, node: 
 
     let statements: Array<Node> = [];
     for (let property of obj.properties) {
+      if (isCommentOnlyNode(property)) {
+        continue;
+      }
       if (property instanceof Assign) {
         let { line, column, start, end, raw } = getLocation(childContext, property);
         let key = mapAny(childContext, property.variable);

--- a/src/mappers/mapObj.ts
+++ b/src/mappers/mapObj.ts
@@ -1,6 +1,7 @@
 import { Assign, Obj, Value } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { AssignOp, ObjectInitialiser, ObjectInitialiserMember } from '../nodes';
 import getLocation from '../util/getLocation';
+import isCommentOnlyNode from '../util/isCommentOnlyNode';
 import ParseContext from '../util/ParseContext';
 import UnsupportedNodeError from '../util/UnsupportedNodeError';
 import mapAny from './mapAny';
@@ -12,6 +13,9 @@ export default function mapObj(context: ParseContext, node: Obj): ObjectInitiali
   let members: Array<ObjectInitialiserMember | AssignOp> = [];
 
   for (let property of node.properties) {
+    if (isCommentOnlyNode(property)) {
+      continue;
+    }
     let { line, column, start, end, raw } = getLocation(context, property);
 
     if (property instanceof Value) {

--- a/test/examples/function-ending-in-block-comment/output.json
+++ b/test/examples/function-ending-in-block-comment/output.json
@@ -1,10 +1,10 @@
 {
   "body": {
     "column": 1,
-    "end": 8,
+    "end": 20,
     "inline": false,
     "line": 1,
-    "raw": "a ->\n  b",
+    "raw": "a ->\n  b\n  ### c ###",
     "start": 0,
     "statements": [
       {
@@ -12,10 +12,10 @@
           {
             "body": {
               "column": 3,
-              "end": 8,
+              "end": 20,
               "inline": false,
               "line": 2,
-              "raw": "b",
+              "raw": "b\n  ### c ###",
               "start": 7,
               "statements": [
                 {
@@ -31,17 +31,17 @@
               "type": "Block"
             },
             "column": 3,
-            "end": 8,
+            "end": 20,
             "line": 1,
             "parameters": [
             ],
-            "raw": "->\n  b",
+            "raw": "->\n  b\n  ### c ###",
             "start": 2,
             "type": "Function"
           }
         ],
         "column": 1,
-        "end": 8,
+        "end": 20,
         "function": {
           "column": 1,
           "data": "a",
@@ -52,7 +52,7 @@
           "type": "Identifier"
         },
         "line": 1,
-        "raw": "a ->\n  b",
+        "raw": "a ->\n  b\n  ### c ###",
         "start": 0,
         "type": "FunctionApplication"
       }

--- a/test/examples/function-followed-by-block-comment/output.json
+++ b/test/examples/function-followed-by-block-comment/output.json
@@ -1,10 +1,10 @@
 {
   "body": {
     "column": 1,
-    "end": 8,
+    "end": 18,
     "inline": false,
     "line": 1,
-    "raw": "a ->\n  b",
+    "raw": "a ->\n  b\n### c ###",
     "start": 0,
     "statements": [
       {


### PR DESCRIPTION
CS2 doesn't provide as much location information when a comment is at the end of
a function block, but also is less strict about block comment positioning. In
CS1, we need to be careful to end the function in a place that doesn't leave a
stray indented block comment, so we track CS1 comments and remove them in an
intermediate state so that function bounds are more accurate.