### PR TITLE
chore(package): manually fix yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -850,7 +850,7 @@ decaffeinate-coffeescript2@2.2.1-patch.4:
 
 decaffeinate-coffeescript@1.12.7-patch.2:
   version "1.12.7-patch.2"
-  resolved "https://registry.npmjs.org/decaffeinate-coffeescript2/-/decaffeinate-coffeescript-1.12.7-patch.2.tgz#c0a453395e0194bcf0dce8d81dbf7170c5a1d578"
+  resolved "https://registry.npmjs.org/decaffeinate-coffeescript/-/decaffeinate-coffeescript-1.12.7-patch.2.tgz#c0a453395e0194bcf0dce8d81dbf7170c5a1d578"
 
 deep-is@~0.1.3:
   version "0.1.3"


### PR DESCRIPTION
Somehow, 655f568 modified yarn.lock to point decaffeinate-coffeescript at decaffeinate-coffeescript2. Maybe this was a yarn bug, since I can't really explain how else it would work and then stop working later with no changes to this file. Whatever the exact cause, this should fix it.