### PR TITLE
feat: add parsing for CS2 super nodes

### DIFF
--- a/src/mappers/mapAny.ts
+++ b/src/mappers/mapAny.ts
@@ -22,7 +22,7 @@ import {
   Range,
   Return,
   Splat,
-  StringWithInterpolations,
+  StringWithInterpolations, Super,
   Switch,
   TaggedTemplateCall,
   Throw,
@@ -55,6 +55,7 @@ import mapParens from './mapParens';
 import mapRange from './mapRange';
 import mapReturn from './mapReturn';
 import mapSplat from './mapSplat';
+import mapSuper from './mapSuper';
 import mapSwitch from './mapSwitch';
 import mapTaggedTemplateCall from './mapTaggedTemplateCall';
 import mapThrow from './mapThrow';
@@ -81,6 +82,10 @@ export default function mapAny(context: ParseContext, node: Base): Node {
 
   if (node instanceof Call) {
     return mapCall(context, node);
+  }
+
+  if (node instanceof Super) {
+    return mapSuper(context, node);
   }
 
   if (node instanceof Arr) {

--- a/src/mappers/mapSuper.ts
+++ b/src/mappers/mapSuper.ts
@@ -1,0 +1,24 @@
+import {SourceType} from 'coffee-lex';
+import {Super as CoffeeSuper} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
+import {Node, Super} from '../nodes';
+import getLocation from '../util/getLocation';
+import ParseContext from '../util/ParseContext';
+import {reduceProperty} from './mapValue';
+
+export default function mapSuper(context: ParseContext, node: CoffeeSuper): Node {
+  let location = getLocation(context, node);
+  let { line, column, start } = location;
+
+  let superTokenIndex = context.sourceTokens.indexOfTokenStartingAtSourceIndex(start);
+  if (!superTokenIndex) {
+    throw new Error('Expected token at the start of super node.');
+  }
+  let superToken = context.sourceTokens.tokenAtIndex(superTokenIndex);
+  if (!superToken || superToken.type !== SourceType.SUPER) {
+    throw new Error('Expected super token at the start of super node.');
+  }
+  let superNode = new Super(
+    line, column, start, superToken.end, context.source.slice(superToken.start, superToken.end)
+  );
+  return reduceProperty(context, location, superNode, node.accessor);
+}

--- a/src/mappers/mapValue.ts
+++ b/src/mappers/mapValue.ts
@@ -18,12 +18,12 @@ export default function mapValue(context: ParseContext, node: Value): Node {
   let location = getLocation(context, node);
 
   return node.properties.reduce(
-    (reduced, property) => propertyReducer(context, location, reduced, property),
+    (reduced, property) => reduceProperty(context, location, reduced, property),
     mapAny(context, node.base)
   );
 }
 
-function propertyReducer(context: ParseContext, location: NodeLocation, reduced: Node, property: Access | Index | CoffeeSlice): Node {
+export function reduceProperty(context: ParseContext, location: NodeLocation, reduced: Node, property: Access | Index | CoffeeSlice): Node {
   if (property instanceof Access) {
     let name = property.name;
 

--- a/test/cs2-examples/super-index-access/input.coffee
+++ b/test/cs2-examples/super-index-access/input.coffee
@@ -1,0 +1,3 @@
+class A
+  b: ->
+    super[c]

--- a/test/cs2-examples/super-index-access/output.json
+++ b/test/cs2-examples/super-index-access/output.json
@@ -1,0 +1,123 @@
+{
+  "body": {
+    "column": 1,
+    "end": 28,
+    "inline": false,
+    "line": 1,
+    "raw": "class A\n  b: ->\n    super[c]",
+    "start": 0,
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "end": 28,
+          "inline": false,
+          "line": 2,
+          "raw": "b: ->\n    super[c]",
+          "start": 10,
+          "statements": [
+            {
+              "assignee": {
+                "column": 3,
+                "data": "b",
+                "end": 11,
+                "line": 2,
+                "raw": "b",
+                "start": 10,
+                "type": "Identifier"
+              },
+              "column": 3,
+              "end": 28,
+              "expression": {
+                "body": {
+                  "column": 5,
+                  "end": 28,
+                  "inline": false,
+                  "line": 3,
+                  "raw": "super[c]",
+                  "start": 20,
+                  "statements": [
+                    {
+                      "column": 5,
+                      "end": 28,
+                      "expression": {
+                        "column": 5,
+                        "end": 25,
+                        "line": 3,
+                        "raw": "super",
+                        "start": 20,
+                        "type": "Super"
+                      },
+                      "indexingExpr": {
+                        "column": 11,
+                        "data": "c",
+                        "end": 27,
+                        "line": 3,
+                        "raw": "c",
+                        "start": 26,
+                        "type": "Identifier"
+                      },
+                      "line": 3,
+                      "raw": "super[c]",
+                      "start": 20,
+                      "type": "DynamicMemberAccessOp"
+                    }
+                  ],
+                  "type": "Block"
+                },
+                "column": 6,
+                "end": 28,
+                "line": 2,
+                "parameters": [
+                ],
+                "raw": "->\n    super[c]",
+                "start": 13,
+                "type": "Function"
+              },
+              "line": 2,
+              "raw": "b: ->\n    super[c]",
+              "start": 10,
+              "type": "ClassProtoAssignOp"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": null,
+        "end": 28,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "end": 7,
+          "line": 1,
+          "raw": "A",
+          "start": 6,
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "end": 7,
+          "line": 1,
+          "raw": "A",
+          "start": 6,
+          "type": "Identifier"
+        },
+        "parent": null,
+        "raw": "class A\n  b: ->\n    super[c]",
+        "start": 0,
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 29,
+  "line": 1,
+  "raw": "class A\n  b: ->\n    super[c]\n",
+  "start": 0,
+  "type": "Program"
+}

--- a/test/cs2-examples/super-property-access/input.coffee
+++ b/test/cs2-examples/super-property-access/input.coffee
@@ -1,0 +1,3 @@
+class A
+  b: ->
+    super.c

--- a/test/cs2-examples/super-property-access/output.json
+++ b/test/cs2-examples/super-property-access/output.json
@@ -1,0 +1,123 @@
+{
+  "body": {
+    "column": 1,
+    "end": 27,
+    "inline": false,
+    "line": 1,
+    "raw": "class A\n  b: ->\n    super.c",
+    "start": 0,
+    "statements": [
+      {
+        "body": {
+          "column": 3,
+          "end": 27,
+          "inline": false,
+          "line": 2,
+          "raw": "b: ->\n    super.c",
+          "start": 10,
+          "statements": [
+            {
+              "assignee": {
+                "column": 3,
+                "data": "b",
+                "end": 11,
+                "line": 2,
+                "raw": "b",
+                "start": 10,
+                "type": "Identifier"
+              },
+              "column": 3,
+              "end": 27,
+              "expression": {
+                "body": {
+                  "column": 5,
+                  "end": 27,
+                  "inline": false,
+                  "line": 3,
+                  "raw": "super.c",
+                  "start": 20,
+                  "statements": [
+                    {
+                      "column": 5,
+                      "end": 27,
+                      "expression": {
+                        "column": 5,
+                        "end": 25,
+                        "line": 3,
+                        "raw": "super",
+                        "start": 20,
+                        "type": "Super"
+                      },
+                      "line": 3,
+                      "member": {
+                        "column": 11,
+                        "data": "c",
+                        "end": 27,
+                        "line": 3,
+                        "raw": "c",
+                        "start": 26,
+                        "type": "Identifier"
+                      },
+                      "raw": "super.c",
+                      "start": 20,
+                      "type": "MemberAccessOp"
+                    }
+                  ],
+                  "type": "Block"
+                },
+                "column": 6,
+                "end": 27,
+                "line": 2,
+                "parameters": [
+                ],
+                "raw": "->\n    super.c",
+                "start": 13,
+                "type": "Function"
+              },
+              "line": 2,
+              "raw": "b: ->\n    super.c",
+              "start": 10,
+              "type": "ClassProtoAssignOp"
+            }
+          ],
+          "type": "Block"
+        },
+        "boundMembers": [
+        ],
+        "column": 1,
+        "ctor": null,
+        "end": 27,
+        "line": 1,
+        "name": {
+          "column": 7,
+          "data": "A",
+          "end": 7,
+          "line": 1,
+          "raw": "A",
+          "start": 6,
+          "type": "Identifier"
+        },
+        "nameAssignee": {
+          "column": 7,
+          "data": "A",
+          "end": 7,
+          "line": 1,
+          "raw": "A",
+          "start": 6,
+          "type": "Identifier"
+        },
+        "parent": null,
+        "raw": "class A\n  b: ->\n    super.c",
+        "start": 0,
+        "type": "Class"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 28,
+  "line": 1,
+  "raw": "class A\n  b: ->\n    super.c\n",
+  "start": 0,
+  "type": "Program"
+}


### PR DESCRIPTION
In CS1, super was always a function call, but not it can be a property or index
access, so we need to properly handle that case, which ends up being very
similar to Value handling.