### PR TITLE
fix: expand block node locations to include surrounding parens

### DIFF
--- a/src/util/expandToIncludeParens.ts
+++ b/src/util/expandToIncludeParens.ts
@@ -1,0 +1,33 @@
+import SourceToken from 'coffee-lex/dist/SourceToken';
+import SourceType from 'coffee-lex/dist/SourceType';
+import {LocationData} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
+import {firstSemanticTokenAfter, firstSemanticTokenBefore} from './getLocation';
+import locationDataFromSourceRange from './locationDataFromSourceRange';
+import ParseContext from './ParseContext';
+import sourceRangeFromLocationData, {SourceRange} from './sourceRangeFromLocationData';
+
+export default function expandToIncludeParens(context: ParseContext, locationData: LocationData): LocationData {
+  let sourceRange = sourceRangeFromLocationData(context, locationData);
+  while (true) {
+    let tokens = getSurroundingParens(context, sourceRange);
+    if (tokens === null) {
+      break;
+    }
+    sourceRange = {start: tokens.openParen.start, end: tokens.closeParen.end};
+  }
+  return locationDataFromSourceRange(context, sourceRange);
+}
+
+type Tokens = {openParen: SourceToken, closeParen: SourceToken};
+
+function getSurroundingParens(context: ParseContext, sourceRange: SourceRange): Tokens | null {
+  let tokenBefore = firstSemanticTokenBefore(context, sourceRange.start);
+  let tokenAfter = firstSemanticTokenAfter(context, sourceRange.end);
+  if (tokenBefore === null || tokenBefore.type !== SourceType.LPAREN) {
+    return null;
+  }
+  if (tokenAfter === null || tokenAfter.type !== SourceType.RPAREN) {
+    return null;
+  }
+  return {openParen: tokenBefore, closeParen: tokenAfter};
+}

--- a/src/util/fixLocations.ts
+++ b/src/util/fixLocations.ts
@@ -3,6 +3,7 @@ import {
   Assign, Base, Block, Call, Class, Code, Extends, For, If, In, Index, Literal,
   Obj, Op, Param, Slice, Switch, Try, Value, While
 } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
+import expandToIncludeParens from './expandToIncludeParens';
 import fixInvalidLocationData from './fixInvalidLocationData';
 import locationWithLastPosition from './locationWithLastPosition';
 import mergeLocations from './mergeLocations';
@@ -159,6 +160,10 @@ export default function fixLocations(context: ParseContext, node: Base): void {
       node.locationData.last_line = loc.line;
       node.locationData.last_column = loc.column;
     }
+    // The CS2 AST doesn't include the surrounding parens in a block, which can cause trouble with
+    // things like postfix loops with parenthesized bodies. Expand every block to include any
+    // surrounding parens.
+    node.locationData = expandToIncludeParens(context, node.locationData);
   }
 
   if (node instanceof If) {

--- a/src/util/locationDataFromSourceRange.ts
+++ b/src/util/locationDataFromSourceRange.ts
@@ -1,0 +1,20 @@
+import {LocationData} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
+import ParseContext from './ParseContext';
+import {SourceRange} from './sourceRangeFromLocationData';
+
+export default function locationDataFromSourceRange(context: ParseContext, sourceRange: SourceRange): LocationData {
+  let startLocationInclusive = context.linesAndColumns.locationForIndex(sourceRange.start);
+  if (startLocationInclusive === null) {
+    throw new Error('Expected start location for source range.');
+  }
+  let endLocationInclusive = context.linesAndColumns.locationForIndex(sourceRange.end - 1);
+  if (endLocationInclusive === null) {
+    throw new Error('Expected end location for source range.');
+  }
+  return {
+    first_line: startLocationInclusive.line,
+    first_column: startLocationInclusive.column,
+    last_line: endLocationInclusive.line,
+    last_column: endLocationInclusive.column,
+  };
+}

--- a/src/util/sourceRangeFromLocationData.ts
+++ b/src/util/sourceRangeFromLocationData.ts
@@ -1,0 +1,28 @@
+import {LocationData} from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
+import ParseContext from './ParseContext';
+
+export type SourceRange = {
+  start: number;
+  end: number;
+};
+
+export default function sourceRangeFromLocationData(context: ParseContext, locationData: LocationData): SourceRange {
+  let startIndexInclusive = context.linesAndColumns.indexForLocation({
+    line: locationData.first_line,
+    column: locationData.first_column,
+  });
+  if (startIndexInclusive === null) {
+    throw new Error('Expected index for start of range.');
+  }
+  let endIndexInclusive = context.linesAndColumns.indexForLocation({
+    line: locationData.last_line,
+    column: locationData.last_column,
+  });
+  if (endIndexInclusive === null) {
+    throw new Error('Expected index for end of range.');
+  }
+  return {
+    start: startIndexInclusive,
+    end: endIndexInclusive + 1,
+  };
+}

--- a/test/examples/parenthesized-break-in-postfix-while/input.coffee
+++ b/test/examples/parenthesized-break-in-postfix-while/input.coffee
@@ -1,0 +1,1 @@
+(break) while true

--- a/test/examples/parenthesized-break-in-postfix-while/output.json
+++ b/test/examples/parenthesized-break-in-postfix-while/output.json
@@ -1,0 +1,57 @@
+{
+  "body": {
+    "column": 1,
+    "end": 18,
+    "inline": false,
+    "line": 1,
+    "raw": "(break) while true",
+    "start": 0,
+    "statements": [
+      {
+        "body": {
+          "column": 1,
+          "end": 7,
+          "inline": true,
+          "line": 1,
+          "raw": "(break)",
+          "start": 0,
+          "statements": [
+            {
+              "column": 2,
+              "end": 6,
+              "line": 1,
+              "raw": "break",
+              "start": 1,
+              "type": "Break"
+            }
+          ],
+          "type": "Block"
+        },
+        "column": 1,
+        "condition": {
+          "column": 15,
+          "data": true,
+          "end": 18,
+          "line": 1,
+          "raw": "true",
+          "start": 14,
+          "type": "Bool"
+        },
+        "end": 18,
+        "guard": null,
+        "isUntil": false,
+        "line": 1,
+        "raw": "(break) while true",
+        "start": 0,
+        "type": "While"
+      }
+    ],
+    "type": "Block"
+  },
+  "column": 1,
+  "end": 19,
+  "line": 1,
+  "raw": "(break) while true\n",
+  "start": 0,
+  "type": "Program"
+}


### PR DESCRIPTION
This fixes cases like `(break) while true` in CS2, where the new AST was
treating `break` as its own block and there was no source index to use to expand
the whole loop to start at the open-paren. Now, we always expand blocks to
include their surrounding parens, which seems to make sense in general.