### PR TITLE
fix: add support for `export { default } from './source'`

### DIFF
--- a/src/mappers/mapModuleDeclaration.ts
+++ b/src/mappers/mapModuleDeclaration.ts
@@ -2,12 +2,12 @@ import {
   ExportAllDeclaration as CoffeeExportAllDeclaration,
   ExportDefaultDeclaration as CoffeeExportDefaultDeclaration,
   ExportNamedDeclaration as CoffeeExportNamedDeclaration, ExportSpecifierList,
+  IdentifierLiteral,
   ImportDeclaration as CoffeeImportDeclaration,
   ImportNamespaceSpecifier,
   ImportSpecifierList,
   Literal,
-  ModuleDeclaration,
-  ModuleSpecifier as CoffeeModuleSpecifier, StringLiteral,
+  ModuleDeclaration, ModuleSpecifier as CoffeeModuleSpecifier, StringLiteral,
 } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import {
   ExportAllDeclaration,
@@ -104,9 +104,12 @@ function mapSpecifier(context: ParseContext, specifier: CoffeeModuleSpecifier): 
 }
 
 function mapLiteralToIdentifier(context: ParseContext, literal: Literal): Identifier {
-  let identifier = mapLiteral(context, literal);
-  if (!(identifier instanceof Identifier)) {
-    throw new Error('Expected identifier in declaration.');
+  if (literal instanceof IdentifierLiteral) {
+    return mapLiteral(context, literal) as Identifier;
+  } else if (literal.constructor === Literal) {
+    let { line, column, start, end, raw } = getLocation(context, literal);
+    return new Identifier(line, column, start, end, raw, literal.value);
+  } else {
+    throw new Error('Expected identifier in module declaration.');
   }
-  return identifier;
 }

--- a/test/__snapshots__/examples.test.ts.snap
+++ b/test/__snapshots__/examples.test.ts.snap
@@ -7838,6 +7838,77 @@ Program {
 }
 `;
 
+exports[`CS1: export-default-from-source 1`] = `
+Program {
+  "body": Block {
+    "column": 1,
+    "end": 35,
+    "inline": false,
+    "line": 1,
+    "raw": "export { default } from './source';",
+    "start": 0,
+    "statements": Array [
+      ExportBindingsDeclaration {
+        "column": 1,
+        "end": 34,
+        "line": 1,
+        "namedExports": Array [
+          ModuleSpecifier {
+            "alias": null,
+            "column": 10,
+            "end": 16,
+            "line": 1,
+            "original": Identifier {
+              "column": 10,
+              "data": "default",
+              "end": 16,
+              "line": 1,
+              "raw": "default",
+              "start": 9,
+              "type": "Identifier",
+            },
+            "raw": "default",
+            "start": 9,
+            "type": "ModuleSpecifier",
+          },
+        ],
+        "raw": "export { default } from './source'",
+        "source": String {
+          "column": 25,
+          "end": 34,
+          "expressions": Array [],
+          "line": 1,
+          "quasis": Array [
+            Quasi {
+              "column": 26,
+              "data": "./source",
+              "end": 33,
+              "line": 1,
+              "raw": "./source",
+              "start": 25,
+              "type": "Quasi",
+            },
+          ],
+          "raw": "'./source'",
+          "start": 24,
+          "type": "String",
+        },
+        "start": 0,
+        "type": "ExportBindingsDeclaration",
+      },
+    ],
+    "type": "Block",
+  },
+  "column": 1,
+  "end": 36,
+  "line": 1,
+  "raw": "export { default } from './source';
+",
+  "start": 0,
+  "type": "Program",
+}
+`;
+
 exports[`CS1: export-multiple-bindings 1`] = `
 Program {
   "body": Block {
@@ -28690,6 +28761,77 @@ Program {
   "end": 17,
   "line": 1,
   "raw": "export default a
+",
+  "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`CS2: export-default-from-source 1`] = `
+Program {
+  "body": Block {
+    "column": 1,
+    "end": 35,
+    "inline": false,
+    "line": 1,
+    "raw": "export { default } from './source';",
+    "start": 0,
+    "statements": Array [
+      ExportBindingsDeclaration {
+        "column": 1,
+        "end": 34,
+        "line": 1,
+        "namedExports": Array [
+          ModuleSpecifier {
+            "alias": null,
+            "column": 10,
+            "end": 16,
+            "line": 1,
+            "original": Identifier {
+              "column": 10,
+              "data": "default",
+              "end": 16,
+              "line": 1,
+              "raw": "default",
+              "start": 9,
+              "type": "Identifier",
+            },
+            "raw": "default",
+            "start": 9,
+            "type": "ModuleSpecifier",
+          },
+        ],
+        "raw": "export { default } from './source'",
+        "source": String {
+          "column": 25,
+          "end": 34,
+          "expressions": Array [],
+          "line": 1,
+          "quasis": Array [
+            Quasi {
+              "column": 26,
+              "data": "./source",
+              "end": 33,
+              "line": 1,
+              "raw": "./source",
+              "start": 25,
+              "type": "Quasi",
+            },
+          ],
+          "raw": "'./source'",
+          "start": 24,
+          "type": "String",
+        },
+        "start": 0,
+        "type": "ExportBindingsDeclaration",
+      },
+    ],
+    "type": "Block",
+  },
+  "column": 1,
+  "end": 36,
+  "line": 1,
+  "raw": "export { default } from './source';
 ",
   "start": 0,
   "type": "Program",

--- a/test/examples/export-default-from-source.coffee
+++ b/test/examples/export-default-from-source.coffee
@@ -1,0 +1,1 @@
+export { default } from './source';


### PR DESCRIPTION

See https://github.com/decaffeinate/decaffeinate/issues/1367